### PR TITLE
Do not try to publish snapshots in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             --dry-run
             --no-parallel
       - uses: gradle/gradle-build-action@v2
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.repository == 'bumble-tech/appyx'
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         with:


### PR DESCRIPTION
## Description

Taken from https://github.com/square/workflow-kotlin/blob/main/.github/workflows/publish-snapshot.yml

The main branch is always red in [my fork](https://github.com/CherryPerry/appyx) because it always tries to publish a new snapshot version, but can't without credentials. 

Add check for repository name for publishing step.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
