### PR TITLE
Add a key to rememberTransitionScope to support dynamically changed transition handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending changes
 
+- [#218](https://github.com/bumble-tech/appyx/pull/231) – **Fixed**: Changing transition handler at runtime does not redraw children
 - [#217](https://github.com/bumble-tech/appyx/pull/217) – **Updated**: Moved `navigation-compose` sample into `:samples:app`.
 - [#218](https://github.com/bumble-tech/appyx/pull/218) – **Updated**: `androidx.core:core-ktx` to 1.9.0.
 - [#165](https://github.com/bumble-tech/appyx/pull/165) – **Added**: A dating-cards-like `NavModel` implementation: `Cards`, along with sample in `:samples:app`

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/transition/ModifierTransitionHandler.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/transition/ModifierTransitionHandler.kt
@@ -53,7 +53,7 @@ abstract class ModifierTransitionHandler<T, S>(open val clipToBounds: Boolean = 
     private fun rememberTransitionScope(
         transition: Transition<S>,
         descriptor: TransitionDescriptor<T, S>
-    ) = remember(transition, descriptor) {
+    ) = remember(transition, descriptor, this) {
         ChildTransitionScopeImpl(
             transition = transition,
             transitionModifier = clipToBoundsModifier


### PR DESCRIPTION
## Description

Changing transition handler at runtime does not result in recomposing children. It happens because `rememberTransitionScope` is remembered and the keys haven't changed. To fix this, I'm adding transition handler instance as a key

Pressing trigger button changes transition handler from fader to slider. To distinguish them, in fader transition handler I added `alpha= 0.5f` for active element

**Before:**

https://user-images.githubusercontent.com/5773436/196752264-0312195f-f820-4d4a-a436-0d74d909a39c.mp4 

**After:**

https://user-images.githubusercontent.com/5773436/196752197-24b8d99e-df41-4326-bd12-c5a7dbb664f8.mp4 


## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
