### PR TITLE
Fix integration sandbox crash

### DIFF
--- a/core/src/main/java/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
+++ b/core/src/main/java/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
@@ -8,7 +8,8 @@ class IntegrationPointStub : IntegrationPoint(savedInstanceState = null) {
         private const val ERROR = "You're accessing an IntegrationPointStub. " +
             "This means you're using a Node without ever integrating it to a proper IntegrationPoint. " +
             "This is fine during tests with limited scope, but it looks like the code that leads here " +
-            "requires interfacing with a valid implementation."
+            "requires interfacing with a valid implementation. " +
+            "You may be attempting to access the IntegrationPoint before it is attached to the Node."
     }
 
     override val activityStarter: ActivityStarter

--- a/sandbox/src/main/java/com/bumble/appyx/sandbox/client/integrationpoint/IntegrationPointExampleNode.kt
+++ b/sandbox/src/main/java/com/bumble/appyx/sandbox/client/integrationpoint/IntegrationPointExampleNode.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
 import com.bumble.appyx.core.integrationpoint.requestcode.RequestCodeClient
 import com.bumble.appyx.core.minimal.reactive.Cancellable
@@ -34,8 +35,8 @@ import java.util.*
 class IntegrationPointExampleNode(buildContext: BuildContext) : Node(buildContext = buildContext),
     RequestCodeClient {
 
-    private val permissionRequester = integrationPoint.permissionRequester
-    private val activityStarter = integrationPoint.activityStarter
+    private val permissionRequester: PermissionRequester get() = integrationPoint.permissionRequester
+    private val activityStarter: ActivityStarter get() = integrationPoint.activityStarter
     private var permissionsResultCancellable: Cancellable? = null
     private var activityResultsCancellable: Cancellable? = null
     private var permissionsResultState by mutableStateOf("Press request permissions to check permissions state")
@@ -91,13 +92,13 @@ class IntegrationPointExampleNode(buildContext: BuildContext) : Node(buildContex
     }
 
     private fun launchActivity() {
-        integrationPoint.activityStarter.startActivity {
+        activityStarter.startActivity {
             Intent(this, StartActivityExample::class.java)
         }
     }
 
     private fun launchActivityForResult() {
-        integrationPoint.activityStarter.startActivityForResult(this, StartActivityForResultCode) {
+        activityStarter.startActivityForResult(this, StartActivityForResultCode) {
             Intent(this, StartActivityExample::class.java)
         }
     }


### PR DESCRIPTION
## Description

Fixed a crash caused by accessing the integrationPoint too early within the IntegrationPointExampleNode class.
I also updated the error message slightly in case developers encounter the same problem.

Please see the issue for further details

Closes #16

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
