### PR TITLE
Fix gradle transitive deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 
 ## Pending changes
 
-- [#138](https://github.com/bumble-tech/appyx/pull/139) - **Fixed**: `androidx.appcompat:appcompat` from is exposed via `api` within `com.bumble.appyx:core`. This prevents potential compilation bugs.
-- **Updated**: `SpotlightSlider` now uses offset modifier with lambda
+- [#138](https://github.com/bumble-tech/appyx/pull/138) - **Fixed**: `androidx.appcompat:appcompat` from is exposed via `api` within `com.bumble.appyx:core`. This prevents potential compilation bugs.
+- [#143](https://github.com/bumble-tech/appyx/issues/143) - **Fixed**: Correctly exposed transitive dependencies that are part of the libraries ABI
+- [#145](https://github.com/bumble-tech/appyx/issues/145) - **Updated**: `SpotlightSlider` now uses offset modifier with lambda
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ plugins {
 dependencyAnalysis {
     issues {
         all {
+            onIncorrectConfiguration {
+                severity("fail")
+            }
             onUnusedDependencies {
                 severity("fail")
 

--- a/interop-ribs/build.gradle.kts
+++ b/interop-ribs/build.gradle.kts
@@ -32,11 +32,11 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
+    api(libs.ribs.base)
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.lifecycle.java8)
     implementation(libs.compose.ui.ui)
-    implementation(libs.ribs.base)
     implementation(libs.ribs.compose)
 }

--- a/interop-rx2/build.gradle.kts
+++ b/interop-rx2/build.gradle.kts
@@ -31,11 +31,11 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
+    api(libs.rxjava2)
+    api(libs.rxrelay)
 
     implementation(libs.androidx.lifecycle.java8)
-    implementation(libs.rxjava2)
-    implementation(libs.rxrelay)
 
     testImplementation(libs.junit.api)
     testRuntimeOnly(libs.junit.engine)

--- a/navmodel-addons/build.gradle.kts
+++ b/navmodel-addons/build.gradle.kts
@@ -33,11 +33,11 @@ android {
 }
 
 dependencies {
-    implementation(project(":core"))
+    api(project(":core"))
+    api(libs.compose.ui.ui)
 
     implementation(libs.androidx.lifecycle.java8)
     implementation(libs.compose.ui.tooling)
-    implementation(libs.compose.ui.ui)
     implementation(libs.compose.foundation.layout)
     implementation(libs.compose.foundation)
 }

--- a/testing-junit4/build.gradle.kts
+++ b/testing-junit4/build.gradle.kts
@@ -33,7 +33,6 @@ android {
 
 dependencies {
     api(project(":testing-unit-common"))
-
-    implementation(libs.junit)
+    api(libs.junit)
     implementation(libs.kotlin.coroutines.test)
 }

--- a/testing-junit5/build.gradle.kts
+++ b/testing-junit5/build.gradle.kts
@@ -37,6 +37,6 @@ android {
 
 dependencies {
     api(project(":testing-unit-common"))
-    implementation(libs.junit.api)
-    implementation(libs.kotlin.coroutines.test.jvm)
+    api(libs.junit.api)
+    api(libs.kotlin.coroutines.test.jvm)
 }


### PR DESCRIPTION
## Description
(Depends on #138)

Correctly exposes transitive dependencies that are part of the libraries ABI. Previously if someone used one of these libraries in isolation, they could have faced quite a few problematic compilation issues.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
