### PR TITLE
Fix node connector invalid usage and add paren extensions

### DIFF
--- a/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNodeExt.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNodeExt.kt
@@ -1,0 +1,15 @@
+package com.bumble.appyx.core.node
+
+import com.bumble.appyx.core.children.nodeOrNull
+
+fun ParentNode<*>.children(): List<Node> {
+    return this.children.value.values.mapNotNull { it.nodeOrNull }
+}
+
+inline fun <reified N : Node> ParentNode<*>.childrenOfType(): List<N> {
+    return this.children.value.values.mapNotNull { it.nodeOrNull }.filterIsInstance<N>()
+}
+
+inline fun <reified N : Node> ParentNode<*>.firstChildOfType(): N {
+    return childrenOfType<N>().first()
+}

--- a/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNode.kt
+++ b/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNode.kt
@@ -6,22 +6,15 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.ParentNodeView
 import com.bumble.appyx.core.plugin.Plugin
-import com.bumble.appyx.interop.rx2.connectable.NodeConnector
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import kotlinx.parcelize.Parcelize
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
 
 class MviCoreExampleNode(
     view: ParentNodeView<Routing>,
     buildContext: BuildContext,
     plugins: List<Plugin>,
     backStack: BackStack<Routing>,
-    private val child1NodeConnector: NodeConnector<Child1Input, Child1Output> = NodeConnector(),
-    private val child2NodeConnector: NodeConnector<Child2Input, Child2Output> = NodeConnector(),
 ) : ParentNode<Routing>(
     view = view,
     navModel = backStack,
@@ -39,7 +32,7 @@ class MviCoreExampleNode(
 
     override fun resolve(routing: Routing, buildContext: BuildContext): Node =
         when (routing) {
-            is Routing.Child1 -> MviCoreChildNode1(buildContext, child1NodeConnector)
-            is Routing.Child2 -> MviCoreChildNode2(buildContext, child2NodeConnector)
+            is Routing.Child1 -> MviCoreChildNode1(buildContext)
+            is Routing.Child2 -> MviCoreChildNode2(buildContext)
         }
 }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeJUnit5Test.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeJUnit5Test.kt
@@ -3,7 +3,7 @@ package com.bumble.appyx.sandbox.client.mvicoreexample
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.ParentNode
-import com.bumble.appyx.interop.rx2.connectable.NodeConnector
+import com.bumble.appyx.core.node.firstChildOfType
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
@@ -20,10 +20,6 @@ import com.bumble.appyx.testing.unit.common.helper.parentNodeTestHelper
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
 
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class MviCoreExampleNodeJUnit5Test {
@@ -45,8 +41,6 @@ class MviCoreExampleNodeJUnit5Test {
         backStack = backStack
     )
 
-    private val child1NodeConnector: NodeConnector<Child1Input, Child1Output> = NodeConnector()
-    private val child2NodeConnector: NodeConnector<Child2Input, Child2Output> = NodeConnector()
 
     private lateinit var node: MviCoreExampleNode
     private lateinit var testHelper: ParentNodeTestHelper<Routing, ParentNode<Routing>>
@@ -58,8 +52,6 @@ class MviCoreExampleNodeJUnit5Test {
             buildContext = BuildContext.root(savedStateMap = null),
             plugins = listOf(interactor),
             backStack = backStack,
-            child1NodeConnector = child1NodeConnector,
-            child2NodeConnector = child2NodeConnector,
         )
 
         testHelper = node.parentNodeTestHelper()
@@ -100,7 +92,9 @@ class MviCoreExampleNodeJUnit5Test {
         val testObserver = feature.wishesRelay.test()
 
         testHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
-            child1NodeConnector.output.accept(MviCoreChildNode1.Output.Result("hello"))
+            node.firstChildOfType<MviCoreChildNode1>().output.accept(
+                MviCoreChildNode1.Output.Result("hello")
+            )
 
             testObserver.assertValue(Wish.ChildInput("hello"))
         }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeTest.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.ParentNode
-import com.bumble.appyx.interop.rx2.connectable.NodeConnector
+import com.bumble.appyx.core.node.firstChildOfType
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.Routing
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
@@ -20,10 +20,6 @@ import com.bumble.appyx.testing.unit.common.helper.parentNodeTestHelper
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input as Child1Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Output as Child1Output
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input as Child2Input
-import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Output as Child2Output
 
 class MviCoreExampleNodeTest {
 
@@ -51,9 +47,6 @@ class MviCoreExampleNodeTest {
         backStack = backStack
     )
 
-    private val child1NodeConnector: NodeConnector<Child1Input, Child1Output> = NodeConnector()
-    private val child2NodeConnector: NodeConnector<Child2Input, Child2Output> = NodeConnector()
-
     private lateinit var node: MviCoreExampleNode
     private lateinit var testHelper: ParentNodeTestHelper<Routing, ParentNode<Routing>>
 
@@ -63,9 +56,7 @@ class MviCoreExampleNodeTest {
             view = view,
             buildContext = BuildContext.root(savedStateMap = null),
             plugins = listOf(interactor),
-            backStack = backStack,
-            child1NodeConnector = child1NodeConnector,
-            child2NodeConnector = child2NodeConnector,
+            backStack = backStack
         )
 
         testHelper = node.parentNodeTestHelper()
@@ -106,7 +97,9 @@ class MviCoreExampleNodeTest {
         val testObserver = feature.wishesRelay.test()
 
         testHelper.moveToStateAndCheck(Lifecycle.State.STARTED) {
-            child1NodeConnector.output.accept(MviCoreChildNode1.Output.Result("hello"))
+            node.firstChildOfType<MviCoreChildNode1>().output.accept(
+                MviCoreChildNode1.Output.Result("hello")
+            )
 
             testObserver.assertValue(Wish.ChildInput("hello"))
         }

--- a/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/NodeViewStub.kt
+++ b/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/NodeViewStub.kt
@@ -3,7 +3,6 @@ package com.bumble.appyx.sandbox.stub
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.node.AbstractParentNodeView
-import com.bumble.appyx.core.node.EmptyNodeView
 import com.bumble.appyx.core.node.ParentNode
 import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.ObservableSource
@@ -21,7 +20,5 @@ open class NodeViewStub<Event : Any, ViewModel : Any, Routing : Any>(
     Disposable by disposable {
 
     @Composable
-    override fun ParentNode<Routing>.NodeView(modifier: Modifier) {
-        EmptyNodeView
-    }
+    override fun ParentNode<Routing>.NodeView(modifier: Modifier) = Unit
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/101

Also fixes cash in MviCoreExampleNode. The same instance of node connection was used for different instances of Nodes. This incorrect usage of `NodeConnectors` and led to a crash with error `Already flushed`

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
