### PR TITLE
Support ComponentActivity for Jetpack Compose template projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#122](https://github.com/bumble-tech/appyx/pull/122) - **Breaking change**: `ChildEntry.ChildMode` is removed, now nodes are always created when a nav model changes (previously default behaviour)
 - [#122](https://github.com/bumble-tech/appyx/pull/122) - **Added**: New `ChildEntry.KeepMode` that allows to destroy nodes that are currently not visible on the screen
+- [#132](https://github.com/bumble-tech/appyx/pull/132) - **Added**: New `NodeComponentActivity` to extend when wanting to work with ComponentActivity as your base activity, eg when migrating from a project built from the Jetpack Compose template
 - [#119](https://github.com/bumble-tech/appyx/pull/119) - **Fixed**: Lifecycle observers are invoked in incorrect order (child before parent)
 - [#62](https://github.com/bumble-tech/appyx/pull/62) - **Fixed**: Node is marked with stable annotation making some of the composable functions skippable
 - [#129](https://github.com/bumble-tech/appyx/pull/129) - **Updated**: Removed sealed interface from operations to allow client to define their own

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -1,15 +1,15 @@
 package com.bumble.appyx.core.integrationpoint
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityBoundary
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequestBoundary
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
 
 open class ActivityIntegrationPoint(
-    private val activity: AppCompatActivity,
+    private val activity: Activity,
     savedInstanceState: Bundle?,
 ) : IntegrationPoint(savedInstanceState = savedInstanceState) {
     private val activityBoundary = ActivityBoundary(activity, requestCodeRegistry)

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeActivity.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeActivity.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 
 /**
- * Helper class for root [Node] integration.
+ * Helper class for root [Node] integration into projects using [AppCompatActivity].
+ *
+ * See [NodeComponentActivity] for building upon [ComponentActivity].
  *
  * Also offers base functionality to satisfy dependencies of Android-related functionality
  * down the tree via [integrationPoint]:

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
@@ -3,10 +3,11 @@ package com.bumble.appyx.core.integrationpoint
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.appcompat.app.AppCompatActivity
 
 /**
- * Helper class for root [Node] integration into projects using ComponentActivity.
+ * Helper class for root [Node] integration into projects using [ComponentActivity].
+ *
+ * See [NodeActivity] for building upon [AppCompatActivity]
  *
  * Also offers base functionality to satisfy dependencies of Android-related functionality
  * down the tree via [integrationPoint]:

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
@@ -1,0 +1,55 @@
+package com.bumble.appyx.core.integrationpoint
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Helper class for root [Node] integration into projects using ComponentActivity.
+ *
+ * Also offers base functionality to satisfy dependencies of Android-related functionality
+ * down the tree via [integrationPoint]:
+ * - [ActivityStarter]
+ * - [PermissionRequester]
+ *
+ * Feel free to not extend this and use your own integration point - in this case,
+ * don't forget to take a look here what methods needs to be forwarded to the root Node.
+ */
+abstract class NodeComponentActivity : ComponentActivity() {
+
+    lateinit var integrationPoint: ActivityIntegrationPoint
+        protected set
+
+    protected open fun createIntegrationPoint(savedInstanceState: Bundle?): ActivityIntegrationPoint =
+        ActivityIntegrationPoint(
+            activity = this,
+            savedInstanceState = savedInstanceState
+        )
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        integrationPoint = createIntegrationPoint(savedInstanceState)
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        integrationPoint.onActivityResult(requestCode, resultCode, data)
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        integrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        integrationPoint.onSaveInstanceState(outState)
+    }
+}


### PR DESCRIPTION
## Description
Replace ActivityIntegrationPoint dependency on AppCompatActivity with Activity
Add NodeComponentActivity as a drop-in replacement for NodeActivity in projects using ComponentActivity

Note: ComponentActivity provides as `registerForActivityResult()` api that deprecates `onActivityResult()` and `onRequestPermissionsResult()`, but I've deemed implementing a solution for supporting that new result api beyond the scope of this PR.

Fixes #131 

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
