### PR TITLE
BackPressHandler plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#39](https://github.com/bumble-tech/appyx/pull/39) – Added: Workflows implementation to support deeplinks
 - [#47](https://github.com/bumble-tech/appyx/issues/47) – Updated: The 'customisations' module is now pure Java/Kotlin.
+- [#32](https://github.com/bumble-tech/appyx/pull/32) – Added: `BackPressHandler` plugin that allows to control back press behaviour via `androidx.activity.OnBackPressedCallback`
 
 
 ## 1.0-alpha03

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -63,4 +63,5 @@ dependencies {
     androidTestImplementation libs.androidx.test.espresso.core
     androidTestImplementation libs.androidx.test.junit
     androidTestImplementation libs.compose.ui.test.junit4
+    androidTestImplementation project(':testing-ui')
 }

--- a/core/src/androidTest/java/com/bumble/appyx/core/plugin/BackPressHandlerTest.kt
+++ b/core/src/androidTest/java/com/bumble/appyx/core/plugin/BackPressHandlerTest.kt
@@ -1,0 +1,145 @@
+package com.bumble.appyx.core.plugin
+
+import android.app.Activity
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.test.espresso.Espresso
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bumble.appyx.core.composable.Children
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.ParentNode
+import com.bumble.appyx.core.node.node
+import com.bumble.appyx.debug.Appyx
+import com.bumble.appyx.routingsource.backstack.BackStack
+import com.bumble.appyx.routingsource.backstack.activeRouting
+import com.bumble.appyx.routingsource.backstack.operation.push
+import com.bumble.appyx.testing.ui.rules.AppyxTestRule
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+
+class BackPressHandlerTest {
+
+    private var onBackPressedHandled = false
+    private var backPressHandler: BackPressHandler = object : BackPressHandler {
+        override val onBackPressedCallback: OnBackPressedCallback =
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    onBackPressedHandled = true
+                }
+            }
+    }
+
+    @get:Rule
+    val rule = AppyxTestRule(launchActivity = false) { buildContext ->
+        TestParentNode(buildContext = buildContext, plugin = backPressHandler)
+    }
+
+    @After
+    fun after() {
+        Appyx.exceptionHandler = null
+    }
+
+    @Test
+    fun routing_handles_back_press_when_plugin_has_disabled_listener() {
+        rule.start()
+        runOnMainSync {
+            backPressHandler.onBackPressedCallback!!.isEnabled = false
+            rule.node.backStack.push(TestParentNode.Routing.ChildB)
+        }
+
+        Espresso.pressBack()
+        Espresso.onIdle()
+
+        assertThat(rule.node.backStack.activeRouting, equalTo(TestParentNode.Routing.ChildA))
+        assertThat(onBackPressedHandled, equalTo(false))
+    }
+
+    @Test
+    fun custom_plugin_handles_back_press_before_routing() {
+        rule.start()
+        runOnMainSync { rule.node.backStack.push(TestParentNode.Routing.ChildB) }
+
+        Espresso.pressBack()
+        Espresso.onIdle()
+
+        assertThat(rule.node.backStack.activeRouting, equalTo(TestParentNode.Routing.ChildB))
+        assertThat(onBackPressedHandled, equalTo(true))
+    }
+
+    @Test
+    fun activity_is_closed_when_nobody_can_handle_back_press() {
+        rule.start()
+        runOnMainSync {
+            backPressHandler.onBackPressedCallback!!.isEnabled = false
+        }
+
+        Espresso.pressBackUnconditionally()
+        Espresso.onIdle()
+
+        assertThat(rule.activityResult.resultCode, equalTo(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun reports_incorrect_handler() {
+        var exception: Exception? = null
+        Appyx.exceptionHandler = { exception = it }
+        backPressHandler = object : BackPressHandler {
+            override val onBackPressedCallback: OnBackPressedCallback =
+                object : OnBackPressedCallback(true) {
+                    override fun handleOnBackPressed() {
+                    }
+                }
+
+            override val onBackPressedCallbackList: List<OnBackPressedCallback> = listOf(
+                onBackPressedCallback, object : OnBackPressedCallback(true) {
+                    override fun handleOnBackPressed() {
+                    }
+                }
+            )
+        }
+        rule.start()
+
+        Espresso.onIdle()
+
+        assertThat(exception, instanceOf(IllegalStateException::class.java))
+    }
+
+    private fun runOnMainSync(runner: Runnable) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(runner)
+    }
+
+    class TestParentNode(
+        buildContext: BuildContext,
+        val backStack: BackStack<Routing> = BackStack(
+            initialElement = Routing.ChildA,
+            savedStateMap = null,
+        ),
+        plugin: Plugin,
+    ) : ParentNode<TestParentNode.Routing>(
+        buildContext = buildContext,
+        routingSource = backStack,
+        plugins = listOf(plugin),
+    ) {
+
+        sealed class Routing {
+            object ChildA : Routing()
+            object ChildB : Routing()
+        }
+
+        override fun resolve(routing: Routing, buildContext: BuildContext) = when (routing) {
+            Routing.ChildA -> node(buildContext) {}
+            Routing.ChildB -> node(buildContext) {}
+        }
+
+        @Composable
+        override fun View(modifier: Modifier) {
+            Children(routingSource = backStack, modifier = modifier)
+        }
+    }
+
+}

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/core/src/main/java/com/bumble/appyx/core/node/ParentNode.kt
+++ b/core/src/main/java/com/bumble/appyx/core/node/ParentNode.kt
@@ -1,11 +1,9 @@
 package com.bumble.appyx.core.node
 
-import androidx.activity.compose.BackHandler
 import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -264,14 +262,6 @@ abstract class ParentNode<Routing : Any>(
                 }
             }
         }
