### PR TITLE
Fix IntegrationPoint memory leak created by ActivityIntegrationPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pending changes
+- [#139](https://github.com/bumble-tech/appyx/pull/139) - **Fixed**: `IntegrationPoint` memory leak created by `ActivityIntegrationPoint`
 
 - [#140](https://github.com/bumble-tech/appyx/issues/140) - **Breaking change**: Added `testing-ui-activity` module to avoid needing to add `testing-ui` as a debug implementation as part of instrumentation testing. See the linked issue for more details
 

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -9,6 +9,7 @@ import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityBoundary
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequestBoundary
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
+import java.lang.ref.WeakReference
 import java.util.WeakHashMap
 
 open class ActivityIntegrationPoint private constructor(
@@ -49,14 +50,14 @@ open class ActivityIntegrationPoint private constructor(
     }
 
     companion object {
-        private val integrationPoints = WeakHashMap<Activity, IntegrationPoint>()
+        private val integrationPoints = WeakHashMap<Activity, WeakReference<IntegrationPoint>>()
 
         fun createIntegrationPoint(
             activity: Activity,
             savedInstanceState: Bundle?,
         ): ActivityIntegrationPoint =
             ActivityIntegrationPoint(activity, savedInstanceState)
-                .also { integrationPoints[activity] = it }
+                .also { integrationPoints[activity] = WeakReference(it) }
 
         fun getIntegrationPoint(context: Context): IntegrationPoint {
             val activity = context.findActivity<Activity>()
@@ -66,7 +67,7 @@ open class ActivityIntegrationPoint private constructor(
             val integrationPoint = integrationPoints
                 .entries
                 .firstOrNull { (key, _) -> key === activity }
-                ?.value
+                ?.value?.get()
 
             return requireNotNull(integrationPoint) {
                 "Unable to find integration point. It was either not created " +


### PR DESCRIPTION
## Description
`ActivityIntegrationPoint` leaking `Activity` instances since `ActivityIntegrationPoint` holds a strong reference to the Activity. `WeakHashMap` is unable to clear the entry since the same `activity` instance is being used as `key` and also in the `value` object

```
┬───
│ GC Root: Thread object
│
├─ android.net.ConnectivityThread instance
│    Leaking: NO (PathClassLoader↓ is not leaking)
│    Thread name: 'ConnectivityThread'
│    ↓ Thread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (ActivityIntegrationPoint↓ is not leaking and A ClassLoader is
│    never leaking)
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (ActivityIntegrationPoint↓ is not leaking)
│    ↓ Object[884]
├─ com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint class
│    Leaking: NO (a class is never leaking)
│    ↓ static ActivityIntegrationPoint.integrationPoints
│                                      ~~~~~~~~~~~~~~~~~
├─ java.util.WeakHashMap instance
│    Leaking: UNKNOWN
│    Retaining 169.6 kB in 3954 objects
│    ↓ WeakHashMap.table
│                  ~~~~~
├─ java.util.WeakHashMap$Entry[] array
│    Leaking: UNKNOWN
│    Retaining 169.5 kB in 3951 objects
│    ↓ WeakHashMap$Entry[0]
│                       ~~~
├─ java.util.WeakHashMap$Entry instance
│    Leaking: UNKNOWN
│    Retaining 83.2 kB in 1926 objects
│    referent instance of co.zuper.android.ui.host.HostActivity with mDestroyed
│    = true
│    ↓ WeakHashMap$Entry.value
│                        ~~~~~
├─ com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint instance
│    Leaking: UNKNOWN
│    Retaining 83.2 kB in 1925 objects
│    activity instance of co.zuper.android.ui.host.HostActivity with mDestroyed
│    = true
│    ↓ ActivityIntegrationPoint.activity
│                               ~~~~~~~~
╰→ co.zuper.android.ui.host.HostActivity instance
​     Leaking: YES (ObjectWatcher was watching this because co.zuper.android.ui.
​     host.HostActivity received Activity#onDestroy() callback and
​     Activity#mDestroyed is true)
​     Retaining 82.9 kB in 1916 objects
​     key = 005ec729-daaa-43df-a6d2-2f97825f9d7a
​     watchDurationMillis = 18279
​     retainedDurationMillis = 13277
​     mApplication instance of co.zuper.android.ZuperApp
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper

METADATA

Build.VERSION.SDK_INT: 33
Build.MANUFACTURER: Google
LeakCanary version: 2.9.1
App process name: co.zuper.android.dev
Class count: 30112
Instance count: 243224
Primitive array count: 143091
Object array count: 38493
Thread count: 31
Heap total bytes: 31331321
Bitmap count: 28
Bitmap total bytes: 900521
Large bitmap count: 0
Large bitmap total bytes: 0
Stats: LruCache[maxSize=3000,hits=117858,misses=248001,hitRate=32%]
RandomAccess[bytes=12538085,reads=248001,travel=81765454152,range=37319569,size=
46458866]
Analysis duration: 4738 ms
```

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
