### PR TITLE
Portals POC

### DIFF
--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildNodeCreationManager.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildNodeCreationManager.kt
@@ -177,7 +177,13 @@ internal class ChildNodeCreationManager<NavTarget : Any>(
                 key = key,
                 node = parentNode
                     .resolve(key.navTarget, childBuildContext(savedState))
-                    .build()
+                    .also {
+                        try {
+                            it.build()
+                        } catch (ignored: IllegalArgumentException) {
+                            // no-op
+                        }
+                    }
             )
         }
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
@@ -19,8 +19,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
-import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.navigation.NavElement
 import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavModel
@@ -29,10 +27,12 @@ import com.bumble.appyx.core.navigation.transition.TransitionBounds
 import com.bumble.appyx.core.navigation.transition.TransitionDescriptor
 import com.bumble.appyx.core.navigation.transition.TransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionParams
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.ParentNodeSomething
 import kotlinx.coroutines.flow.map
 
 @Composable
-fun <NavTarget : Any, State> ParentNode<NavTarget>.Child(
+fun <NavTarget : Any, State> ParentNodeSomething<NavTarget>.Child(
     navElement: NavElement<NavTarget, out State>,
     saveableStateHolder: SaveableStateHolder,
     transitionParams: TransitionParams,
@@ -85,7 +85,7 @@ private class ChildRendererImpl(
 }
 
 @Composable
-fun <NavTarget : Any, State> ParentNode<NavTarget>.Child(
+fun <NavTarget : Any, State> ParentNodeSomething<NavTarget>.Child(
     navElement: NavElement<NavTarget, out State>,
     transitionHandler: TransitionHandler<NavTarget, State> = JumpToEndTransitionHandler(),
     decorator: @Composable ChildTransitionScope<State>.(

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
@@ -15,18 +15,18 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
-import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.navigation.NavModel
 import com.bumble.appyx.core.navigation.transition.JumpToEndTransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionBounds
 import com.bumble.appyx.core.navigation.transition.TransitionDescriptor
 import com.bumble.appyx.core.navigation.transition.TransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionParams
+import com.bumble.appyx.core.node.ParentNodeSomething
 import kotlinx.coroutines.flow.map
 import kotlin.reflect.KClass
 
 @Composable
-inline fun <reified NavTarget : Any, State> ParentNode<NavTarget>.Children(
+inline fun <reified NavTarget : Any, State> ParentNodeSomething<NavTarget>.Children(
     navModel: NavModel<NavTarget, State>,
     modifier: Modifier = Modifier,
     transitionHandler: TransitionHandler<NavTarget, State> = JumpToEndTransitionHandler(),
@@ -70,7 +70,7 @@ class ChildrenTransitionScope<T : Any, S>(
 ) {
 
     @Composable
-    inline fun <reified V : T> ParentNode<T>.children(
+    inline fun <reified V : T> ParentNodeSomething<T>.children(
         noinline block: @Composable ChildTransitionScope<S>.(
             child: ChildRenderer,
             transitionDescriptor: TransitionDescriptor<T, S>
@@ -80,14 +80,14 @@ class ChildrenTransitionScope<T : Any, S>(
     }
 
     @Composable
-    inline fun <reified V : T> ParentNode<T>.children(
+    inline fun <reified V : T> ParentNodeSomething<T>.children(
         noinline block: @Composable ChildTransitionScope<S>.(child: ChildRenderer) -> Unit,
     ) {
         children(V::class, block)
     }
 
     @Composable
-    fun ParentNode<T>.children(
+    fun ParentNodeSomething<T>.children(
         clazz: KClass<out T>,
         block: @Composable ChildTransitionScope<S>.(child: ChildRenderer) -> Unit,
     ) {
@@ -99,7 +99,7 @@ class ChildrenTransitionScope<T : Any, S>(
     }
 
     @Composable
-    fun ParentNode<T>.children(
+    fun ParentNodeSomething<T>.children(
         clazz: KClass<out T>,
         block: @Composable ChildTransitionScope<S>.(
             child: ChildRenderer,
@@ -115,7 +115,7 @@ class ChildrenTransitionScope<T : Any, S>(
     }
 
     @Composable
-    private fun ParentNode<T>._children(
+    private fun ParentNodeSomething<T>._children(
         clazz: KClass<out T>,
         block: @Composable (
             transitionScope: ChildTransitionScope<S>,

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/ChildNodeLifecycleManager.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/ChildNodeLifecycleManager.kt
@@ -27,6 +27,7 @@ internal class ChildNodeLifecycleManager<NavTarget>(
     private val navModel: NavModel<NavTarget, *>,
     private val children: StateFlow<ChildEntryMap<NavTarget>>,
     private val coroutineScope: CoroutineScope,
+    private val owner: Any,
 ) {
 
     private val lifecycleState = MutableStateFlow(Lifecycle.State.INITIALIZED)
@@ -97,7 +98,7 @@ internal class ChildNodeLifecycleManager<NavTarget>(
             .distinctUntilChanged()
 
     private fun ChildEntry<*>.setState(state: Lifecycle.State) {
-        nodeOrNull?.updateLifecycleState(state)
+        nodeOrNull?.updateLifecycleState(state, owner)
     }
 
     private data class ScreenState<NavTarget>(

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/NodeLifecycle.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/NodeLifecycle.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.LifecycleOwner
 
 interface NodeLifecycle : LifecycleOwner {
 
-    fun updateLifecycleState(state: Lifecycle.State)
+    /** Used by Portal to take lifecycle ownership of the Node. */
+    fun lockCaller(caller: Any? = null)
+
+    fun updateLifecycleState(state: Lifecycle.State, caller: Any? = null)
 
 }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/NodeLifecycleImpl.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/lifecycle/NodeLifecycleImpl.kt
@@ -6,12 +6,18 @@ import androidx.lifecycle.LifecycleRegistry
 
 internal class NodeLifecycleImpl(owner: LifecycleOwner) : NodeLifecycle {
 
+    private var lock: Any? = null
     private val lifecycleRegistry = LifecycleRegistry(owner)
 
     override fun getLifecycle(): Lifecycle =
         lifecycleRegistry
 
-    override fun updateLifecycleState(state: Lifecycle.State) {
+    override fun lockCaller(caller: Any?) {
+        lock = caller
+    }
+
+    override fun updateLifecycleState(state: Lifecycle.State, caller: Any?) {
+        if (lock != null && lock != caller) return // Invalid caller, ignore
         lifecycleRegistry.currentState = state
     }
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavKey.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavKey.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 @Parcelize
 @Immutable
-class NavKey<NavTarget> private constructor(
+class NavKey<NavTarget> internal constructor(
     val navTarget: @RawValue NavTarget,
     val id: String
 ) : Parcelable {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
@@ -150,7 +150,7 @@ abstract class Node(
     override fun getLifecycle(): Lifecycle =
         nodeLifecycle.lifecycle
 
-    override fun updateLifecycleState(state: Lifecycle.State) {
+    override fun updateLifecycleState(state: Lifecycle.State, caller: Any?) {
         if (lifecycle.currentState == state) return
         if (lifecycle.currentState == Lifecycle.State.DESTROYED && state != Lifecycle.State.DESTROYED) {
             Appyx.reportException(
@@ -160,10 +160,14 @@ abstract class Node(
             )
             return
         }
-        nodeLifecycle.updateLifecycleState(state)
+        nodeLifecycle.updateLifecycleState(state, caller)
         if (state == Lifecycle.State.DESTROYED) {
             plugins<Destroyable>().forEach { it.destroy() }
         }
+    }
+
+    override fun lockCaller(caller: Any?) {
+        nodeLifecycle.lockCaller(caller)
     }
 
     fun saveInstanceState(scope: SaverScope): SavedStateMap {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNodeSomething.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNodeSomething.kt
@@ -1,0 +1,16 @@
+package com.bumble.appyx.core.node
+
+import androidx.compose.runtime.Stable
+import com.bumble.appyx.core.children.ChildEntry
+import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.NavModel
+
+// TODO: Naming!
+@Stable
+interface ParentNodeSomething<NavTarget : Any> {
+
+    val navModel: NavModel<NavTarget, *>
+
+    fun childOrCreate(navKey: NavKey<NavTarget>): ChildEntry.Initialized<NavTarget>
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/plugin/Plugins.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/plugin/Plugins.kt
@@ -4,6 +4,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.state.MutableSavedStateMap
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 interface Plugin
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClient.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClient.kt
@@ -1,0 +1,37 @@
+package com.bumble.appyx.core.portal
+
+import androidx.lifecycle.Lifecycle
+import com.bumble.appyx.core.children.ChildEntryMap
+import com.bumble.appyx.core.lifecycle.subscribe
+import com.bumble.appyx.core.state.SavedStateMap
+import kotlinx.coroutines.flow.StateFlow
+
+interface PortalClient<NavTarget : Any> {
+
+    val navModel: PortalClientNavModel<NavTarget>
+
+    /** Invoke in onBuilt() to let Portal take control of children of the current node. */
+    fun attach(children: StateFlow<ChildEntryMap<NavTarget>>, lifecycle: Lifecycle)
+
+}
+
+internal class PortalClientImpl<NavTarget : Any>(
+    savedStateMap: SavedStateMap?,
+) : PortalClient<NavTarget> {
+    var onAttachListener: (StateFlow<ChildEntryMap<NavTarget>>) -> Unit = {}
+    var onDetachListener: () -> Unit = {}
+
+    override val navModel: PortalClientNavModel<NavTarget> =
+        PortalClientNavModel(
+            savedStateMap = savedStateMap,
+        )
+
+    override fun attach(children: StateFlow<ChildEntryMap<NavTarget>>, lifecycle: Lifecycle) {
+        lifecycle.subscribe(
+            onCreate = { onAttachListener(children) },
+            onDestroy = { onDetachListener() }
+        )
+
+    }
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientFactory.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientFactory.kt
@@ -1,0 +1,22 @@
+package com.bumble.appyx.core.portal
+
+import com.bumble.appyx.core.state.SavedStateMap
+
+interface PortalClientFactory {
+
+    fun <NavTarget : Any> createPortalClient(
+        savedStateMap: SavedStateMap?,
+    ): PortalClient<NavTarget>
+
+}
+
+internal class PortalClientFactoryImpl(
+    private val onClientCreated: (PortalClientImpl<*>) -> Unit,
+) : PortalClientFactory {
+
+    override fun <NavTarget : Any> createPortalClient(
+        savedStateMap: SavedStateMap?,
+    ): PortalClient<NavTarget> =
+        PortalClientImpl<NavTarget>(savedStateMap).also(onClientCreated)
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientNavModel.kt
@@ -1,0 +1,70 @@
+package com.bumble.appyx.core.portal
+
+import com.bumble.appyx.core.navigation.BaseNavModel
+import com.bumble.appyx.core.navigation.NavElements
+import com.bumble.appyx.core.navigation.NavModelAdapter
+import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
+import com.bumble.appyx.core.navigation.onscreen.isOnScreen
+import com.bumble.appyx.core.state.SavedStateMap
+import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.navmodel.backstack.backpresshandler.PopBackPressHandler
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class PortalClientNavModel<NavTarget : Any>(
+    savedStateMap: SavedStateMap?,
+    private val inOnScreen: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    private val screenResolver: OnScreenStateResolver<BackStack.State> = OnScreenStateResolver { state ->
+        if (!inOnScreen.value) false
+        else when (state) {
+            BackStack.State.CREATED,
+            BackStack.State.STASHED,
+            BackStack.State.DESTROYED -> false
+            BackStack.State.ACTIVE -> true
+        }
+    },
+) : BaseNavModel<NavTarget, BackStack.State>(
+    savedStateMap = savedStateMap,
+    finalState = BackStack.State.DESTROYED,
+    screenResolver = screenResolver,
+    backPressHandler = PortalClientNavModelPressHandler(),
+    key = "PortalNavModel",
+) {
+
+    override val initialElements: NavElements<NavTarget, BackStack.State> = emptyList()
+
+    override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, BackStack.State>> by lazy {
+        // Recalculate screenState on every isOnScreen change
+        inOnScreen
+            .flatMapLatest {
+                elements
+                    .map { elements ->
+                        NavModelAdapter.ScreenState(
+                            onScreen = elements.filter { screenResolver.isOnScreen(it) },
+                            offScreen = elements.filterNot { screenResolver.isOnScreen(it) },
+                        )
+                    }
+            }
+            .stateIn(scope, SharingStarted.Eagerly, NavModelAdapter.ScreenState())
+    }
+
+    init {
+        // Trigger sanitizeOffScreenTransitions() when the property is changed
+        scope.launch {
+            inOnScreen.filterNot { it }.collect {
+                updateState { it }
+            }
+        }
+    }
+
+    fun setVisibility(isOnScreen: Boolean) {
+        this.inOnScreen.value = isOnScreen
+    }
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientNavModelPressHandler.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalClientNavModelPressHandler.kt
@@ -1,0 +1,35 @@
+package com.bumble.appyx.core.portal
+
+import android.os.Parcelable
+import com.bumble.appyx.core.navigation.NavElements
+import com.bumble.appyx.core.navigation.Operation
+import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BaseBackPressHandlerStrategy
+import com.bumble.appyx.navmodel.backstack.BackStack
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.parcelize.Parcelize
+
+class PortalClientNavModelPressHandler<NavTarget : Any> :
+    BaseBackPressHandlerStrategy<NavTarget, BackStack.State>() {
+
+    private val operation = Back<NavTarget>()
+
+    override val canHandleBackPressFlow: Flow<Boolean> by lazy {
+        navModel.elements.map(operation::isApplicable)
+    }
+
+    override fun onBackPressed() {
+        navModel.accept(operation)
+    }
+
+    @Parcelize
+    private class Back<NavTarget : Any> : Operation<NavTarget, BackStack.State>, Parcelable {
+
+        override fun isApplicable(elements: NavElements<NavTarget, BackStack.State>): Boolean =
+            elements.isNotEmpty()
+
+        override fun invoke(elements: NavElements<NavTarget, BackStack.State>): NavElements<NavTarget, BackStack.State> =
+            elements.take(elements.size - 1)
+
+    }
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/portal/PortalNode.kt
@@ -1,0 +1,210 @@
+package com.bumble.appyx.core.portal
+
+import android.os.Parcelable
+import androidx.activity.OnBackPressedCallback
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.coroutineScope
+import com.bumble.appyx.Appyx
+import com.bumble.appyx.core.children.ChildEntry
+import com.bumble.appyx.core.children.nodeOrNull
+import com.bumble.appyx.core.composable.Children
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.BaseNavModel
+import com.bumble.appyx.core.navigation.NavElement
+import com.bumble.appyx.core.navigation.NavElements
+import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.ParentNode
+import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.navmodel.backstack.BackStackOnScreenResolver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+
+class PortalNode(
+    buildContext: BuildContext,
+    private val portalMultiStack: PortalMultiStack = PortalMultiStack(),
+    private val rootNodeFactory: (BuildContext, PortalClientFactory) -> Node,
+) : ParentNode<PortalNode.NavTarget>(
+    buildContext = buildContext,
+    navModel = portalMultiStack,
+) {
+    private val portalClientChildren =
+        HashMap<PortalClient<out Any>, StateFlow<Map<out NavKey<out Any>, ChildEntry<out Any>>>>()
+    private val portalClientFactory = PortalClientFactoryImpl { client ->
+        val scope = CoroutineScope(lifecycle.coroutineScope.coroutineContext)
+        client.onAttachListener = { children ->
+            portalClientChildren[client] = children
+            scope.launch {
+                combine(client.navModel.screenState, children, ::Pair)
+                    .distinctUntilChanged()
+                    .collect { (state, children) ->
+                        state.onScreen.forEach { onScreenElement ->
+                            children[onScreenElement.key]?.nodeOrNull?.also {
+                                it.lockCaller(this@PortalNode)
+                                it.updateLifecycleState(lifecycle.currentState, this@PortalNode)
+                            }
+                        }
+                        state.offScreen.forEach { offScreenElement ->
+                            children[offScreenElement.key]?.nodeOrNull?.lockCaller(this@PortalNode)
+                        }
+                    }
+            }
+            portalMultiStack.add(client.navModel)
+        }
+        client.onDetachListener = {
+            scope.cancel()
+            portalClientChildren.remove(client)
+        }
+    }
+
+    init {
+        require(Appyx.defaultChildKeepMode == ChildEntry.KeepMode.KEEP) { "Portal supports only KEEP mode" }
+    }
+
+    override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
+        when (navTarget) {
+            is NavTarget.Root -> rootNodeFactory(buildContext, portalClientFactory)
+            is NavTarget.Client -> {
+                portalClientChildren.values.forEach { stateFlow ->
+                    stateFlow.value[navTarget.originalKey]?.also {
+                        return@resolve requireNotNull(it.nodeOrNull)
+                    }
+                }
+                error("Not found")
+            }
+        }
+
+    @Composable
+    override fun View(modifier: Modifier) {
+        Children(navModel = portalMultiStack, modifier = modifier)
+    }
+
+    // TODO: Handle restoration order of children, it may produce different order of elements in backStacks
+    class PortalMultiStack : BaseNavModel<NavTarget, BackStack.State>(
+        savedStateMap = null, // Child routers will save the state
+        finalState = BackStack.State.DESTROYED,
+        screenResolver = BackStackOnScreenResolver,
+    ) {
+        private val backStacks = MutableStateFlow<List<PortalClientNavModel<*>>>(emptyList())
+
+        override val initialElements: NavElements<NavTarget, BackStack.State> =
+            listOf(
+                NavElement(
+                    key = NavKey(NavTarget.Root),
+                    fromState = BackStack.State.ACTIVE,
+                    targetState = BackStack.State.ACTIVE,
+                    operation = Operation.Noop(),
+                )
+            )
+
+        init {
+            // Update inOnScreen property separately to make it easier to handle it later
+            // TODO: Maybe merge in imperative manner for performance?
+            scope.launch {
+                backStacks
+                    .flatMapLatest { list ->
+                        combine(list.map { it.elements }) { array -> list to array }
+                    }
+                    .collect { (stacks, elements) ->
+                        var visibleHandled = false
+                        for (i in stacks.indices.reversed()) {
+                            if (elements[i].isNotEmpty() && !visibleHandled) {
+                                stacks[i].setVisibility(true)
+                                visibleHandled = false
+                            } else {
+                                stacks[i].setVisibility(false)
+                            }
+                        }
+                    }
+            }
+            // Collect and build current state
+            scope.launch {
+                backStacks
+                    .flatMapLatest { list ->
+                        combine(list.map { it.elements }) { array -> list to array }
+                    }
+                    .collect { (stacks, elements) ->
+                        val finalElements =
+                            ArrayList<NavElement<NavTarget, BackStack.State>>()
+                        elements.forEach { list ->
+                            list.forEach { element ->
+                                finalElements.add(
+                                    NavElement(
+                                        key = NavKey(NavTarget.Client(element.key), element.key.id),
+                                        fromState = element.fromState,
+                                        targetState = element.targetState,
+                                        operation = Operation.Noop(),
+                                    )
+                                )
+                            }
+                        }
+                        updateState {
+                            if (finalElements.isEmpty()) {
+                                listOf(
+                                    it[0].transitionTo(BackStack.State.ACTIVE, Operation.Noop())
+                                        .onTransitionFinished()
+                                )
+                            } else {
+                                listOf(
+                                    it[0].transitionTo(BackStack.State.STASHED, Operation.Noop())
+                                ) + finalElements
+                            }
+                        }
+                    }
+            }
+        }
+
+        fun add(backStack: PortalClientNavModel<*>) {
+            backStacks.update { it + backStack }
+        }
+
+        fun remove(backStack: PortalClientNavModel<*>) {
+            backStacks.update { it - backStack }
+        }
+
+        override val onBackPressedCallback: OnBackPressedCallback by lazy {
+            val callback = object : OnBackPressedCallback(false) {
+                override fun handleOnBackPressed() {
+                    backStacks.value.forEach {
+                        it.onBackPressedCallbackList.forEach {
+                            if (it.isEnabled) {
+                                it.handleOnBackPressed()
+                            }
+                        }
+                    }
+                }
+            }
+            // TODO: Make the list observable!
+            scope.launch {
+                while (isActive) {
+                    delay(100)
+                    callback.isEnabled =
+                        backStacks.value.any { it.onBackPressedCallbackList.any { it.isEnabled } }
+                }
+            }
+            callback
+        }
+
+    }
+
+    sealed class NavTarget : Parcelable {
+        @Parcelize
+        object Root : NavTarget()
+
+        @Parcelize
+        data class Client(val originalKey: NavKey<*>) : NavTarget()
+    }
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/backstack/BackStack.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/navmodel/backstack/BackStack.kt
@@ -1,20 +1,21 @@
 package com.bumble.appyx.navmodel.backstack
 
 import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.Operation.Noop
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 import com.bumble.appyx.core.navigation.operationstrategies.ExecuteImmediately
 import com.bumble.appyx.core.navigation.operationstrategies.OperationStrategy
+import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.navmodel.backstack.BackStack.State
+import com.bumble.appyx.navmodel.backstack.BackStack.State.ACTIVE
 import com.bumble.appyx.navmodel.backstack.BackStack.State.DESTROYED
 import com.bumble.appyx.navmodel.backstack.backpresshandler.PopBackPressHandler
-import com.bumble.appyx.core.state.SavedStateMap
-import com.bumble.appyx.navmodel.backstack.BackStack.State.ACTIVE
 
+// TODO: Need nullable for Portal usage
 class BackStack<NavTarget : Any>(
-    initialElement: NavTarget,
+    initialElement: NavTarget?,
     savedStateMap: SavedStateMap?,
     key: String = KEY_NAV_MODEL,
     backPressHandler: BackPressHandlerStrategy<NavTarget, State> = PopBackPressHandler(),
@@ -33,13 +34,15 @@ class BackStack<NavTarget : Any>(
         CREATED, ACTIVE, STASHED, DESTROYED,
     }
 
-    override val initialElements = listOf(
-        BackStackElement(
-            key = NavKey(initialElement),
-            fromState = ACTIVE,
-            targetState = ACTIVE,
-            operation = Noop()
-        )
+    override val initialElements = listOfNotNull(
+        initialElement?.let {
+            BackStackElement(
+                key = NavKey(it),
+                fromState = ACTIVE,
+                targetState = ACTIVE,
+                operation = Noop()
+            )
+        }
     )
 
 }

--- a/plugins/gradle/wrapper/gradle-wrapper.jar
+++ b/plugins/gradle/wrapper/gradle-wrapper.jar
@@ -1,0 +1,1 @@
+../../../gradle/wrapper/gradle-wrapper.jar

--- a/plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+../../../gradle/wrapper/gradle-wrapper.properties

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/MainActivity.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/MainActivity.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.bumble.appyx.core.integration.NodeHost
 import com.bumble.appyx.core.integrationpoint.NodeActivity
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.portal.PortalNode
 import com.bumble.appyx.sandbox.client.container.ContainerBuilder
+import com.bumble.appyx.sandbox.client.container.ContainerNode
 import com.bumble.appyx.sandbox.ui.AppyxSandboxTheme
 
 class MainActivity : NodeActivity() {
@@ -23,7 +25,12 @@ class MainActivity : NodeActivity() {
                 Surface(color = MaterialTheme.colors.background) {
                     Column {
                         NodeHost(integrationPoint = integrationPoint) {
-                            ContainerBuilder().build(buildContext = it)
+                            PortalNode(buildContext = it) { buildContext, portalClientFactory ->
+                                ContainerNode(
+                                    portalClientFactory = portalClientFactory,
+                                    buildContext = buildContext,
+                                )
+                            }
                         }
                     }
                 }

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerBuilder.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerBuilder.kt
@@ -7,5 +7,5 @@ import com.bumble.appyx.core.node.Node
 class ContainerBuilder : SimpleBuilder() {
 
     override fun build(buildContext: BuildContext): Node =
-        ContainerNode(buildContext = buildContext)
+        TODO()
 }

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentRouter.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentRouter.kt
@@ -36,7 +36,7 @@ internal class RibsParentRouter(
                 child {
                     InteropBuilder(
                         nodeFactory = { buildContext ->
-                            ContainerNode(buildContext)
+                            TODO()
                         }
                     ).build(it)
                 }


### PR DESCRIPTION
## Description

**IMHO** Portals itself looks like a proof that current navigation mental model is not scaleable at all. We are confusing component scopes (tree) and navigation (stack). At the moment when we start doing things like Portal we break initial tree. The base idea behind current component structure is wrong. To be able to do what Portals do, we need to completely separate rendering from component tree. 

Works in the following way:
1. Nodes who want to use portals should create `PortalClientNavModel` via factory
2. Client nodes should use the created nav model as its own nav model to manage creation/destruction of portaled node
3. PortalNode will be aware of all created `PortalClientNavModel`
4. PortalNode will merge all client nav models into single nav model which will be used as its own nav model
5. PortalNode resolver will reuse children created by client nodes via `PortalClient.attach`
6. PortalNode will take control over children lifecycle by using sync object

Issues:
1. Hard to handle transitions. Need to do sync in both ways: from client to portal to be aware about new nav targets, merge all clients into a single list and from portal to client to properly update transition state.
2. Back press handler system should be updated again, as it requires now to update the list of back click handlers dynamically.
3. Hard to support `KeepMode.SUSPEND` properly.

Client code:
```kotlin
PortalNode(buildContext, rootNodeFactory = { context, clientFactory
   RootNode(context, clientFactory)
})

class RootNode(
   ...
   clientFactory: PortalClientFactory,
   val client: PortalClient = clientFactory.createPortalClient(),
): ParentNode(
   ...
   navModel = client.navModel + backStack + ...,
) {

fun onBuilt() {
    client.attach(children, lifecycle)
}
   
fun openPortal() {
   client.navModel.push(PortaledNavTarget)
}

}
```

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
