### PR TITLE
Updated accompanist flowlayout to match Compose version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-google-accompanist-flow = "com.google.accompanist:accompanist-flowlayout:0.20.0"
+google-accompanist-flow = "com.google.accompanist:accompanist-flowlayout:0.25.1"
 google-material = "com.google.android.material:material:1.4.0"
 junit = "junit:junit:4.13.2"
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }


### PR DESCRIPTION
## Description
Updated accompanist flowlayout to a version that uses the same Compose version.

According to their documentation, there are no functional changes to the library other than possibly minor changes to make it work with Compose 1.2.1.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
