### PR TITLE
Updated androidx core to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending changes
 
 - [#217](https://github.com/bumble-tech/appyx/pull/217) – **Updated**: Moved `navigation-compose` sample into the main sample app.
+- [#218](https://github.com/bumble-tech/appyx/pull/218) – **Updated**: `androidx.core:core-ktx` to 1.9.0.
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ accompanist-systemui = "com.google.accompanist:accompanist-systemuicontroller:0.
 androidx-activity-compose = "androidx.activity:activity-compose:1.3.1"
 androidx-appcompat = "androidx.appcompat:appcompat:1.3.1"
 androidx-arch-core-testing = "androidx.arch.core:core-testing:2.1.0"
-androidx-core = "androidx.core:core-ktx:1.6.0"
+androidx-core = "androidx.core:core-ktx:1.9.0"
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-java8 = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
## Description
Updated androidx-core to 1.9.0

This is needed as part of being able to update to Compose 1.3.0 in a future release. It was noticed by @antonshilov as part of testing Compose 1.3.0 internally.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
