### PR TITLE
Do not allow setting integration point on non-root nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending changes
 
  - Migrate [app-tree-utils](https://github.com/badoo/app-tree-utils) into this repository.
+ - Do not allow setting `Node.integrationPoint` on non-root nodes.
 
 ## 1.0-alpha01
 

--- a/core/src/main/java/com/bumble/appyx/core/node/Node.kt
+++ b/core/src/main/java/com/bumble/appyx/core/node/Node.kt
@@ -60,6 +60,10 @@ abstract class Node(
                 "Non-root Node should have a parent"
             )
         }
+        set(value) {
+            check(isRoot) { "Only a root Node can have an integration point" }
+            field = value
+        }
 
     private val lifecycleRegistry = LifecycleRegistry(this)
 


### PR DESCRIPTION
## Description

Make code a little more error prone.
If a library user will try to set an integration point on a non-root Node, we not simply ignore the request, but also throws exception to show that it is prohibited and meaningless.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
