### PR TITLE
Move initialElements into constructor

### DIFF
--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/BaseNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/BaseNavModel.kt
@@ -1,14 +1,14 @@
 package com.bumble.appyx.core.navigation
 
 import androidx.activity.OnBackPressedCallback
-import com.bumble.appyx.core.plugin.BackPressHandler
-import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.DontHandleBackPress
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 import com.bumble.appyx.core.navigation.onscreen.isOnScreen
 import com.bumble.appyx.core.navigation.operationstrategies.ExecuteImmediately
 import com.bumble.appyx.core.navigation.operationstrategies.OperationStrategy
+import com.bumble.appyx.core.plugin.BackPressHandler
+import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import com.bumble.appyx.core.state.SavedStateMap
 import kotlinx.coroutines.CoroutineScope
@@ -34,6 +34,7 @@ abstract class BaseNavModel<NavTarget, State>(
     private val backPressHandler: BackPressHandlerStrategy<NavTarget, State> = DontHandleBackPress(),
     private val operationStrategy: OperationStrategy<NavTarget, State> = ExecuteImmediately(),
     private val screenResolver: OnScreenStateResolver<State>,
+    initialElements: NavElements<NavTarget, State>,
     protected val scope: CoroutineScope = CoroutineScope(EmptyCoroutineContext + Dispatchers.Unconfined),
     private val finalStates: Set<State>,
     private val key: String = KEY_NAV_MODEL,
@@ -44,6 +45,7 @@ abstract class BaseNavModel<NavTarget, State>(
         backPressHandler: BackPressHandlerStrategy<NavTarget, State> = DontHandleBackPress(),
         operationStrategy: OperationStrategy<NavTarget, State> = ExecuteImmediately(),
         screenResolver: OnScreenStateResolver<State>,
+        initialElements: NavElements<NavTarget, State>,
         scope: CoroutineScope = CoroutineScope(EmptyCoroutineContext + Dispatchers.Unconfined),
         finalState: State?,
         key: String = KEY_NAV_MODEL,
@@ -52,14 +54,12 @@ abstract class BaseNavModel<NavTarget, State>(
         backPressHandler = backPressHandler,
         operationStrategy = operationStrategy,
         screenResolver = screenResolver,
+        initialElements = initialElements,
         scope = scope,
         finalStates = setOfNotNull(finalState),
         key = key,
         savedStateMap = savedStateMap
     )
-
-    // TODO: think about how we can avoid keeping unnecessary object after state initialization
-    protected abstract val initialElements: NavElements<NavTarget, State>
 
     private val state: MutableStateFlow<NavElements<NavTarget, State>> by lazy {
         MutableStateFlow(savedStateMap?.restoreHistory() ?: initialElements)

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/backstack/BackStack.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/backstack/BackStack.kt
@@ -1,17 +1,17 @@
 package com.bumble.appyx.navmodel.backstack
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 import com.bumble.appyx.core.navigation.operationstrategies.ExecuteImmediately
 import com.bumble.appyx.core.navigation.operationstrategies.OperationStrategy
+import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.navmodel.backstack.BackStack.State
+import com.bumble.appyx.navmodel.backstack.BackStack.State.ACTIVE
 import com.bumble.appyx.navmodel.backstack.BackStack.State.DESTROYED
 import com.bumble.appyx.navmodel.backstack.backpresshandler.PopBackPressHandler
-import com.bumble.appyx.core.state.SavedStateMap
-import com.bumble.appyx.navmodel.backstack.BackStack.State.ACTIVE
 
 class BackStack<NavTarget : Any>(
     initialElement: NavTarget,
@@ -24,6 +24,14 @@ class BackStack<NavTarget : Any>(
     backPressHandler = backPressHandler,
     screenResolver = screenResolver,
     operationStrategy = operationStrategy,
+    initialElements = listOf(
+        BackStackElement(
+            key = NavKey(initialElement),
+            fromState = ACTIVE,
+            targetState = ACTIVE,
+            operation = Noop()
+        )
+    ),
     finalState = DESTROYED,
     savedStateMap = savedStateMap,
     key = key,
@@ -32,14 +40,5 @@ class BackStack<NavTarget : Any>(
     enum class State {
         CREATED, ACTIVE, STASHED, DESTROYED,
     }
-
-    override val initialElements = listOf(
-        BackStackElement(
-            key = NavKey(initialElement),
-            fromState = ACTIVE,
-            targetState = ACTIVE,
-            operation = Noop()
-        )
-    )
 
 }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/spotlight/Spotlight.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/spotlight/Spotlight.kt
@@ -24,6 +24,7 @@ class Spotlight<NavTarget : Any>(
     backPressHandler = backPressHandler,
     operationStrategy = operationStrategy,
     screenResolver = screenResolver,
+    initialElements = items.toSpotlightElements(initialActiveIndex),
     finalState = null,
     savedStateMap = savedStateMap,
     key = key,
@@ -32,7 +33,5 @@ class Spotlight<NavTarget : Any>(
     enum class State {
         INACTIVE_BEFORE, ACTIVE, INACTIVE_AFTER;
     }
-
-    override val initialElements = items.toSpotlightElements(initialActiveIndex)
 
 }

--- a/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/utils/DummyNavModel.kt
+++ b/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/utils/DummyNavModel.kt
@@ -1,7 +1,6 @@
 package com.bumble.appyx.testing.ui.utils
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 
 class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
@@ -9,9 +8,6 @@ class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
     finalState = null,
     screenResolver = object : OnScreenStateResolver<State> {
         override fun isOnScreen(state: State) = true
-    }
-) {
-    override val initialElements: NavElements<NavTarget, State>
-        get() = emptyList()
-
-}
+    },
+    initialElements = emptyList(),
+)

--- a/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/DummyNavModel.kt
+++ b/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/DummyNavModel.kt
@@ -1,7 +1,6 @@
 package com.bumble.appyx.testing.unit.common.util
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 
 class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
@@ -9,9 +8,6 @@ class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
     finalState = null,
     screenResolver = object : OnScreenStateResolver<State> {
         override fun isOnScreen(state: State) = true
-    }
-) {
-    override val initialElements: NavElements<NavTarget, State>
-        get() = emptyList()
-
-}
+    },
+    initialElements = emptyList()
+)

