### PR TITLE
Immediately complete transitions pending on a Child on removal from composition

### DIFF
--- a/libraries/core/src/main/kotlin/com/bumble/appyx/Appyx.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/Appyx.kt
@@ -6,6 +6,8 @@ object Appyx {
 
     var exceptionHandler: ((Exception) -> Unit)? = null
     var defaultChildKeepMode: ChildEntry.KeepMode = ChildEntry.KeepMode.KEEP
+    var defaultChildTransitionStrategy: ChildEntry.ChildTransitionStrategy =
+        ChildEntry.ChildTransitionStrategy.COMPLETE
 
     fun reportException(exception: Exception) {
         val handler = exceptionHandler

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildEntry.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildEntry.kt
@@ -1,5 +1,7 @@
 package com.bumble.appyx.core.children
 
+import com.bumble.appyx.core.children.ChildEntry.ChildTransitionStrategy.COMPLETE
+import com.bumble.appyx.core.children.ChildEntry.ChildTransitionStrategy.KEEP
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.state.SavedStateMap
@@ -34,4 +36,16 @@ sealed class ChildEntry<T> {
         SUSPEND,
     }
 
+    /**
+     * How should pending Child transitions be handled if the Child leaves the composition?
+     * [KEEP] will suspend the state transition until the child re-enters composition
+     * [COMPLETE] will complete the transition as soon as the child leaves the composition,
+     * to avoid leaving incomplete state that might cause visual or state bugs when using eg a LazyList
+     * [KEEP] is the original behaviour, [COMPLETE] is the proposed replacement behaviour.
+     * This is configurable in case [KEEP] behaviour is required in an existing use-case.
+     * */
+    enum class ChildTransitionStrategy {
+        KEEP,
+        COMPLETE,
+    }
 }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import com.bumble.appyx.Appyx
+import com.bumble.appyx.core.children.ChildEntry
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.navigation.NavElement
@@ -64,8 +66,10 @@ fun <NavTarget : Any, State> ParentNode<NavTarget>.Child(
         )
     }
 
-    DisposableEffect(navElement.key) {
-        onDispose { navModel.onTransitionFinished(childEntry.key) }
+    if (Appyx.defaultChildTransitionStrategy == ChildEntry.ChildTransitionStrategy.COMPLETE) {
+        DisposableEffect(navElement.key) {
+            onDispose { navModel.onTransitionFinished(childEntry.key) }
+        }
     }
 }
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.core.composable
 import androidx.compose.animation.core.Transition
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
@@ -61,6 +62,10 @@ fun <NavTarget : Any, State> ParentNode<NavTarget>.Child(
             ),
             transitionDescriptor = descriptor,
         )
+    }
+
+    DisposableEffect(navElement.key) {
+        onDispose { navModel.onTransitionFinished(childEntry.key) }
     }
 }
 


### PR DESCRIPTION
Courtesy of a suggestion by Yury.

## Description

Implemented DisposableEffect in Child to complete transitions when it leaves composition rather than leaving them hanging. This prevents unexpected transition animations from occurring when, for example, scrolling a LazyList containing elements that may have been mid-transition when the user scrolled past them, and avoids situations where subsequent transitions may get into races to complete with pending ones.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