-
-    @Composable
-    final override fun DerivedSetup() {
-        val canHandleBackPress by routingSource.canHandleBackPress.collectAsState()
-        BackHandler(canHandleBackPress) {
-            routingSource.onBackPressed()
-        }
-    }
 
     open fun onChildFinished(child: Node) {
         // TODO warn unhandled child

--- a/core/src/main/java/com/bumble/appyx/core/routing/RoutingSource.kt
+++ b/core/src/main/java/com/bumble/appyx/core/routing/RoutingSource.kt
@@ -14,8 +14,6 @@ interface RoutingSource<Routing, State> : RoutingSourceAdapter<Routing, State>,
 
     val elements: StateFlow<RoutingElements<Routing, out State>>
 
-    val canHandleBackPress: StateFlow<Boolean>
-
     fun onTransitionFinished(key: RoutingKey<Routing>) {
         onTransitionFinished(listOf(key))
     }
@@ -25,5 +23,6 @@ interface RoutingSource<Routing, State> : RoutingSourceAdapter<Routing, State>,
     fun accept(operation: Operation<Routing, State>) = Unit
 
     override fun handleUpNavigation(): Boolean =
-        canHandleBackPress.value.also { if (it) onBackPressed() }
+        handleOnBackPressed()
+
 }

--- a/core/src/main/java/com/bumble/appyx/core/routing/backpresshandlerstrategies/BackPressHandlerStrategy.kt
+++ b/core/src/main/java/com/bumble/appyx/core/routing/backpresshandlerstrategies/BackPressHandlerStrategy.kt
@@ -1,16 +1,15 @@
 package com.bumble.appyx.core.routing.backpresshandlerstrategies
 
-import com.bumble.appyx.core.plugin.BackPressHandler
 import com.bumble.appyx.core.routing.BaseRoutingSource
