### PR TITLE
Issue #28 Added scrolling to sandbox to fix small devices

### DIFF
--- a/sandbox/src/main/java/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
+++ b/sandbox/src/main/java/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -164,8 +166,10 @@ class ContainerNode(
 
     @Composable
     fun ExamplesList(modifier: Modifier) {
+        val scrollState = rememberScrollState()
         Box(
             modifier = modifier
+                .verticalScroll(scrollState)
                 .fillMaxSize()
                 .padding(24.dp),
             contentAlignment = Alignment.Center
@@ -203,8 +207,10 @@ class ContainerNode(
 
     @Composable
     fun RoutingSources(modifier: Modifier) {
+        val scrollState = rememberScrollState()
         Box(
             modifier = modifier
+                .verticalScroll(scrollState)
                 .fillMaxSize()
                 .padding(24.dp),
             contentAlignment = Alignment.Center

--- a/sandbox/src/main/java/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleView.kt
+++ b/sandbox/src/main/java/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleView.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
@@ -63,8 +65,11 @@ class MviCoreExampleViewImpl(
     @Composable
     override fun ParentNode<Routing>.NodeView(modifier: Modifier) {
         val viewModel = vm ?: return
+        val scrollState = rememberScrollState()
         Column(
-            modifier = modifier.fillMaxSize(),
+            modifier = modifier
+                .verticalScroll(scrollState)
+                .fillMaxSize(),
             verticalArrangement = Arrangement.Center
         ) {
             Text(


### PR DESCRIPTION
## Description

Fixes #28 

Videos demonstrating fixes (I also fixed the MVICore example screen):

[appyx-scrolling-fix-1.webm](https://user-images.githubusercontent.com/1333155/179365544-ee9681bc-485d-4324-a99b-948add58cde5.webm)

[appyx-scrolling-fix-2.webm](https://user-images.githubusercontent.com/1333155/179365548-66ce5b7c-898f-489d-837d-2e9c1058f4c5.webm)

[appyx-mvicore-scrolling-fix.webm](https://user-images.githubusercontent.com/1333155/179365550-9f0c22c0-e6f7-4ee8-896e-a20d330e43ab.webm)

## Check list

- [x] I do not need to update `CHANGELOG.md`.
- [x] I do not need to update the documentation.
