### PR TITLE
Add interactor tests when parent node implements Connectable

### DIFF
--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
@@ -23,7 +23,9 @@ class MviCoreChildNode1(
 ) : Node(buildContext),
     Connectable<Input, Output> by connector {
 
-    sealed class Input
+    sealed class Input {
+        object ExampleInput: Input()
+    }
 
     sealed class Output {
         data class Result(val data: String) : Output()

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
@@ -24,7 +24,7 @@ class MviCoreChildNode1(
     Connectable<Input, Output> by connector {
 
     sealed class Input {
-        object ExampleInput: Input()
+        object ExampleInput1: Input()
     }
 
     sealed class Output {

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
@@ -23,7 +23,7 @@ class MviCoreChildNode2(
 ) : Node(buildContext), Connectable<Input, Output> by connector {
 
     sealed class Input {
-        object ExampleInput: Input()
+        object ExampleInput2: Input()
     }
 
     sealed class Output {

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
@@ -22,7 +22,9 @@ class MviCoreChildNode2(
     private val connector: NodeConnector<Input, Output> = NodeConnector()
 ) : Node(buildContext), Connectable<Input, Output> by connector {
 
-    sealed class Input
+    sealed class Input {
+        object ExampleInput: Input()
+    }
 
     sealed class Output {
         data class Result(val data: String) : Output()

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractor.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractor.kt
@@ -16,6 +16,8 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing.Child2
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.EventsToWish
+import com.bumble.appyx.sandbox.client.mvicoreexample.feature.InputToInputChild1
+import com.bumble.appyx.sandbox.client.mvicoreexample.feature.InputToInputChild2
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.News
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.State
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.Wish
@@ -52,8 +54,14 @@ class MviCoreExampleInteractor(
         whenChildAttached { _: Lifecycle, child: Node ->
             child.lifecycle.createDestroy {
                 when (child) {
-                    is MviCoreChildNode1 -> bind(child.output to feature using OutputChild1ToWish)
-                    is MviCoreChildNode2 -> bind(child.output to feature using OutputChild2ToWish)
+                    is MviCoreChildNode1 -> {
+                        bind(child.output to feature using OutputChild1ToWish)
+                        bind(node.input to child.input using InputToInputChild1)
+                    }
+                    is MviCoreChildNode2 -> {
+                        bind(child.output to feature using OutputChild2ToWish)
+                        bind(node.input to child.input using InputToInputChild2)
+                    }
                 }
             }
         }

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNode.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNode.kt
@@ -1,26 +1,40 @@
 package com.bumble.appyx.sandbox.client.mvicoreexample
 
 import android.os.Parcelable
+import com.bumble.appyx.connectable.rx2.Connectable
+import com.bumble.appyx.connectable.rx2.NodeConnector
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.ParentNodeView
 import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import kotlinx.parcelize.Parcelize
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
 
 class MviCoreExampleNode(
     view: ParentNodeView<Routing>,
     buildContext: BuildContext,
     plugins: List<Plugin>,
     backStack: BackStack<Routing>,
+    connector: NodeConnector<Input, Nothing> = NodeConnector(),
+    private val child1Connector: NodeConnector<Child1Input, Child1Output> = NodeConnector(),
+    private val child2Connector: NodeConnector<Child2Input, Child2Output> = NodeConnector(),
 ) : ParentNode<Routing>(
     view = view,
     navModel = backStack,
     buildContext = buildContext,
     plugins = plugins
-) {
+), Connectable<Input, Nothing> by connector {
+
+    sealed class Input {
+        object ExampleInput : Input()
+    }
 
     sealed class Routing : Parcelable {
         @Parcelize
@@ -32,7 +46,13 @@ class MviCoreExampleNode(
 
     override fun resolve(routing: Routing, buildContext: BuildContext): Node =
         when (routing) {
-            is Routing.Child1 -> MviCoreChildNode1(buildContext)
-            is Routing.Child2 -> MviCoreChildNode2(buildContext)
+            is Routing.Child1 -> MviCoreChildNode1(
+                buildContext = buildContext,
+                connector = child1Connector,
+            )
+            is Routing.Child2 -> MviCoreChildNode2(
+                buildContext = buildContext,
+                connector = child2Connector,
+            )
         }
 }

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild1.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild1.kt
@@ -1,0 +1,11 @@
+package com.bumble.appyx.sandbox.client.mvicoreexample.feature
+
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input
+
+internal object InputToInputChild1 : (Input) -> MviCoreChildNode1.Input {
+    override fun invoke(output: Input): MviCoreChildNode1.Input =
+        when (output) {
+            is Input.ExampleInput -> MviCoreChildNode1.Input.ExampleInput
+        }
+}

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild1.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild1.kt
@@ -6,6 +6,6 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input
 internal object InputToInputChild1 : (Input) -> MviCoreChildNode1.Input {
     override fun invoke(output: Input): MviCoreChildNode1.Input =
         when (output) {
-            is Input.ExampleInput -> MviCoreChildNode1.Input.ExampleInput
+            is Input.ExampleInput -> MviCoreChildNode1.Input.ExampleInput1
         }
 }

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild2.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild2.kt
@@ -6,6 +6,6 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input
 internal object InputToInputChild2 : (Input) -> MviCoreChildNode2.Input {
     override fun invoke(output: Input): MviCoreChildNode2.Input =
         when (output) {
-            is Input.ExampleInput -> MviCoreChildNode2.Input.ExampleInput
+            is Input.ExampleInput -> MviCoreChildNode2.Input.ExampleInput2
         }
 }

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild2.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/InputToInputChild2.kt
@@ -1,0 +1,11 @@
+package com.bumble.appyx.sandbox.client.mvicoreexample.feature
+
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input
+
+internal object InputToInputChild2 : (Input) -> MviCoreChildNode2.Input {
+    override fun invoke(output: Input): MviCoreChildNode2.Input =
+        when (output) {
+            is Input.ExampleInput -> MviCoreChildNode2.Input.ExampleInput
+        }
+}

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorJUnit5Test.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorJUnit5Test.kt
@@ -66,7 +66,7 @@ class MviCoreExampleInteractorJUnit5Test {
         interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             parentNodeConnector.input.accept(ParentInput.ExampleInput)
 
-            child1InputTestObserver.assertValue(Child1Input.ExampleInput)
+            child1InputTestObserver.assertValue(Child1Input.ExampleInput1)
             child2InputTestObserver.assertNoValues()
         }
     }
@@ -80,7 +80,7 @@ class MviCoreExampleInteractorJUnit5Test {
         interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             parentNodeConnector.input.accept(ParentInput.ExampleInput)
 
-            child2InputTestObserver.assertValue(Child2Input.ExampleInput)
+            child2InputTestObserver.assertValue(Child2Input.ExampleInput2)
             child1InputTestObserver.assertNoValues()
         }
     }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorJUnit5Test.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorJUnit5Test.kt
@@ -3,6 +3,8 @@ package com.bumble.appyx.sandbox.client.mvicoreexample
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.connectable.rx2.NodeConnector
 import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.News
@@ -12,37 +14,82 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.InitialState
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.Loading
 import com.bumble.appyx.sandbox.stub.FeatureStub
-import com.bumble.appyx.testing.unit.common.helper.interactorTestHelper
 import com.bumble.appyx.sandbox.stub.NodeViewStub
 import com.bumble.appyx.testing.junit5.util.CoroutinesTestExtension
 import com.bumble.appyx.testing.junit5.util.InstantExecutorExtension
+import com.bumble.appyx.testing.unit.common.helper.InteractorTestHelperWithConnectable
+import com.bumble.appyx.testing.unit.common.helper.interactorTestHelperWithConnectable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input as ParentInput
 
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class MviCoreExampleInteractorJUnit5Test {
 
     private val view = object : NodeViewStub<Event, ViewModel, Routing>(), MviCoreExampleView {}
-
     private val feature = FeatureStub<Wish, State, News>(
         initialState = State.InitialState("Test Initial State")
     )
+    private val parentNodeConnector: NodeConnector<ParentInput, Nothing> = NodeConnector()
+    private val child1Connector: NodeConnector<Child1Input, Child1Output> = NodeConnector()
+    private val child2Connector: NodeConnector<Child2Input, Child2Output> = NodeConnector()
 
-    private val backStack = BackStack<Routing>(
-        initialElement = Routing.Child1,
-        savedStateMap = null
-    )
+    private lateinit var backStack: BackStack<Routing>
+    private lateinit var interactorTestHelper: InteractorTestHelperWithConnectable<MviCoreExampleNode>
 
-    private val interactor = MviCoreExampleInteractor(
-        view = view,
-        feature = feature,
-        backStack = backStack
-    )
+    private fun before(initialElement: Routing = Routing.Child1) {
+        backStack = BackStack(
+            initialElement = initialElement,
+            savedStateMap = null,
+        )
+
+        val interactor = MviCoreExampleInteractor(
+            view = view,
+            feature = feature,
+            backStack = backStack,
+        )
+
+        interactorTestHelper =
+            interactor.interactorTestHelperWithConnectable(nodeBuilder = ::createNode)
+    }
+
+    @Test
+    fun `given child 1 is set when input received then child 1 receives input`() {
+        val child1InputTestObserver = child1Connector.input.test()
+        val child2InputTestObserver = child2Connector.input.test()
+        before()
+
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
+            parentNodeConnector.input.accept(ParentInput.ExampleInput)
+
+            child1InputTestObserver.assertValue(Child1Input.ExampleInput)
+            child2InputTestObserver.assertNoValues()
+        }
+    }
+
+    @Test
+    fun `given child 2 is set when input received then child 2 receives input`() {
+        val child1InputTestObserver = child1Connector.input.test()
+        val child2InputTestObserver = child2Connector.input.test()
+        before(initialElement = Routing.Child2)
+
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
+            parentNodeConnector.input.accept(ParentInput.ExampleInput)
+
+            child2InputTestObserver.assertValue(Child2Input.ExampleInput)
+            child1InputTestObserver.assertNoValues()
+        }
+    }
 
     @Test
     fun `when load data clicked then load data wish is received`() {
+        before()
         val testObserver = feature.wishesRelay.test()
-        interactor.interactorTestHelper().moveToStateAndCheck(Lifecycle.State.STARTED) {
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             view.eventsRelay.accept(Event.LoadDataClicked)
 
             testObserver.assertValue(Wish.LoadData)
@@ -51,26 +98,30 @@ class MviCoreExampleInteractorJUnit5Test {
 
     @Test
     fun `given child 1 is set when child 1 outputs a result then wish is received`() {
-        val nodeConnector = NodeConnector<MviCoreChildNode1.Input, MviCoreChildNode1.Output>()
+        before()
         val testObserver = feature.wishesRelay.test()
 
-        interactor.interactorTestHelper(navModel = backStack) {
-            MviCoreChildNode1(
-                buildContext = it,
-                connector = nodeConnector
-            )
-        }
+        child1Connector.output.accept(Child1Output.Result("hello"))
 
-        nodeConnector.output.accept(MviCoreChildNode1.Output.Result("hello"))
+        testObserver.assertValue(Wish.ChildInput("hello"))
+    }
+
+    @Test
+    fun `given child 2 is set when child 2 outputs a result then wish is received`() {
+        before(initialElement = Routing.Child2)
+        val testObserver = feature.wishesRelay.test()
+
+        child2Connector.output.accept(Child2Output.Result("hello"))
 
         testObserver.assertValue(Wish.ChildInput("hello"))
     }
 
     @Test
     fun `given feature sends loading then view model is loading`() {
+        before()
         val testObserver = view.viewModelRelay.test()
 
-        interactor.interactorTestHelper().moveToStateAndCheck(Lifecycle.State.STARTED) {
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             feature.statesRelay.accept(State.Loading)
 
             testObserver.assertValueSequence(
@@ -81,4 +132,14 @@ class MviCoreExampleInteractorJUnit5Test {
             )
         }
     }
+
+    private fun createNode(buildContext: BuildContext, plugins: List<Plugin>) = MviCoreExampleNode(
+        view = view,
+        buildContext = buildContext,
+        plugins = plugins,
+        backStack = backStack,
+        connector = parentNodeConnector,
+        child1Connector = child1Connector,
+        child2Connector = child2Connector,
+    )
 }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorTest.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorTest.kt
@@ -71,7 +71,7 @@ class MviCoreExampleInteractorTest {
         interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             parentNodeConnector.input.accept(ParentInput.ExampleInput)
 
-            child1InputTestObserver.assertValue(Child1Input.ExampleInput)
+            child1InputTestObserver.assertValue(Child1Input.ExampleInput1)
             child2InputTestObserver.assertNoValues()
         }
     }
@@ -85,7 +85,7 @@ class MviCoreExampleInteractorTest {
         interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             parentNodeConnector.input.accept(ParentInput.ExampleInput)
 
-            child2InputTestObserver.assertValue(Child2Input.ExampleInput)
+            child2InputTestObserver.assertValue(Child2Input.ExampleInput2)
             child1InputTestObserver.assertNoValues()
         }
     }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorTest.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractorTest.kt
@@ -3,6 +3,8 @@ package com.bumble.appyx.sandbox.client.mvicoreexample
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.connectable.rx2.NodeConnector
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.plugin.Plugin
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
@@ -13,11 +15,17 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.InitialState
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.Loading
 import com.bumble.appyx.sandbox.stub.FeatureStub
-import com.bumble.appyx.testing.unit.common.helper.interactorTestHelper
 import com.bumble.appyx.sandbox.stub.NodeViewStub
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
+import com.bumble.appyx.testing.unit.common.helper.InteractorTestHelperWithConnectable
+import com.bumble.appyx.testing.unit.common.helper.interactorTestHelperWithConnectable
 import org.junit.Rule
 import org.junit.Test
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Input as ParentInput
 
 class MviCoreExampleInteractorTest {
 
@@ -27,28 +35,66 @@ class MviCoreExampleInteractorTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-
     private val view = object : NodeViewStub<Event, ViewModel, Routing>(), MviCoreExampleView {}
-
     private val feature = FeatureStub<Wish, State, News>(
         initialState = State.InitialState("Test Initial State")
     )
+    private val parentNodeConnector: NodeConnector<ParentInput, Nothing> = NodeConnector()
+    private val child1Connector: NodeConnector<Child1Input, Child1Output> = NodeConnector()
+    private val child2Connector: NodeConnector<Child2Input, Child2Output> = NodeConnector()
 
-    private val backStack = BackStack<Routing>(
-        initialElement = Routing.Child1,
-        savedStateMap = null
-    )
+    private lateinit var backStack: BackStack<Routing>
+    private lateinit var interactorTestHelper: InteractorTestHelperWithConnectable<MviCoreExampleNode>
 
-    private val interactor = MviCoreExampleInteractor(
-        view = view,
-        feature = feature,
-        backStack = backStack
-    )
+    private fun before(initialElement: Routing = Routing.Child1) {
+        backStack = BackStack(
+            initialElement = initialElement,
+            savedStateMap = null,
+        )
+
+        val interactor = MviCoreExampleInteractor(
+            view = view,
+            feature = feature,
+            backStack = backStack,
+        )
+
+        interactorTestHelper =
+            interactor.interactorTestHelperWithConnectable(nodeBuilder = ::createNode)
+    }
+
+    @Test
+    fun `given child 1 is set when input received then child 1 receives input`() {
+        val child1InputTestObserver = child1Connector.input.test()
+        val child2InputTestObserver = child2Connector.input.test()
+        before()
+
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
+            parentNodeConnector.input.accept(ParentInput.ExampleInput)
+
+            child1InputTestObserver.assertValue(Child1Input.ExampleInput)
+            child2InputTestObserver.assertNoValues()
+        }
+    }
+
+    @Test
+    fun `given child 2 is set when input received then child 2 receives input`() {
+        val child1InputTestObserver = child1Connector.input.test()
+        val child2InputTestObserver = child2Connector.input.test()
+        before(initialElement = Routing.Child2)
+
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
+            parentNodeConnector.input.accept(ParentInput.ExampleInput)
+
+            child2InputTestObserver.assertValue(Child2Input.ExampleInput)
+            child1InputTestObserver.assertNoValues()
+        }
+    }
 
     @Test
     fun `when load data clicked then load data wish is received`() {
+        before()
         val testObserver = feature.wishesRelay.test()
-        interactor.interactorTestHelper().moveToStateAndCheck(Lifecycle.State.STARTED) {
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             view.eventsRelay.accept(Event.LoadDataClicked)
 
             testObserver.assertValue(Wish.LoadData)
@@ -57,26 +103,30 @@ class MviCoreExampleInteractorTest {
 
     @Test
     fun `given child 1 is set when child 1 outputs a result then wish is received`() {
-        val nodeConnector = NodeConnector<MviCoreChildNode1.Input, MviCoreChildNode1.Output>()
+        before()
         val testObserver = feature.wishesRelay.test()
 
-        interactor.interactorTestHelper(navModel = backStack) {
-            MviCoreChildNode1(
-                buildContext = it,
-                connector = nodeConnector
-            )
-        }
+        child1Connector.output.accept(Child1Output.Result("hello"))
 
-        nodeConnector.output.accept(MviCoreChildNode1.Output.Result("hello"))
+        testObserver.assertValue(Wish.ChildInput("hello"))
+    }
+
+    @Test
+    fun `given child 2 is set when child 2 outputs a result then wish is received`() {
+        before(initialElement = Routing.Child2)
+        val testObserver = feature.wishesRelay.test()
+
+        child2Connector.output.accept(Child2Output.Result("hello"))
 
         testObserver.assertValue(Wish.ChildInput("hello"))
     }
 
     @Test
     fun `given feature sends loading then view model is loading`() {
+        before()
         val testObserver = view.viewModelRelay.test()
 
-        interactor.interactorTestHelper().moveToStateAndCheck(Lifecycle.State.STARTED) {
+        interactorTestHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
             feature.statesRelay.accept(State.Loading)
 
             testObserver.assertValueSequence(
@@ -87,4 +137,14 @@ class MviCoreExampleInteractorTest {
             )
         }
     }
+
+    private fun createNode(buildContext: BuildContext, plugins: List<Plugin>) = MviCoreExampleNode(
+        view = view,
+        buildContext = buildContext,
+        plugins = plugins,
+        backStack = backStack,
+        connector = parentNodeConnector,
+        child1Connector = child1Connector,
+        child2Connector = child2Connector,
+    )
 }

--- a/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/helper/InteractorTestHelperWithConnectable.kt
+++ b/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/helper/InteractorTestHelperWithConnectable.kt
@@ -1,0 +1,37 @@
+package com.bumble.appyx.testing.unit.common.helper
+
+import androidx.lifecycle.Lifecycle
+import com.bumble.appyx.core.clienthelper.interactor.Interactor
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.plugin.Plugin
+
+fun <N : Node> Interactor<N>.interactorTestHelperWithConnectable(
+    nodeBuilder: (BuildContext, List<Plugin>) -> Node,
+) = InteractorTestHelperWithConnectable(
+    interactor = this,
+    nodeBuilder = nodeBuilder,
+)
+
+class InteractorTestHelperWithConnectable<N : Node>(
+    interactor: Interactor<N>,
+    nodeBuilder: (BuildContext, List<Plugin>) -> Node,
+) {
+    private val node = nodeBuilder(
+        BuildContext.root(savedStateMap = null),
+        listOf(interactor),
+    )
+
+    private val nodeTestHelper = node.nodeTestHelper()
+
+    fun moveTo(state: Lifecycle.State) {
+        nodeTestHelper.moveTo(state)
+    }
+
+    /**
+     * moves the Node to the desired state and then returns to the original state if possible
+     */
+    fun moveToStateAndCheck(state: Lifecycle.State, block: (Node) -> Unit) {
+        nodeTestHelper.moveToStateAndCheck(state, block)
+    }
+}


### PR DESCRIPTION
## Description
This PR fix a crash (on unit tests) when using an `InteractorTestHelper`, the steps to reproduce it are:

- Have a Node that implements `Connectable<Input, Output>` 
- In the Interactor of that Node we add a binding that uses either the `node.input` or `node.output`
- Create an Interactor unit test that uses the current `InteractorTestHelper`

Crashlogs:
![image](https://user-images.githubusercontent.com/20324156/185932568-de61b20b-7596-46a6-8870-b0dff64c5998.png)

I'm not sure if this is the best approach and there are some classes name I wasn't sure about it but probably we can fix that more easily :)
...

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [X] I have updated documentation if required.
