### PR TITLE
Fixed parcelling bug for navmodel samples

### DIFF
--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/cards/Cards.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/cards/Cards.kt
@@ -1,5 +1,6 @@
 package com.bumble.appyx.navmodel.cards
 
+import android.os.Parcelable
 import com.bumble.appyx.core.navigation.BaseNavModel
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.Operation.Noop
@@ -11,6 +12,7 @@ import com.bumble.appyx.navmodel.cards.Cards.State.Queued
 import com.bumble.appyx.navmodel.cards.Cards.State.Top
 import com.bumble.appyx.navmodel.cards.Cards.State.VoteLike
 import com.bumble.appyx.navmodel.cards.Cards.State.VotePass
+import kotlinx.parcelize.Parcelize
 
 class Cards<NavTarget : Any>(
     initialItems: List<NavTarget> = listOf(),
@@ -24,13 +26,20 @@ class Cards<NavTarget : Any>(
         internal val TOP_STATES = setOf(Top, IndicateLike, IndicatePass)
     }
 
-    sealed class State {
+    sealed class State : Parcelable {
+        @Parcelize
         data class Queued(val queueNumber: Int) : State()
+        @Parcelize
         object Bottom : State()
+        @Parcelize
         object Top : State()
+        @Parcelize
         object IndicateLike : State()
+        @Parcelize
         object IndicatePass : State()
+        @Parcelize
         object VoteLike : State()
+        @Parcelize
         object VotePass : State()
 
         fun next(): State =

--- a/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/spotlightadvanced/SpotlightAdvanced.kt
+++ b/samples/navmodel-samples/src/main/kotlin/com/bumble/appyx/navmodel/spotlightadvanced/SpotlightAdvanced.kt
@@ -1,5 +1,6 @@
 package com.bumble.appyx.navmodel.spotlightadvanced
 
+import android.os.Parcelable
 import com.bumble.appyx.core.navigation.BaseNavModel
 import com.bumble.appyx.core.navigation.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
@@ -9,6 +10,7 @@ import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.navmodel.spotlightadvanced.SpotlightAdvanced.State
 import com.bumble.appyx.navmodel.spotlightadvanced.backpresshandler.GoToDefault
 import com.bumble.appyx.navmodel.spotlightadvanced.operation.toSpotlightAdvancedElements
+import kotlinx.parcelize.Parcelize
 
 class SpotlightAdvanced<NavTarget : Any>(
     items: List<NavTarget>,
@@ -28,10 +30,14 @@ class SpotlightAdvanced<NavTarget : Any>(
     key = key,
 ) {
 
-    sealed class State {
+    sealed class State : Parcelable {
+        @Parcelize
         object InactiveBefore : State()
+        @Parcelize
         object Active : State()
+        @Parcelize
         object InactiveAfter : State()
+        @Parcelize
         data class Carousel(val offset: Int, val max: Int) : State()
     }
 


### PR DESCRIPTION
## Description
The navmodels for cards and spotlight-advanced crash if you put the activity in the background

```
FATAL EXCEPTION: main
Process: com.bumble.appyx, PID: 4785
java.lang.RuntimeException: Parcel: unable to marshal value com.bumble.appyx.navmodel.cards.Cards$State$Top@6d9cbc1
	at android.os.Parcel.writeValue(Parcel.java:1772)
	at com.bumble.appyx.core.navigation.NavElement.writeToParcel(Unknown Source:12)
	at android.os.Parcel.writeParcelable(Parcel.java:1791)
	at android.os.Parcel.writeValue(Parcel.java:1697)
	at android.os.Parcel.writeList(Parcel.java:926)
	at android.os.Parcel.writeValue(Parcel.java:1719)
	at android.os.Parcel.writeMapInternal(Parcel.java:812)
	at android.os.Parcel.writeMap(Parcel.java:796)
	at android.os.Parcel.writeValue(Parcel.java:1684)
	at android.os.Parcel.writeMapInternal(Parcel.java:812)
	at android.os.Parcel.writeMap(Parcel.java:796)
	at android.os.Parcel.writeValue(Parcel.java:1684)
	at android.os.Parcel.writeMapInternal(Parcel.java:812)
	at android.os.Parcel.writeMap(Parcel.java:796)
	at android.os.Parcel.writeValue(Parcel.java:1684)
	at android.os.Parcel.writeMapInternal(Parcel.java:812)
	at android.os.Parcel.writeMap(Parcel.java:796)
	at android.os.Parcel.writeValue(Parcel.java:1684)
	at android.os.Parcel.writeList(Parcel.java:926)
	at android.os.Parcel.writeValue(Parcel.java:1719)
	at androidx.compose.runtime.ParcelableSnapshotMutableState.writeToParcel(ParcelableSnapshotMutableState.kt:30)
	at android.os.Parcel.writeParcelable(Parcel.java:1791)
	at android.os.Parcel.writeValue(Parcel.java:1697)
	at android.os.Parcel.writeList(Parcel.java:926)
	at android.os.Parcel.writeValue(Parcel.java:1719)
	at android.os.Parcel.writeArrayMapInternal(Parcel.java:838)
	at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
	at android.os.Bundle.writeToParcel(Bundle.java:1232)
	at android.os.Parcel.writeBundle(Parcel.java:878)
	at android.os.Parcel.writeValue(Parcel.java:1688)
	at android.os.Parcel.writeArrayMapInternal(Parcel.java:838)
	at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
	at android.os.Bundle.writeToParcel(Bundle.java:1232)
	at android.os.Parcel.writeBundle(Parcel.java:878)
	at android.os.Parcel.writeValue(Parcel.java:1688)
	at android.os.Parcel.writeArrayMapInternal(Parcel.java:838)
	at android.os.BaseBundle.writeToParcelInner(BaseBundle.java:1542)
	at android.os.Bundle.writeToParcel(Bundle.java:1232)
	at android.app.IActivityManager$Stub$Proxy.activityStopped(IActivityManager.java:4604)
	at android.app.ActivityThread$StopInfo.run(ActivityThread.java:3934)
	at android.os.Handler.handleCallback(Handler.java:790)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
