### PR TITLE
Fix incorrect state comparison when adding to transition history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Migrate [app-tree-utils](https://github.com/badoo/app-tree-utils) into this repository.
  - Do not allow setting `Node.integrationPoint` on non-root nodes.
  - #20 Fix integration point attached twice crash when using live literals 
+ - Fix transition interruptions bug
 
 ## 1.0-alpha01
 

--- a/core/src/main/java/com/bumble/appyx/core/routing/RoutingElement.kt
+++ b/core/src/main/java/com/bumble/appyx/core/routing/RoutingElement.kt
@@ -28,17 +28,17 @@ class RoutingElement<Routing, State> private constructor(
     )
 
     fun transitionTo(
-        targetState: @RawValue State,
+        newTargetState: @RawValue State,
         operation: @RawValue Operation<Routing, State>
     ): RoutingElement<Routing, State> =
         RoutingElement(
             key = key,
             fromState = fromState,
-            targetState = targetState,
+            targetState = newTargetState,
             operation = operation,
             transitionHistory =
-            if (isTransitioning) {
-                transitionHistory + listOf(fromState to targetState)
+            if (fromState != newTargetState) {
+                transitionHistory + listOf(fromState to newTargetState)
             } else transitionHistory
         )
 

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/NewRoot.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/NewRoot.kt
@@ -34,7 +34,7 @@ data class NewRoot<T : Any>(
         } else {
             listOf(
                 current.transitionTo(
-                    targetState = BackStack.TransitionState.DESTROYED,
+                    newTargetState = BackStack.TransitionState.DESTROYED,
                     operation = this
                 ),
                 BackStackElement(

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Pop.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Pop.kt
@@ -29,11 +29,11 @@ class Pop<T : Any> : BackStackOperation<T> {
         return elements.mapIndexed { index, element ->
             when (index) {
                 destroyIndex -> element.transitionTo(
-                    targetState = BackStack.TransitionState.DESTROYED,
+                    newTargetState = BackStack.TransitionState.DESTROYED,
                     operation = this
                 )
                 unStashIndex -> element.transitionTo(
-                    targetState = BackStack.TransitionState.ACTIVE,
+                    newTargetState = BackStack.TransitionState.ACTIVE,
                     operation = this
                 )
                 else -> element

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Push.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Push.kt
@@ -27,7 +27,7 @@ data class Push<T : Any>(
         return elements.map {
             if (it.targetState == BackStack.TransitionState.ACTIVE) {
                 it.transitionTo(
-                    targetState = BackStack.TransitionState.STASHED_IN_BACK_STACK,
+                    newTargetState = BackStack.TransitionState.STASHED_IN_BACK_STACK,
                     operation = this
                 )
             } else {

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Remove.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Remove.kt
@@ -45,11 +45,11 @@ data class Remove<T : Any>(
             elements.mapIndexed { index, element ->
                 when (index) {
                     toRemoveIndex -> element.transitionTo(
-                        targetState = BackStack.TransitionState.DESTROYED,
+                        newTargetState = BackStack.TransitionState.DESTROYED,
                         operation = this
                     )
                     unStashIndex -> element.transitionTo(
-                        targetState = BackStack.TransitionState.ACTIVE,
+                        newTargetState = BackStack.TransitionState.ACTIVE,
                         operation = this
                     )
                     else -> element

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Replace.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/Replace.kt
@@ -32,7 +32,7 @@ data class Replace<T : Any>(
         return elements.mapIndexed { index, element ->
             if (index == elements.activeIndex) {
                 element.transitionTo(
-                    targetState = BackStack.TransitionState.DESTROYED,
+                    newTargetState = BackStack.TransitionState.DESTROYED,
                     operation = this
                 )
             } else {

--- a/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/SingleTop.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/backstack/operation/SingleTop.kt
@@ -8,7 +8,6 @@ import com.bumble.appyx.routingsource.backstack.active
 import com.bumble.appyx.routingsource.backstack.activeRouting
 import com.bumble.appyx.routingsource.backstack.BackStack.TransitionState.ACTIVE
 import com.bumble.appyx.routingsource.backstack.BackStack.TransitionState.CREATED
-import com.bumble.appyx.routingsource.backstack.operation.SingleTop.Companion
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -41,14 +40,14 @@ sealed class SingleTop<T : Any> : BackStackOperation<T> {
             return newElements.mapIndexed { index, element ->
                 if (index == newElements.lastIndex) {
                     element.transitionTo(
-                        targetState = BackStack.TransitionState.ACTIVE,
+                        newTargetState = BackStack.TransitionState.ACTIVE,
                         operation = this
                     )
                 } else {
                     element
                 }
             } + current.transitionTo(
-                targetState = BackStack.TransitionState.DESTROYED,
+                newTargetState = BackStack.TransitionState.DESTROYED,
                 operation = this
             )
         }
@@ -75,7 +74,7 @@ sealed class SingleTop<T : Any> : BackStackOperation<T> {
             val newElements = elements.dropLast(elements.size - position)
 
             return newElements + current.transitionTo(
-                targetState = BackStack.TransitionState.DESTROYED,
+                newTargetState = BackStack.TransitionState.DESTROYED,
                 operation = this
             ) + BackStackElement(
                 key = RoutingKey(element),

--- a/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Activate.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Activate.kt
@@ -21,19 +21,19 @@ class Activate<T : Any>(
             when {
                 index < toActivateIndex -> {
                     element.transitionTo(
-                        targetState = TransitionState.INACTIVE_BEFORE,
+                        newTargetState = TransitionState.INACTIVE_BEFORE,
                         operation = this
                     )
                 }
                 index == toActivateIndex -> {
                     element.transitionTo(
-                        targetState = TransitionState.ACTIVE,
+                        newTargetState = TransitionState.ACTIVE,
                         operation = this
                     )
                 }
                 else -> {
                     element.transitionTo(
-                        targetState = TransitionState.INACTIVE_AFTER,
+                        newTargetState = TransitionState.INACTIVE_AFTER,
                         operation = this
                     )
                 }

--- a/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Next.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Next.kt
@@ -22,13 +22,13 @@ class Next<T : Any> : SpotlightOperation<T> {
             when {
                 it.targetState == ACTIVE -> {
                     it.transitionTo(
-                        targetState = INACTIVE_BEFORE,
+                        newTargetState = INACTIVE_BEFORE,
                         operation = this
                     )
                 }
                 it.key == nextKey -> {
                     it.transitionTo(
-                        targetState = ACTIVE,
+                        newTargetState = ACTIVE,
                         operation = this
                     )
                 }

--- a/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Previous.kt
+++ b/core/src/main/java/com/bumble/appyx/routingsource/spotlight/operation/Previous.kt
@@ -22,13 +22,13 @@ class Previous<T : Any> : SpotlightOperation<T> {
             when {
                 it.targetState == ACTIVE -> {
                     it.transitionTo(
-                        targetState = INACTIVE_AFTER,
+                        newTargetState = INACTIVE_AFTER,
                         operation = this
                     )
                 }
                 it.key == previousKey -> {
                     it.transitionTo(
-                        targetState = ACTIVE,
+                        newTargetState = ACTIVE,
                         operation = this
                     )
                 }

--- a/core/src/test/java/com/bumble/appyx/core/lifecycle/ChildLifecycleTest.kt
+++ b/core/src/test/java/com/bumble/appyx/core/lifecycle/ChildLifecycleTest.kt
@@ -155,7 +155,7 @@ class ChildLifecycleTest {
                     .map {
                         if (it.key.routing == key) {
                             it
-                                .transitionTo(targetState = onScreen, operation = Operation.Noop())
+                                .transitionTo(newTargetState = onScreen, operation = Operation.Noop())
                                 .onTransitionFinished()
                         } else {
                             it

--- a/core/src/test/java/com/bumble/appyx/core/lifecycle/ParentLifecycleTest.kt
+++ b/core/src/test/java/com/bumble/appyx/core/lifecycle/ParentLifecycleTest.kt
@@ -4,7 +4,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
-import com.bumble.appyx.core.children.ChildEntry
 import com.bumble.appyx.core.lifecycle.ParentLifecycleTest.RoutingImpl.State
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
@@ -108,7 +107,7 @@ class ParentLifecycleTest {
                     .map {
                         if (it.key.routing == routing) {
                             it.transitionTo(
-                                targetState = defaultState,
+                                newTargetState = defaultState,
                                 operation = Operation.Noop()
                             )
                         } else {

--- a/documentation/routingsources/custom.md
+++ b/documentation/routingsources/custom.md
@@ -68,7 +68,7 @@ class SomeOperation<T : Any> : FooOperation<T> {
         //  In this example we're changing all elements to transition to BAR.
         elements.map {
             it.transitionTo(
-                targetState = BAR,
+                newTargetState = BAR,
                 operation = this
             )
         }

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Destroy.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Destroy.kt
@@ -17,7 +17,7 @@ data class Destroy<T : Any>(
         return elements.map {
             if (it.key == key) {
                 it.transitionTo(
-                    targetState = DESTROYED,
+                    newTargetState = DESTROYED,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Dismiss.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Dismiss.kt
@@ -17,7 +17,7 @@ data class Dismiss<T : Any>(
         return elements.map {
             if (it.key == key) {
                 it.transitionTo(
-                    targetState = CREATED,
+                    newTargetState = CREATED,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/FullScreen.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/FullScreen.kt
@@ -17,7 +17,7 @@ data class FullScreen<T : Any>(
         return elements.map {
             if (it.key == key) {
                 it.transitionTo(
-                    targetState = FULL_SCREEN,
+                    newTargetState = FULL_SCREEN,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Revert.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Revert.kt
@@ -17,13 +17,13 @@ class Revert<T : Any> : ModalOperation<T> {
             when (it.targetState) {
                 FULL_SCREEN -> {
                     it.transitionTo(
-                        targetState = MODAL,
+                        newTargetState = MODAL,
                         operation = this
                     )
                 }
                 MODAL -> {
                     it.transitionTo(
-                        targetState = FULL_SCREEN,
+                        newTargetState = FULL_SCREEN,
                         operation = this
                     )
                 }

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Show.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/modal/operation/Show.kt
@@ -17,7 +17,7 @@ data class Show<T : Any>(
         return elements.map {
             if (it.key == key) {
                 it.transitionTo(
-                    targetState = MODAL,
+                    newTargetState = MODAL,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/promoter/routingsource/operation/PromoteAll.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/promoter/routingsource/operation/PromoteAll.kt
@@ -16,7 +16,7 @@ class PromoteAll<T : Any> : PromoterOperation<T> {
     ): RoutingElements<T, Promoter.TransitionState> =
         elements.map {
             it.transitionTo(
-                targetState = it.targetState.next(),
+                newTargetState = it.targetState.next(),
                 operation = this
             )
         }

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Deselect.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Deselect.kt
@@ -19,7 +19,7 @@ data class Deselect<T : Any>(
         elements.map {
             if (it.key == key && it.targetState == Tiles.TransitionState.SELECTED) {
                 it.transitionTo(
-                    targetState = Tiles.TransitionState.STANDARD,
+                    newTargetState = Tiles.TransitionState.STANDARD,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/DeselectAll.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/DeselectAll.kt
@@ -16,7 +16,7 @@ class DeselectAll<T : Any> : TilesOperation<T> {
         elements.map {
             if (it.targetState == Tiles.TransitionState.SELECTED) {
                 it.transitionTo(
-                    targetState = Tiles.TransitionState.STANDARD,
+                    newTargetState = Tiles.TransitionState.STANDARD,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Destroy.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Destroy.kt
@@ -19,7 +19,7 @@ data class Destroy<T : Any>(
         elements.map {
             if (it.key == key) {
                 it.transitionTo(
-                    targetState = Tiles.TransitionState.DESTROYED,
+                    newTargetState = Tiles.TransitionState.DESTROYED,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/RemoveSelected.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/RemoveSelected.kt
@@ -16,7 +16,7 @@ class RemoveSelected<T : Any> : TilesOperation<T> {
         elements.map {
             if (it.targetState == Tiles.TransitionState.SELECTED) {
                 it.transitionTo(
-                    targetState = Tiles.TransitionState.DESTROYED,
+                    newTargetState = Tiles.TransitionState.DESTROYED,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Select.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/Select.kt
@@ -19,7 +19,7 @@ data class Select<T : Any>(
         elements.map {
             if (it.key == key && it.targetState == Tiles.TransitionState.STANDARD) {
                 it.transitionTo(
-                    targetState = Tiles.TransitionState.SELECTED,
+                    newTargetState = Tiles.TransitionState.SELECTED,
                     operation = this
                 )
             } else {

--- a/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/ToggleSelection.kt
+++ b/routing-source-addons/src/main/java/com/bumble/appyx/routingsource/tiles/operation/ToggleSelection.kt
@@ -20,11 +20,11 @@ data class ToggleSelection<T : Any>(
             if (it.key == key) {
                 when (it.targetState) {
                     Tiles.TransitionState.SELECTED -> it.transitionTo(
-                        targetState = Tiles.TransitionState.STANDARD,
+                        newTargetState = Tiles.TransitionState.STANDARD,
                         operation = this
                     )
                     Tiles.TransitionState.STANDARD -> it.transitionTo(
-                        targetState = Tiles.TransitionState.SELECTED,
+                        newTargetState = Tiles.TransitionState.SELECTED,
                         operation = this
                     )
                     else -> it


### PR DESCRIPTION
## Description

On every transition we add it to transition history if `fromState` and `targetState` are different. `isTransitioning` extension check `fromState` with incorrect `targetState`. It should be comparing with `newTarget` state.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
