### PR TITLE
Mark Node class as stable to allow compose compiler to infer stability of composable functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending changes
 
 - [#119](https://github.com/bumble-tech/appyx/pull/119) - **Fixed**: Lifecycle observers are invoked in incorrect order (child before parent)
+- [#62](https://github.com/bumble-tech/appyx/pull/62) - **Fixed**: Node is marked with stable annotation making some of the composable functions skippable 
 
 ## 1.0-alpha06 – 26 Aug 2022
 

--- a/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
@@ -5,6 +5,7 @@ import androidx.annotation.CallSuper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.SaverScope
 import androidx.compose.ui.Modifier
@@ -36,6 +37,7 @@ import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.debug.Appyx
 import kotlinx.coroutines.withContext
 
+@Stable
 abstract class Node(
     buildContext: BuildContext,
     val view: NodeView = EmptyNodeView,


### PR DESCRIPTION
## Description

Node class is used as a parameter in some composable functions. Making it stable allows compose compiler mark some of the functions skippable improving performance

Fixes https://github.com/bumble-tech/appyx/issues/62 

Before:
```
{
 "skippableComposables": 16,
 "restartableComposables": 31,
 "readonlyComposables": 0,
 "totalComposables": 60,
 "restartGroups": 31,
 "totalGroups": 66,
 "staticArguments": 9,
 "certainArguments": 29,
 "knownStableArguments": 110,
 "knownUnstableArguments": 15,
 "unknownStableArguments": 10,
 "totalArguments": 135,
 "markedStableClasses": 6,
 "inferredStableClasses": 40,
 "inferredUnstableClasses": 34,
 "inferredUncertainClasses": 10,
 "effectivelyStableClasses": 46,
 "totalClasses": 90,
 "memoizedLambdas": 19,
 "singletonLambdas": 0,
 "singletonComposableLambdas": 11,
 "composableLambdas": 20,
 "totalLambdas": 27
}
```

After:
```
{
 "skippableComposables": 26,
 "restartableComposables": 31,
 "readonlyComposables": 0,
 "totalComposables": 60,
 "restartGroups": 31,
 "totalGroups": 67,
 "staticArguments": 9,
 "certainArguments": 30,
 "knownStableArguments": 115,
 "knownUnstableArguments": 13,
 "unknownStableArguments": 10,
 "totalArguments": 138,
 "markedStableClasses": 7,
 "inferredStableClasses": 43,
 "inferredUnstableClasses": 30,
 "inferredUncertainClasses": 10,
 "effectivelyStableClasses": 50,
 "totalClasses": 90,
 "memoizedLambdas": 20,
 "singletonLambdas": 0,
 "singletonComposableLambdas": 11,
 "composableLambdas": 20,
 "totalLambdas": 27
}
```

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
