### PR TITLE
HandleBackPress should provide lifecycle to OnBackPressedDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#96](https://github.com/bumble-tech/appyx/pull/96) – **Breaking change**: Removed `InteractorTestHelper`. Please use Node tests instead of Interactor tests.
 - [#99](https://github.com/bumble-tech/appyx/pull/99) – **Added**: Source<T>.rx2() to convert Source<T> to io.reactivex.Observable<T>
 - [#99](https://github.com/bumble-tech/appyx/pull/99) – **Breaking change**: Modified package of `NodeConnector` and `Connectable`
+- [#107](https://github.com/bumble-tech/appyx/pull/107) – **Fixed**: Back press handlers are not properly registered on lifecycle events
 
 ## 1.0-alpha05 – 19 Aug 2022
 


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/102

Sorry, without test, a setup is too big.
Can't reproduce with Activity only, have to also setup nav graph with fragments.

[device-2022-08-26-101833.webm](https://user-images.githubusercontent.com/9081555/186880488-d0d33ba1-b7d4-4797-908f-83f4979f8d66.webm)

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
