### PR TITLE
Always explicitly start test activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending changes
 
+- [#214](https://github.com/bumble-tech/appyx/pull/214) – **Breaking change**: `AppyxViewTestRule` stops supporting automatic launching activity. Activities should be started explicitly in tests.
 - [#197](https://github.com/bumble-tech/appyx/pull/197) – **Breaking change**: `ParentNodeView` does not implement plugin anymore. Node instance is retrieved via LocalComposition. `AppyxParentViewTestRule` and `AbstractParentNodeView` have been removed. 
 - [#196](https://github.com/bumble-tech/appyx/pull/196) – **Breaking change**: `InteropBuilder` now should be supplied with Appyx `IntegrationPointProvider` to attach it at the same time Appyx Node is created.
 - [#185](https://github.com/bumble-tech/appyx/issues/185) – **Breaking change**: `Activity` must implement `IntegrationPointProvider` and create `IntegrationPoint` manually. Weak references usage has been removed.

--- a/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/rules/AppyxViewTestRule.kt
+++ b/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/rules/AppyxViewTestRule.kt
@@ -16,12 +16,11 @@ import org.junit.runners.model.Statement
 
 open class AppyxViewTestRule<View : NodeView>(
     viewFactory: ViewFactory<View>,
-    private val launchActivity: Boolean = true,
     private val composeTestRule: ComposeTestRule = createEmptyComposeRule()
 ) : ActivityTestRule<AppyxTestActivity>(
     /* activityClass = */ AppyxTestActivity::class.java,
     /* initialTouchMode = */ true,
-    /* launchActivity = */ launchActivity
+    /* launchActivity = */ false
 ), ComposeTestRule by composeTestRule {
 
     val view by lazy { viewFactory.invoke() }
@@ -35,9 +34,6 @@ open class AppyxViewTestRule<View : NodeView>(
 
     @Suppress("TooGenericExceptionCaught") // launchActivity does throw RuntimeException
     fun start() {
-        require(!launchActivity) {
-            "Activity will be launched automatically, launchActivity parameter was passed into constructor"
-        }
         try {
             launchActivity(null)
         } catch (e: RuntimeException) {

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleViewTest.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleViewTest.kt
@@ -18,7 +18,7 @@ internal class MviCoreExampleViewTest {
     private var title = "Title"
 
     @get:Rule
-    val rule = appyxViewRule(launchActivity = false) {
+    val rule = appyxViewRule {
         createView()
     }
 
@@ -33,7 +33,6 @@ internal class MviCoreExampleViewTest {
         with(screen) {
             titleText.assert(hasText(title))
             loader.assertIsDisplayed()
-
         }
     }
 

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxMviViewTestRule.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxMviViewTestRule.kt
@@ -1,19 +1,17 @@
 package com.bumble.appyx.sandbox.client.test
 
-import com.bumble.appyx.testing.ui.rules.AppyxViewTestRule
 import com.bumble.appyx.core.node.NodeView
 import com.bumble.appyx.core.node.ViewFactory
+import com.bumble.appyx.testing.ui.rules.AppyxViewTestRule
 import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
 
 class AppyxMviViewTestRule<ViewModel : Any, Event : Any, View : NodeView>(
-    launchActivity: Boolean = true,
     private val modelConsumer: (View) -> Consumer<in ViewModel>,
     private val eventObservable: (View) -> ObservableSource<out Event>,
     viewFactory: ViewFactory<View>,
 ) : AppyxViewTestRule<View>(
-    launchActivity = launchActivity,
     viewFactory = viewFactory,
 ) {
     private lateinit var _modelConsumer: Consumer<in ViewModel>

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxViewRules.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxViewRules.kt
@@ -6,11 +6,9 @@ import io.reactivex.ObservableSource
 import io.reactivex.functions.Consumer
 
 fun <ViewModel : Any, Event : Any, View> appyxViewRule(
-    launchActivity: Boolean = true,
     viewFactory: ViewFactory<View>,
 ) where View : NodeView, View : Consumer<in ViewModel>, View : ObservableSource<out Event> =
     AppyxMviViewTestRule(
-        launchActivity = launchActivity,
         modelConsumer = { it },
         eventObservable = { it },
         viewFactory = viewFactory


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/213

AppyxViewTestRule merges `composeTestRule` and `ActivityTestRule` to make it easier to use for the clients. However if we  automatically start activity we see the crash with stacktrace:
```
(3) setContent was called before the ComposeTestRule ran. If setContent is called by the Activity, make sure the Activity is launched after the ComposeTestRule runs
```

To avoid this instead automatic activity launching we could start activity explicitly. 

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
