### PR TITLE
Provide proper initial states for nav model flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## Pending changes
 
 - [#218](https://github.com/bumble-tech/appyx/pull/231) – **Fixed**: Changing transition handler at runtime does not redraw children
+- [#218](https://github.com/bumble-tech/appyx/pull/239) – **Fixed**: Fixed an issue with desynchronisation between nav model and children's restoration process
 - [#217](https://github.com/bumble-tech/appyx/pull/217) – **Updated**: Moved `navigation-compose` sample into `:samples:app`.
 - [#218](https://github.com/bumble-tech/appyx/pull/218) – **Updated**: `androidx.core:core-ktx` to 1.9.0.
 - [#165](https://github.com/bumble-tech/appyx/pull/165) – **Added**: A dating-cards-like `NavModel` implementation: `Cards`, along with sample in `:samples:app`
-- 
 ---
 
 ## 1.0.0-rc01

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/FlowExt.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/FlowExt.kt
@@ -1,8 +1,51 @@
 package com.bumble.appyx.core
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Maps [StateFlow] into [StateFlow] in synchronous manner without having to provide a default value manually.
+ *
+ * Issues in Kotlin bug tracker:
+ * [#2008](https://github.com/Kotlin/kotlinx.coroutines/issues/2008)
+ * [#2514](https://github.com/Kotlin/kotlinx.coroutines/issues/2514)
+ * [#2631](https://github.com/Kotlin/kotlinx.coroutines/issues/2631)
+ */
+internal fun <T, R> StateFlow<T>.mapState(
+    scope: CoroutineScope,
+    sharingStarted: SharingStarted = SharingStarted.Eagerly,
+    mapper: (T) -> R,
+) =
+    map { mapper(it) }
+        .stateIn(scope, sharingStarted, mapper(value))
+
+/**
+ * Combines [StateFlow] into [StateFlow] in synchronous manner without having to provide a default value manually.
+ *
+ * Issues in Kotlin bug tracker:
+ * [#2008](https://github.com/Kotlin/kotlinx.coroutines/issues/2008)
+ * [#2514](https://github.com/Kotlin/kotlinx.coroutines/issues/2514)
+ * [#2631](https://github.com/Kotlin/kotlinx.coroutines/issues/2631)
+ */
+internal inline fun <reified T, R> combineState(
+    flows: Iterable<StateFlow<T>>,
+    scope: CoroutineScope,
+    sharingStarted: SharingStarted = SharingStarted.Eagerly,
+    crossinline transform: (Array<T>) -> R,
+): StateFlow<R> =
+    combine(flows) { transform(it) }
+        .stateIn(
+            scope = scope,
+            started = sharingStarted,
+            initialValue = transform(flows.map { it.value }.toTypedArray())
+        )
 
 internal fun <T> Flow<T>.withPrevious(): Flow<CompareValues<T>> =
     scan(CompareValues<T>()) { previous, current -> previous.combine(current) }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/BaseNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/BaseNavModel.kt
@@ -1,24 +1,22 @@
 package com.bumble.appyx.core.navigation
 
 import androidx.activity.OnBackPressedCallback
-import com.bumble.appyx.core.plugin.BackPressHandler
-import com.bumble.appyx.core.plugin.Destroyable
+import com.bumble.appyx.core.mapState
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.DontHandleBackPress
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
 import com.bumble.appyx.core.navigation.onscreen.isOnScreen
 import com.bumble.appyx.core.navigation.operationstrategies.ExecuteImmediately
 import com.bumble.appyx.core.navigation.operationstrategies.OperationStrategy
+import com.bumble.appyx.core.plugin.BackPressHandler
+import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import com.bumble.appyx.core.state.SavedStateMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.EmptyCoroutineContext
@@ -69,13 +67,12 @@ abstract class BaseNavModel<NavTarget, State>(
 
     override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, State>> by lazy {
         state
-            .map { elements ->
+            .mapState(scope) { elements ->
                 NavModelAdapter.ScreenState(
                     onScreen = elements.filter { screenResolver.isOnScreen(it) },
                     offScreen = elements.filterNot { screenResolver.isOnScreen(it) },
                 )
             }
-            .stateIn(scope, SharingStarted.Eagerly, NavModelAdapter.ScreenState())
     }
 
     override val onBackPressedCallback: OnBackPressedCallback by lazy {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
@@ -1,19 +1,17 @@
 package com.bumble.appyx.core.navigation.model.combined
 
 import androidx.activity.OnBackPressedCallback
-import com.bumble.appyx.core.plugin.Destroyable
+import com.bumble.appyx.core.combineState
 import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.NavModel
 import com.bumble.appyx.core.navigation.NavModelAdapter
+import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlin.coroutines.EmptyCoroutineContext
 
 class CombinedNavModel<NavTarget>(
@@ -24,18 +22,24 @@ class CombinedNavModel<NavTarget>(
 
     private val scope = CoroutineScope(EmptyCoroutineContext + Dispatchers.Unconfined)
 
-    override val elements: StateFlow<NavElements<NavTarget, *>> =
-        combine(navModels.map { it.elements }) { arr -> arr.reduce { acc, list -> acc + list } }
-            .stateIn(scope, SharingStarted.Eagerly, emptyList())
+    override val elements: StateFlow<NavElements<NavTarget, *>> by lazy {
+        combineState(
+            flows = navModels.map { it.elements },
+            scope = scope,
+        ) { arr -> arr.reduce { acc, list -> acc + list } }
+    }
 
-    override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, *>> =
-        combine(navModels.map { it.screenState }) { arr ->
+    override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, *>> by lazy {
+        combineState(
+            flows = navModels.map { it.screenState },
+            scope = scope,
+        ) { arr ->
             NavModelAdapter.ScreenState(
                 onScreen = arr.flatMap { it.onScreen },
                 offScreen = arr.flatMap { it.offScreen },
             )
         }
-            .stateIn(scope, SharingStarted.Eagerly, NavModelAdapter.ScreenState())
+    }
 
     override val onBackPressedCallbackList: List<OnBackPressedCallback>
         get() = navModels.flatMap { it.onBackPressedCallbackList }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/PermanentNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/PermanentNavModel.kt
@@ -1,19 +1,17 @@
 package com.bumble.appyx.core.navigation.model.permanent
 
-import com.bumble.appyx.core.navigation.Operation
+import com.bumble.appyx.core.mapState
 import com.bumble.appyx.core.navigation.NavElement
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.NavModel
 import com.bumble.appyx.core.navigation.NavModelAdapter
+import com.bumble.appyx.core.navigation.Operation
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import com.bumble.appyx.core.state.SavedStateMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -49,14 +47,9 @@ class PermanentNavModel<NavTarget : Any>(
     override val elements: StateFlow<PermanentElements<NavTarget>>
         get() = state
 
-    override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, Int>>
-        get() = state
-            .map { NavModelAdapter.ScreenState(onScreen = it) }
-            .stateIn(
-                scope = scope,
-                started = SharingStarted.Lazily,
-                initialValue = NavModelAdapter.ScreenState(onScreen = state.value)
-            )
+    override val screenState: StateFlow<NavModelAdapter.ScreenState<NavTarget, Int>> by lazy {
+        state.mapState(scope) { NavModelAdapter.ScreenState(onScreen = it) }
+    }
 
     override fun onTransitionFinished(keys: Collection<NavKey<NavTarget>>) {
         // no-op


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/235

StateFlows are killing me...

The issue log:
- `BackStack` is recreated from saved state.
- Because `BackStack` uses `stateIn(initialValue = emptyList()`, empty list is produced as the first value when subscribed.
- `ChildNodeCreationManager` restores children from saved state and subscribes to `BackStack`.
- Because `BackStack` returns empty list `ChildNodeCreationManager` drops the restored children.
- Then `BackStack` sends the restored list and `ChildNodeCreationManager` recreates children from scratch (they were dropped on the previous step).

No tests, sorry.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
