### PR TITLE
Make NodeView.kt interface and ParentNode class stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#119](https://github.com/bumble-tech/appyx/pull/119) - **Fixed**: Lifecycle observers are invoked in incorrect order (child before parent)
 - [#62](https://github.com/bumble-tech/appyx/pull/62) - **Fixed**: Node is marked with stable annotation making some of the composable functions skippable
 - [#129](https://github.com/bumble-tech/appyx/pull/129) - **Updated**: Removed sealed interface from operations to allow client to define their own
+- [#133](https://github.com/bumble-tech/appyx/pull/133) - **Updated**: NodeView interface marked as stable improving amount of skippable composables
 
 ## 1.0-alpha06 – 26 Aug 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [#119](https://github.com/bumble-tech/appyx/pull/119) - **Fixed**: Lifecycle observers are invoked in incorrect order (child before parent)
 - [#62](https://github.com/bumble-tech/appyx/pull/62) - **Fixed**: Node is marked with stable annotation making some of the composable functions skippable
 - [#129](https://github.com/bumble-tech/appyx/pull/129) - **Updated**: Removed sealed interface from operations to allow client to define their own
-- [#133](https://github.com/bumble-tech/appyx/pull/133) - **Updated**: NodeView interface marked as stable improving amount of skippable composables
+- [#133](https://github.com/bumble-tech/appyx/pull/133) - **Updated**: NodeView interface and ParentNode marked as stable improving amount of skippable composables
 
 ## 1.0-alpha06 – 26 Aug 2022
 

--- a/core/src/main/kotlin/com/bumble/appyx/core/node/NodeView.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/node/NodeView.kt
@@ -1,8 +1,10 @@
 package com.bumble.appyx.core.node
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 
+@Stable
 interface NodeView {
 
     @Composable

--- a/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -4,6 +4,7 @@ import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 import kotlin.reflect.KClass
 
+@Stable
 abstract class ParentNode<Routing : Any>(
     navModel: NavModel<Routing, *>,
     buildContext: BuildContext,


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/133

+ a follow up for https://github.com/bumble-tech/appyx/pull/127 as ParentNode is not automatically stable if Node is stable

```
{
 "skippableComposables": 27,
 "restartableComposables": 31,
 "readonlyComposables": 0,
 "totalComposables": 60,
 "restartGroups": 31,
 "totalGroups": 67,
 "staticArguments": 9,
 "certainArguments": 30,
 "knownStableArguments": 115,
 "knownUnstableArguments": 13,
 "unknownStableArguments": 10,
 "totalArguments": 138,
 "markedStableClasses": 8,
 "inferredStableClasses": 43,
 "inferredUnstableClasses": 30,
 "inferredUncertainClasses": 10,
 "effectivelyStableClasses": 51,
 "totalClasses": 91,
 "memoizedLambdas": 20,
 "singletonLambdas": 0,
 "singletonComposableLambdas": 11,
 "composableLambdas": 20,
 "totalLambdas": 27
}
```


## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
