### PR TITLE
[Draft] Use AndroidX saved state

### DIFF
--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistry
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityBoundary
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequestBoundary
@@ -13,7 +16,7 @@ import java.lang.ref.WeakReference
 import java.util.WeakHashMap
 
 open class ActivityIntegrationPoint private constructor(
-    private val activity: Activity,
+    private val activity: ComponentActivity,
     savedInstanceState: Bundle?,
 ) : IntegrationPoint(savedInstanceState = savedInstanceState) {
     private val activityBoundary = ActivityBoundary(activity, requestCodeRegistry)
@@ -24,6 +27,12 @@ open class ActivityIntegrationPoint private constructor(
 
     override val permissionRequester: PermissionRequester
         get() = permissionRequestBoundary
+
+    override val activityResultCaller: ActivityResultCaller
+        get() = activity
+
+    override val activityResultRegistry: ActivityResultRegistry
+        get() = activity.activityResultRegistry
 
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         activityBoundary.onActivityResult(requestCode, resultCode, data)
@@ -53,7 +62,7 @@ open class ActivityIntegrationPoint private constructor(
         private val integrationPoints = WeakHashMap<Activity, WeakReference<IntegrationPoint>>()
 
         fun createIntegrationPoint(
-            activity: Activity,
+            activity: ComponentActivity,
             savedInstanceState: Bundle?,
         ): ActivityIntegrationPoint =
             ActivityIntegrationPoint(activity, savedInstanceState)

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
@@ -1,6 +1,8 @@
 package com.bumble.appyx.core.integrationpoint
 
 import android.os.Bundle
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistry
 import androidx.compose.runtime.Stable
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
@@ -17,6 +19,10 @@ abstract class IntegrationPoint(
     abstract val activityStarter: ActivityStarter
 
     abstract val permissionRequester: PermissionRequester
+
+    abstract val activityResultCaller: ActivityResultCaller
+
+    abstract val activityResultRegistry: ActivityResultRegistry
 
     fun onSaveInstanceState(outState: Bundle) {
         requestCodeRegistry.onSaveInstanceState(outState)

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
@@ -1,5 +1,7 @@
 package com.bumble.appyx.core.integrationpoint
 
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistry
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
 
@@ -16,6 +18,12 @@ class IntegrationPointStub : IntegrationPoint(savedInstanceState = null) {
         get() = error(ERROR)
 
     override val permissionRequester: PermissionRequester
+        get() = error(ERROR)
+
+    override val activityResultCaller: ActivityResultCaller
+        get() = error(ERROR)
+
+    override val activityResultRegistry: ActivityResultRegistry
         get() = error(ERROR)
 
     override fun handleUpNavigation() {

--- a/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/requestcode/RequestCodeBasedEventStreamImpl.kt
+++ b/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/requestcode/RequestCodeBasedEventStreamImpl.kt
@@ -40,15 +40,6 @@ abstract class RequestCodeBasedEventStreamImpl<T : RequestCodeBasedEvent>(
 
         ensureSubject(id) {
             val internalRequestCode = externalRequestCode.toInternalRequestCode()
-            Appyx.reportException(
-                IllegalStateException(
-                    "There's no one listening for request code event! " +
-                            "requestCode: $externalRequestCode, " +
-                            "resolved group: $id, " +
-                            "resolved code: $internalRequestCode, " +
-                            "event: $event"
-                )
-            )
         }
 
         events.getValue(id).tryEmit(event)


### PR DESCRIPTION
## Description

Instead of using custom activity result engine, use AndroidX provided.

Other option: use permissions and activity results only from view via Compose provided methods.

Fixes https://github.com/bumble-tech/appyx/issues/174

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
