### PR TITLE
IntegrationPointProvider should return ActivityIntegrationPoint instead of IntegrationPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-–
+- [#215](https://github.com/bumble-tech/appyx/pull/21) – **Breaking change**: `IntegrationPointProvider` renamed to `ActivityIntegrationPointProvider` and returns `ActivityIntegrationPoint` instead of `IntegrationPoint`
 
 ---
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -48,17 +48,17 @@ open class ActivityIntegrationPoint(
     }
 
     companion object {
-        fun getIntegrationPoint(context: Context): IntegrationPoint {
+        fun getIntegrationPoint(context: Context): ActivityIntegrationPoint {
             val activity = context.findActivity<Activity>()
             checkNotNull(activity) {
                 "Could not find an activity from the context: $context"
             }
 
-            val integrationPointProvider = activity as? IntegrationPointProvider ?: error(
+            val activityIntegrationPointProvider = activity as? ActivityIntegrationPointProvider ?: error(
                 "Activity ${activity::class.qualifiedName} does not implement IntegrationPointProvider"
             )
 
-            return integrationPointProvider.appyxIntegrationPoint
+            return activityIntegrationPointProvider.appyxIntegrationPoint
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPointProvider.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPointProvider.kt
@@ -1,0 +1,6 @@
+package com.bumble.appyx.core.integrationpoint
+
+interface ActivityIntegrationPointProvider {
+
+    val appyxIntegrationPoint: ActivityIntegrationPoint
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointProvider.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointProvider.kt
@@ -1,6 +1,0 @@
-package com.bumble.appyx.core.integrationpoint
-
-interface IntegrationPointProvider {
-
-    val appyxIntegrationPoint: IntegrationPoint
-}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeActivity.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeActivity.kt
@@ -17,7 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
  * Feel free to not extend this and use your own integration point - in this case,
  * don't forget to take a look here what methods needs to be forwarded to the root Node.
  */
-open class NodeActivity : AppCompatActivity(), IntegrationPointProvider {
+open class NodeActivity : AppCompatActivity(), ActivityIntegrationPointProvider {
 
     override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
         protected set

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/NodeComponentActivity.kt
@@ -17,7 +17,7 @@ import androidx.activity.ComponentActivity
  * Feel free to not extend this and use your own integration point - in this case,
  * don't forget to take a look here what methods needs to be forwarded to the root Node.
  */
-open class NodeComponentActivity : ComponentActivity(), IntegrationPointProvider {
+open class NodeComponentActivity : ComponentActivity(), ActivityIntegrationPointProvider {
 
     override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
         protected set

--- a/libraries/interop-ribs/src/main/kotlin/com/bumble/appyx/interop/ribs/InteropActivity.kt
+++ b/libraries/interop-ribs/src/main/kotlin/com/bumble/appyx/interop/ribs/InteropActivity.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import com.badoo.ribs.android.RibActivity
 import com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint
-import com.bumble.appyx.core.integrationpoint.IntegrationPointProvider
+import com.bumble.appyx.core.integrationpoint.ActivityIntegrationPointProvider
 
-abstract class InteropActivity : RibActivity(), IntegrationPointProvider {
+abstract class InteropActivity : RibActivity(), ActivityIntegrationPointProvider {
 
     override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
 


### PR DESCRIPTION
## Description

Since it's IntegrationPointProvider must be implemented by activity IntegrationPointProvider should return ActivityIntegrationPoint instead of IntegrationPoint.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
