### PR TITLE
Remove assumption that there can be only one root from IntegrationPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#47](https://github.com/bumble-tech/appyx/issues/47) – Updated: The 'customisations' module is now pure Java/Kotlin.
 - [#32](https://github.com/bumble-tech/appyx/pull/32) – Added: `BackPressHandler` plugin that allows to control back press behaviour via `androidx.activity.OnBackPressedCallback`
 - [#32](https://github.com/bumble-tech/appyx/issues/69) – Added: Jetpack Compose Navigation code sample
+- [#81](https://github.com/bumble-tech/appyx/issues/81) – Added: Support integration point for multiple roots
 
 
 ## 1.0-alpha03

--- a/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
+++ b/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.core.integration
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,9 +30,8 @@ fun <N : Node> NodeHost(
     factory: NodeFactory<N>
 ) {
     val node by rememberNode(factory, customisations)
-    DisposableEffect(integrationPoint) {
-        integrationPoint.attach(node)
-        onDispose { integrationPoint.detach() }
+    LaunchedEffect(integrationPoint, node) {
+        node.integrationPoint = integrationPoint
     }
     DisposableEffect(node) {
         onDispose { node.updateLifecycleState(Lifecycle.State.DESTROYED) }

--- a/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
+++ b/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -25,7 +26,7 @@ import com.bumble.appyx.core.state.SavedStateMap
  */
 @Composable
 fun <N : Node> NodeHost(
-    customisations: NodeCustomisationDirectory = NodeCustomisationDirectoryImpl(),
+    customisations: NodeCustomisationDirectory = remember { NodeCustomisationDirectoryImpl() },
     integrationPoint: IntegrationPoint,
     factory: NodeFactory<N>
 ) {

--- a/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
+++ b/core/src/main/java/com/bumble/appyx/core/integration/NodeHost.kt
@@ -2,7 +2,6 @@ package com.bumble.appyx.core.integration
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +16,7 @@ import com.bumble.appyx.core.integrationpoint.IntegrationPoint
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.build
+import com.bumble.appyx.core.state.SavedStateMap
 
 /**
  * Composable function to host [Node].
@@ -29,10 +29,7 @@ fun <N : Node> NodeHost(
     integrationPoint: IntegrationPoint,
     factory: NodeFactory<N>
 ) {
-    val node by rememberNode(factory, customisations)
-    LaunchedEffect(integrationPoint, node) {
-        node.integrationPoint = integrationPoint
-    }
+    val node by rememberNode(factory, customisations, integrationPoint)
     DisposableEffect(node) {
         onDispose { node.updateLifecycleState(Lifecycle.State.DESTROYED) }
     }
@@ -49,30 +46,30 @@ fun <N : Node> NodeHost(
 }
 
 @Composable
-internal fun <N : Node> rememberNode(
+private fun <N : Node> rememberNode(
     factory: NodeFactory<N>,
-    customisations: NodeCustomisationDirectory
-): State<N> =
-    rememberSaveable(
+    customisations: NodeCustomisationDirectory,
+    integrationPoint: IntegrationPoint,
+): State<N> {
+
+    fun createNode(savedStateMap: SavedStateMap?): N =
+        factory
+            .create(
+                buildContext = BuildContext.root(
+                    savedStateMap = savedStateMap,
+                    customisations = customisations
+                ),
+            )
+            .build()
+            .apply { this.integrationPoint = integrationPoint }
+
+    return rememberSaveable(
         inputs = arrayOf(),
         stateSaver = mapSaver(
             save = { node -> node.saveInstanceState(this) },
-            restore = { state ->
-                factory.create(
-                    buildContext = BuildContext.root(
-                        savedStateMap = state,
-                        customisations = customisations
-                    ),
-                ).build()
-            },
+            restore = { state -> createNode(savedStateMap = state) },
         ),
     ) {
-        mutableStateOf(
-            factory.create(
-                buildContext = BuildContext.root(
-                    savedStateMap = null,
-                    customisations = customisations
-                )
-            ).build()
-        )
+        mutableStateOf(createNode(savedStateMap = null))
     }
+}

--- a/core/src/main/java/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
+++ b/core/src/main/java/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Stable
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
 import com.bumble.appyx.core.integrationpoint.requestcode.RequestCodeRegistry
-import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.routing.upnavigation.UpNavigationHandler
 
 @Stable
@@ -18,21 +17,6 @@ abstract class IntegrationPoint(
     abstract val activityStarter: ActivityStarter
 
     abstract val permissionRequester: PermissionRequester
-
-    private var _root: Node? = null
-    private val root: Node
-        get() = _root ?: error("Root has not been initialised. Did you forget to call attach?")
-
-    fun attach(root: Node) {
-        if (_root != null) error("A root has already been attached to this integration point")
-        if (!root.isRoot) error("Trying to attach non-root Node")
-        this._root = root
-        root.integrationPoint = this
-    }
-
-    fun detach() {
-        _root = null
-    }
 
     fun onSaveInstanceState(outState: Bundle) {
         requestCodeRegistry.onSaveInstanceState(outState)


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/81

1. Removed assumption that only one Appyx root can exist
2. IntegrationPoint should be attached at the moment of the node creation. This way we can guarantee that a `Node` has `IntegrationPoint` before `node.Compose()` is called

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
