### PR TITLE
[WIP] Deploy documentation only on release

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,14 +1,11 @@
 name: Deploy mkdocs to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy
+  deploy-documentation:
+    name: Deploy documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,14 @@ jobs:
             -Psigning.password=${{ secrets.SIGNING_PASSWORD }}
             -Psonatype.username=${{ secrets.SONATYPE_USERNAME }}
             -Psonatype.password=${{ secrets.SONATYPE_PASSWORD }}
+
+  deploy-documentation:
+    name: Deploy documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Description

Deploy the documentation only on release otherwise the documentation will describe features that cannot be used right now.
Keep a manual deployment just in case.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