--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/modal/Modal.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/modal/Modal.kt
@@ -1,9 +1,8 @@
 package com.bumble.appyx.navmodel.modal
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.Operation.Noop
-import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 import com.bumble.appyx.core.navigation.operationstrategies.ExecuteImmediately
@@ -26,6 +25,14 @@ class Modal<NavTarget : Any>(
     screenResolver = screenResolver,
     operationStrategy = operationStrategy,
     backPressHandler = backPressHandler,
+    initialElements = listOf(
+        ModalElement(
+            key = NavKey(initialElement),
+            fromState = CREATED,
+            targetState = CREATED,
+            operation = Noop()
+        )
+    ),
     key = key,
     finalState = DESTROYED
 ) {
@@ -34,12 +41,4 @@ class Modal<NavTarget : Any>(
         CREATED, MODAL, FULL_SCREEN, DESTROYED
     }
 
-    override val initialElements: NavElements<NavTarget, State> = listOf(
-        ModalElement(
-            key = NavKey(initialElement),
-            fromState = CREATED,
-            targetState = CREATED,
-            operation = Noop()
-        )
-    )
 }

--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/promoter/navmodel/Promoter.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/promoter/navmodel/Promoter.kt
@@ -1,19 +1,25 @@
 package com.bumble.appyx.navmodel.promoter.navmodel
 
-import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State
-import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State.CREATED
-import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State.DESTROYED
-import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State.STAGE1
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation
+import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State
+import com.bumble.appyx.navmodel.promoter.navmodel.Promoter.State.DESTROYED
 
 class Promoter<T : Any>(
     initialItems: List<T> = listOf(),
 ) : BaseNavModel<T, State>(
     screenResolver = PromoterOnScreenResolver,
     finalState = DESTROYED,
-    savedStateMap = null
+    initialElements = initialItems.map {
+        PromoterElement(
+            key = NavKey(it),
+            fromState = State.CREATED,
+            targetState = State.STAGE1,
+            operation = Operation.Noop()
+        )
+    },
+    savedStateMap = null,
 ) {
 
     enum class State {
@@ -31,12 +37,4 @@ class Promoter<T : Any>(
             }
     }
 
-    override val initialElements = initialItems.map {
-        PromoterElement(
-            key = NavKey(it),
-            fromState = CREATED,
-            targetState = STAGE1,
-            operation = Noop()
-        )
-    }
 }

--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/spotlightadvanced/SpotlightAdvanced.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/spotlightadvanced/SpotlightAdvanced.kt
@@ -23,6 +23,7 @@ class SpotlightAdvanced<NavTarget : Any>(
     backPressHandler = backPressHandler,
     operationStrategy = operationStrategy,
     screenResolver = screenResolver,
+    initialElements = items.toSpotlightAdvancedElements(initialActiveIndex),
     finalState = null,
     savedStateMap = savedStateMap,
     key = key,
@@ -34,7 +35,5 @@ class SpotlightAdvanced<NavTarget : Any>(
         object InactiveAfter : State()
         data class Carousel(val offset: Int, val max: Int) : State()
     }
-
-    override val initialElements = items.toSpotlightAdvancedElements(initialActiveIndex)
 
 }

--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/tiles/Tiles.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/tiles/Tiles.kt
@@ -1,13 +1,13 @@
 package com.bumble.appyx.navmodel.tiles
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
-import com.bumble.appyx.navmodel.tiles.backPressHandler.DeselectAllTiles
 import com.bumble.appyx.navmodel.tiles.Tiles.State
 import com.bumble.appyx.navmodel.tiles.Tiles.State.CREATED
 import com.bumble.appyx.navmodel.tiles.Tiles.State.STANDARD
+import com.bumble.appyx.navmodel.tiles.backPressHandler.DeselectAllTiles
 
 class Tiles<T : Any>(
     initialItems: List<T>,
@@ -15,6 +15,14 @@ class Tiles<T : Any>(
 ) : BaseNavModel<T, State>(
     backPressHandler = backPressHandler,
     screenResolver = TilesOnScreenResolver,
+    initialElements = initialItems.map {
+        TilesElement(
+            key = NavKey(it),
+            fromState = CREATED,
+            targetState = STANDARD,
+            operation = Noop()
+        )
+    },
     finalState = null,
     savedStateMap = null,
 ) {
@@ -23,12 +31,4 @@ class Tiles<T : Any>(
         CREATED, STANDARD, SELECTED, DESTROYED
     }
 
-    override val initialElements = initialItems.map {
-        TilesElement(
-            key = NavKey(it),
-            fromState = CREATED,
-            targetState = STANDARD,
-            operation = Noop()
-        )
-    }
 }


### PR DESCRIPTION
## Description

`initialElements` are used only during creation process. Making it `val` makes them to be captured for the all lifetime of `NavModel`, making it a small memory leak.

We can keep the old implementation if you think API became worse.

Fixes https://github.com/bumble-tech/appyx/issues/193

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