-import com.bumble.appyx.core.routing.RoutingSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
-interface BackPressHandlerStrategy<Routing, State>
-    : BackPressHandler {
+interface BackPressHandlerStrategy<Routing, State> {
 
     fun init(routingSource: BaseRoutingSource<Routing, State>, scope: CoroutineScope)
 
     val canHandleBackPress: StateFlow<Boolean>
+
+    fun onBackPressed()
 
 }

--- a/core/src/main/java/com/bumble/appyx/core/routing/source/combined/CombinedRoutingSource.kt
+++ b/core/src/main/java/com/bumble/appyx/core/routing/source/combined/CombinedRoutingSource.kt
@@ -1,5 +1,6 @@
 package com.bumble.appyx.core.routing.source.combined
 
+import androidx.activity.OnBackPressedCallback
 import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.routing.RoutingElements
 import com.bumble.appyx.core.routing.RoutingKey
@@ -36,13 +37,8 @@ class CombinedRoutingSource<Routing>(
         }
             .stateIn(scope, SharingStarted.Eagerly, RoutingSourceAdapter.ScreenState())
 
-    override val canHandleBackPress: StateFlow<Boolean> =
-        combine(sources.map { it.canHandleBackPress }) { arr -> arr.any { it } }
-            .stateIn(scope, SharingStarted.Eagerly, false)
-
-    override fun onBackPressed() {
-        sources.firstOrNull { it.canHandleBackPress.value }?.onBackPressed()
-    }
+    override val onBackPressedCallbackList: List<OnBackPressedCallback>
+        get() = sources.flatMap { it.onBackPressedCallbackList }
 
     override fun onTransitionFinished(key: RoutingKey<Routing>) {
         sources.forEach { it.onTransitionFinished(key) }

--- a/core/src/main/java/com/bumble/appyx/core/routing/source/permanent/PermanentRoutingSource.kt
+++ b/core/src/main/java/com/bumble/appyx/core/routing/source/permanent/PermanentRoutingSource.kt
@@ -58,13 +58,6 @@ class PermanentRoutingSource<Routing : Any>(
                 initialValue = RoutingSourceAdapter.ScreenState(onScreen = state.value)
             )
 
-    override val canHandleBackPress: StateFlow<Boolean> =
-        MutableStateFlow(false)
-
-    override fun onBackPressed() {
-        // no-op
-    }
-
     override fun onTransitionFinished(keys: Collection<RoutingKey<Routing>>) {
         // no-op
     }

--- a/core/src/test/java/com/bumble/appyx/core/children/ChildAwareTestBase.kt
+++ b/core/src/test/java/com/bumble/appyx/core/children/ChildAwareTestBase.kt
@@ -128,8 +128,6 @@ abstract class ChildAwareTestBase {
             get() = state.map { RoutingSourceAdapter.ScreenState(onScreen = it) }
                 .stateIn(scope, SharingStarted.Eagerly, RoutingSourceAdapter.ScreenState())
 
-        override fun onBackPressed() = Unit
-
         override fun onTransitionFinished(keys: Collection<RoutingKey<Key>>) {
             state.update { list ->
                 list.map {
@@ -141,9 +139,6 @@ abstract class ChildAwareTestBase {
                 }
             }
         }
-
-        override val canHandleBackPress: StateFlow<Boolean>
-            get() = MutableStateFlow(false)
 
         fun add(vararg key: RoutingKey<Key>) {
             state.update { list ->

--- a/core/src/test/java/com/bumble/appyx/core/lifecycle/ParentLifecycleTest.kt
+++ b/core/src/test/java/com/bumble/appyx/core/lifecycle/ParentLifecycleTest.kt
@@ -16,8 +16,6 @@ import com.bumble.appyx.core.routing.RoutingElements
 import com.bumble.appyx.core.routing.RoutingKey
 import com.bumble.appyx.core.routing.onscreen.OnScreenStateResolver
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -71,13 +69,6 @@ class ParentLifecycleTest {
         }
 
         override val initialElements: RoutingElements<String, State> = emptyList()
-
-        override val canHandleBackPress: StateFlow<Boolean> =
-            MutableStateFlow(false)
-
-        override fun onBackPressed() {
-            // no-op
-        }
 
         fun add(routing: String, defaultState: State) {
             updateState { list ->

--- a/core/src/test/java/com/bumble/appyx/routingsource/backstack/BackStackTest.kt
+++ b/core/src/test/java/com/bumble/appyx/routingsource/backstack/BackStackTest.kt
@@ -205,30 +205,8 @@ internal class BackStackTest {
             savedStateMap = savedStateMap
         )
 
-        val canHandleBackPress = backStack.canHandleBackPress.value
+        val canHandleBackPress = backStack.onBackPressedCallback.isEnabled
 
-        assertEquals(true, canHandleBackPress)
-    }
-
-    @Test
-    fun `canHandleBackPress gets notified when change in backstack`() = testScope.runTest {
-
-        val initialElement = Routing1
-        val backStack = BackStack<Routing>(
-            initialElement = initialElement,
-            savedStateMap = null
-        )
-
-        var canHandleBackPress: Boolean? = null
-        val job = launch {
-            backStack
-                .canHandleBackPress
-                .collect { canHandleBackPress = it }
-        }
-
-        backStack.push(Routing2)
-
-        job.cancel()
         assertEquals(true, canHandleBackPress)
     }
 
@@ -250,7 +228,7 @@ internal class BackStackTest {
             savedStateMap = savedStateMap
         )
 
-        val canHandleBackPress = backStack.canHandleBackPress.value
+        val canHandleBackPress = backStack.onBackPressedCallback.isEnabled
 
         assertEquals(false, canHandleBackPress)
     }
@@ -473,7 +451,7 @@ internal class BackStackTest {
             savedStateMap = savedStateMap
         )
 
-        backStack.onBackPressed()
+        backStack.handleOnBackPressed()
 
         val state = backStack.elements.value
 

--- a/documentation/other/plugins.md
+++ b/documentation/other/plugins.md
@@ -72,6 +72,30 @@ class SomeClass(
 ⚠️ Note: the reference to ```node``` is set by ```Node``` automatically, and isn't available immediately after constructing your object, but only after the construction of the ```Node``` itself.
 
 
+### Navigation plugins
+
+In case if you need to control navigation behaviour, you can use these plugins:
+
+```kotlin
+interface UpNavigationHandler : Plugin {
+    fun handleUpNavigation(): Boolean = false
+}
+
+interface BackPressHandler : Plugin {
+    val onBackPressedCallback: OnBackPressedCallback? get() = null
+}
+```
+
+`UpNavigationHandler` controls `Node.navigateUp` behaviour and allows to intercept its invocation.
+
+`BackPressHandler` controls device back press behaviour via `androidx.activity.OnBackPressedCallback`.
+You can read more about it [here](https://developer.android.com/guide/navigation/navigation-custom-back).
+
+⚠️ Note: `OnBackPressedCallback` are invoked in the following order:
+1. From children to parents. Render order of children matters! The last rendered child will be the first to handle back press.
+2. Direct order of plugins within a node. Plugins are invoked in order they appears in `Node(plugins = ...)` before routing source. 
+
+
 ## Using Plugins 
 
 All plugins are designed to have empty ```{}``` default implementations (or other sensible defaults when a return value is defined), so it's convenient to implement them only if you need.

--- a/sandbox/src/main/java/com/bumble/appyx/sandbox/client/blocker/BlockerExampleBackPressInteractor.kt
+++ b/sandbox/src/main/java/com/bumble/appyx/sandbox/client/blocker/BlockerExampleBackPressInteractor.kt
@@ -1,0 +1,44 @@
+package com.bumble.appyx.sandbox.client.blocker
+
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.Stable
+import com.bumble.appyx.core.plugin.BackPressHandler
+import com.bumble.appyx.core.plugin.Destroyable
+import com.bumble.appyx.core.plugin.UpNavigationHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+@Stable
+class BlockerExampleBackPressInteractor : BackPressHandler, UpNavigationHandler, Destroyable {
+    private val scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
+
+    val interceptBackClicks: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val allowNavigateUp: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val errors: MutableSharedFlow<Long> = MutableSharedFlow(extraBufferCapacity = 1)
+
+    override val onBackPressedCallback: OnBackPressedCallback =
+        object : OnBackPressedCallback(interceptBackClicks.value) {
+            override fun handleOnBackPressed() {
+                errors.tryEmit(System.currentTimeMillis())
+            }
+        }
+
+    init {
+        scope.launch {
+            interceptBackClicks.collect { onBackPressedCallback.isEnabled = it }
+        }
+    }
+
+    override fun destroy() {
+        scope.cancel()
+    }
+
+    override fun handleUpNavigation(): Boolean =
+        !allowNavigateUp.value
+
+}

--- a/testing-ui/src/main/java/com/bumble/appyx/testing/ui/rules/AppyxTestRule.kt
+++ b/testing-ui/src/main/java/com/bumble/appyx/testing/ui/rules/AppyxTestRule.kt
@@ -1,0 +1,67 @@
+package com.bumble.appyx.testing.ui.rules
+
+import androidx.annotation.CallSuper
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.rule.ActivityTestRule
+import com.bumble.appyx.core.integration.NodeFactory
+import com.bumble.appyx.core.integration.NodeHost
+import com.bumble.appyx.core.node.Node
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+open class AppyxTestRule<T : Node>(
+    private val launchActivity: Boolean = true,
+    private val composeTestRule: ComposeTestRule = createEmptyComposeRule(),
+    /** Add decorations like custom theme or CompositionLocalProvider. Do not forget to invoke `content()`. */
+    private val decorator: (@Composable (content: @Composable () -> Unit) -> Unit) = { content -> content() },
+    private val nodeFactory: NodeFactory<T>,
+) : ActivityTestRule<AppyxViewActivity>(
+    /* activityClass = */ AppyxViewActivity::class.java,
+    /* initialTouchMode = */ true,
+    /* launchActivity = */ launchActivity
+), ComposeTestRule by composeTestRule {
+
+    lateinit var node: T
+        private set
+
+    override fun apply(base: Statement, description: Description): Statement {
+        val parent =
+            TestRule { parentBase, parentDescription -> super.apply(parentBase, parentDescription) }
+
+        return RunRules(base, listOf(composeTestRule, parent), description, ::before, ::after)
+    }
+
+    fun start() {
+        require(!launchActivity) {
+            "Activity will be launched automatically, launchActivity parameter was passed into constructor"
+        }
+        launchActivity(null)
+    }
+
+    override fun beforeActivityLaunched() {
+        AppyxViewActivity.composableView = { activity ->
+            NodeHost(integrationPoint = activity.integrationPoint, factory = { buildContext ->
+                node = nodeFactory.create(buildContext)
+                node
+            })
+        }
+    }
+
+    override fun afterActivityLaunched() {
+        AppyxViewActivity.composableView = null
+    }
+
+    @CallSuper
+    open fun before() {
+
+    }
+
+    @CallSuper
+    open fun after() {
+
+    }
+
+}

--- a/testing-ui/src/main/java/com/bumble/appyx/testing/ui/rules/AppyxViewActivity.kt
+++ b/testing-ui/src/main/java/com/bumble/appyx/testing/ui/rules/AppyxViewActivity.kt
@@ -2,22 +2,22 @@ package com.bumble.appyx.testing.ui.rules
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
+import com.bumble.appyx.core.integrationpoint.NodeActivity
 
-class AppyxViewActivity : AppCompatActivity() {
+class AppyxViewActivity : NodeActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val composableView = composableView
         setContent {
             requireNotNull(composableView) { "AppyxViewActivity View has not been setup" }
-            composableView()
+            composableView(this)
         }
     }
 
     companion object {
-        var composableView: (@Composable () -> Unit)? = null
+        var composableView: (@Composable (activity: AppyxViewActivity) -> Unit)? = null
     }
 
 }


### PR DESCRIPTION
## Description

[Currently](https://github.com/bumble-tech/appyx/blob/main/core/src/main/java/com/bumble/appyx/core/plugin/Plugins.kt#L31) `BackPressHandler` is not an actual plugin and is manually supported only for a routing source. In this PR I tried to implement `BackPressHandler` that is available for any component in a node.

Also in this PR i tried to support [predictive back gesture](https://developer.android.com/about/versions/13/features/predictive-back-gesture) feature of Android 13. As you can see on the attached video it works as expected.

## Concerns

### AndroidX

In this PR I implement `BackPressHandler` as a provider of AndroidX `OnBackPressedCallback`. It allows more seamless integration with other AndroidX components but has the following issues:
- We are one step further away from multi platform support and it is Android only library.
- Client has to work with not the best of class API, but still more familiar than some custom API.
- `OnBackPressedCallback.isEnabled` is not reactive/observable, so we need to manually synchronise internal state of an owner component with this property like `feature.state.subscribe { callback.isEnabled = state.someCheck }`.
 - In case of custom API it is possible to create more interesting API like
```kotlin
interface OnBackPressedCallback {
   // flow here instead of simple boolean property
   // to be able to easily map internal state into boolean state in a reactive way 
   val isEnabled: StateFlow<Boolean>
   fun dispatchBackPressed()
}
```
 - But in this case we are forcing clients (including us) to use `StateFlow` in their internal components (like interactors) instead of RxJava for example. But we are already doing it in `RoutingSource`.
- We can't keep current API of `fun onBackPressed()` because we need to declare if we support going back or not first, so AndroidX and Android integration works fine. This change also allowed me to remove one property from `RoutingSource`.
- By using AndroidX API directly we are guarding ourselves from potential changes like predictive back button in the future. 

### Registration order

In the current implementation and in this pull request we are relying on Compose to register `OnBackPressedCallback`. Invocation order of `OnBackPressedCallback` of different nodes in the same parent is defined by the order of Composable functions. If a node is out of a composition, it won't handle back presses. Implementation details is [here](https://github.com/bumble-tech/appyx/blob/main/core/src/main/java/com/bumble/appyx/core/node/ParentNode.kt#L217).

Most likely this problem is out of scope of this pull request 

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.

[predictive-support.webm](https://user-images.githubusercontent.com/9081555/179012451-4b4cbfd1-4a67-4b0d-b6db-a7cfb8548f6e.webm)