### PR TITLE
Fix sample app coroutines onstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-–
+– [#247](https://github.com/bumble-tech/appyx/pull/247) – **Added**: Added `EmptyNavModel` to core for cases in which a `ParentNode` only uses `PermanentChild`. The `DummyNavModel` test class is deprecated.
 
 ---
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/EmptyNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/EmptyNavModel.kt
@@ -1,0 +1,17 @@
+package com.bumble.appyx.core.navigation
+
+import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
+
+/**
+ * An implementation of a NavModel that won't add any children.
+ * This is potentially useful if your ParentNode only uses
+ * [com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel]
+ */
+class EmptyNavModel<NavTarget, State> : BaseNavModel<NavTarget, State>(
+    savedStateMap = null,
+    finalState = null,
+    screenResolver = OnScreenStateResolver { true }
+) {
+    override val initialElements: NavElements<NavTarget, State>
+        get() = emptyList()
+}

--- a/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/utils/DummyNavModel.kt
+++ b/libraries/testing-ui/src/main/kotlin/com/bumble/appyx/testing/ui/utils/DummyNavModel.kt
@@ -1,15 +1,12 @@
 package com.bumble.appyx.testing.ui.utils
 
-import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.NavElements
-import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
+import com.bumble.appyx.core.navigation.EmptyNavModel
 
-class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
-    savedStateMap = null,
-    finalState = null,
-    screenResolver = OnScreenStateResolver { true }
-) {
-    override val initialElements: NavElements<NavTarget, State>
-        get() = emptyList()
-
-}
+@Deprecated(
+    message = "Replaced with to EmptyNavModel",
+    replaceWith = ReplaceWith(
+        expression = "EmptyNavModel",
+        imports = ["com.bumble.appyx.core.navigation.EmptyNavModel"]
+    ),
+)
+typealias DummyNavModel<NavTarget, State> = EmptyNavModel<NavTarget, State>

--- a/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/DummyNavModel.kt
+++ b/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/DummyNavModel.kt
@@ -1,17 +1,12 @@
 package com.bumble.appyx.testing.unit.common.util
 
-import com.bumble.appyx.core.navigation.BaseNavModel
-import com.bumble.appyx.core.navigation.NavElements
-import com.bumble.appyx.core.navigation.onscreen.OnScreenStateResolver
+import com.bumble.appyx.core.navigation.EmptyNavModel
 
-class DummyNavModel<NavTarget : Any, State> : BaseNavModel<NavTarget, State>(
-    savedStateMap = null,
-    finalState = null,
-    screenResolver = object : OnScreenStateResolver<State> {
-        override fun isOnScreen(state: State) = true
-    }
-) {
-    override val initialElements: NavElements<NavTarget, State>
-        get() = emptyList()
-
-}
+@Deprecated(
+    message = "Replaced with to EmptyNavModel",
+    replaceWith = ReplaceWith(
+        expression = "EmptyNavModel",
+        imports = ["com.bumble.appyx.core.navigation.EmptyNavModel"]
+    ),
+)
+typealias DummyNavModel<NavTarget, State> = EmptyNavModel<NavTarget, State>

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesContainerNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesContainerNode.kt
@@ -29,6 +29,7 @@ import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.activeElement
 import com.bumble.appyx.navmodel.backstack.operation.newRoot
 import com.bumble.appyx.navmodel.backstack.operation.pop
+import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.transitionhandler.rememberBackstackSlider
 import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
 import kotlinx.parcelize.Parcelize
@@ -71,7 +72,21 @@ class SamplesContainerNode(
     @ExperimentalComposeUiApi
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
         when (navTarget) {
-            is NavTarget.SamplesListScreen -> SamplesSelectorNode(buildContext, backStack)
+            is NavTarget.SamplesListScreen -> SamplesSelectorNode(buildContext) { output ->
+                backStack.push(
+                    when (output) {
+                        is SamplesSelectorNode.Output.OpenCardsExample -> {
+                            NavTarget.CardsExample
+                        }
+                        is SamplesSelectorNode.Output.OpenComposeNavigation -> {
+                            NavTarget.ComposeNavigationScreen
+                        }
+                        is SamplesSelectorNode.Output.OpenOnboarding -> {
+                            NavTarget.OnboardingScreen
+                        }
+                    }
+                )
+            }
             is NavTarget.CardsExample -> CardsExampleNode(buildContext)
             is NavTarget.OnboardingScreen -> WhatsAppyxSlideShow(buildContext)
             is NavTarget.ComposeNavigationScreen -> {

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesContainerNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesContainerNode.kt
@@ -2,13 +2,9 @@ package com.bumble.appyx.app.node.samples
 
 import android.os.Parcelable
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
@@ -17,16 +13,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.app.node.cards.CardsExampleNode
-import com.bumble.appyx.app.node.helper.screenNode
 import com.bumble.appyx.app.node.slideshow.WhatsAppyxSlideShow
-import com.bumble.appyx.core.composable.ChildRenderer
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.integrationpoint.LocalIntegrationPoint
 import com.bumble.appyx.core.modality.BuildContext
@@ -37,7 +29,6 @@ import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.activeElement
 import com.bumble.appyx.navmodel.backstack.operation.newRoot
 import com.bumble.appyx.navmodel.backstack.operation.pop
-import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.transitionhandler.rememberBackstackSlider
 import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
 import kotlinx.parcelize.Parcelize
@@ -63,7 +54,7 @@ class SamplesContainerNode(
         }
 
         @Parcelize
-        data class OnboardingScreen(val autoAdvance: Boolean = false) : NavTarget() {
+        object OnboardingScreen : NavTarget() {
             override val showBackButton: Boolean
                 get() = false
         }
@@ -80,12 +71,9 @@ class SamplesContainerNode(
     @ExperimentalComposeUiApi
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
         when (navTarget) {
-            is NavTarget.SamplesListScreen -> screenNode(buildContext) { SamplesSelector(backStack) }
-            NavTarget.CardsExample -> CardsExampleNode(buildContext)
-            is NavTarget.OnboardingScreen -> WhatsAppyxSlideShow(
-                buildContext = buildContext,
-                autoAdvanceDelayMs = if (navTarget.autoAdvance) 2500 else null
-            )
+            is NavTarget.SamplesListScreen -> SamplesSelectorNode(buildContext, backStack)
+            is NavTarget.CardsExample -> CardsExampleNode(buildContext)
+            is NavTarget.OnboardingScreen -> WhatsAppyxSlideShow(buildContext)
             is NavTarget.ComposeNavigationScreen -> {
                 node(buildContext) {
                     // compose-navigation fetches the integration point via LocalIntegrationPoint
@@ -130,57 +118,6 @@ class SamplesContainerNode(
                 transitionHandler = rememberBackstackSlider(),
                 navModel = backStack
             )
-        }
-    }
-
-    @Composable
-    fun SamplesSelector(backStack: BackStack<NavTarget>, modifier: Modifier = Modifier) {
-        val decorator: @Composable (child: ChildRenderer) -> Unit = remember {
-            {
-                ScaledLayout() {
-                    it.invoke()
-                }
-
-            }
-        }
-        LazyColumn(
-            modifier = modifier.fillMaxSize(),
-            contentPadding = PaddingValues(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)
-
-        ) {
-            item {
-                SampleItem(
-                    title = "Dating cards NavModel",
-                    subtitle = "Swipe right on the NavModel concept",
-                    onClick = { backStack.push(NavTarget.CardsExample) },
-                ) { PermanentChild(navTarget = NavTarget.CardsExample, decorator = decorator) }
-            }
-            item {
-                SampleItem(
-                    title = "What is Appyx?",
-                    subtitle = "Explore some of the main ideas of Appyx in a set of slides",
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .aspectRatio(16f / 9),
-                    onClick = { backStack.push(NavTarget.OnboardingScreen(false)) },
-                ) { PermanentChild(navTarget = NavTarget.OnboardingScreen(true), decorator = decorator) }
-            }
-            item {
-                SampleItem(
-                    title = "Compose Navigation",
-                    subtitle = "See Appyx nodes interact with Jetpack Compose Navigation library",
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .aspectRatio(16f / 9),
-                    onClick = { backStack.push(NavTarget.ComposeNavigationScreen) },
-                ) {
-                    PermanentChild(
-                        navTarget = NavTarget.ComposeNavigationScreen,
-                        decorator = decorator
-                    )
-                }
-            }
         }
     }
 }

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
@@ -1,0 +1,141 @@
+package com.bumble.appyx.app.node.samples
+
+import android.os.Parcelable
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.ExperimentalUnitApi
+import androidx.compose.ui.unit.dp
+import com.bumble.appyx.app.node.cards.CardsExampleNode
+import com.bumble.appyx.app.node.slideshow.WhatsAppyxSlideShow
+import com.bumble.appyx.core.composable.ChildRenderer
+import com.bumble.appyx.core.integrationpoint.LocalIntegrationPoint
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.EmptyNavModel
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.ParentNode
+import com.bumble.appyx.core.node.node
+import com.bumble.appyx.navmodel.backstack.BackStack
+import com.bumble.appyx.navmodel.backstack.operation.push
+import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
+import kotlinx.parcelize.Parcelize
+
+class SamplesSelectorNode(
+    buildContext: BuildContext,
+    private val samplesContainerBackStack: BackStack<SamplesContainerNode.NavTarget>
+) : ParentNode<SamplesSelectorNode.NavTarget>(
+    navModel = EmptyNavModel<NavTarget, Unit>(),
+    buildContext = buildContext
+) {
+    sealed class NavTarget : Parcelable {
+        @Parcelize
+        object OnboardingScreen : NavTarget()
+
+        @Parcelize
+        object ComposeNavigationScreen : NavTarget()
+
+        @Parcelize
+        object CardsExample : NavTarget()
+    }
+
+    @ExperimentalUnitApi
+    @ExperimentalAnimationApi
+    @ExperimentalComposeUiApi
+    override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
+        when (navTarget) {
+            is NavTarget.CardsExample -> CardsExampleNode(buildContext)
+            is NavTarget.OnboardingScreen -> WhatsAppyxSlideShow(
+                buildContext = buildContext,
+                autoAdvanceDelayMs = 2500
+            )
+            is NavTarget.ComposeNavigationScreen -> {
+                node(buildContext) {
+                    // compose-navigation fetches the integration point via LocalIntegrationPoint
+                    CompositionLocalProvider(
+                        LocalIntegrationPoint provides integrationPoint,
+                    ) {
+                        ComposeNavigationRoot()
+                    }
+                }
+            }
+        }
+
+    @Composable
+    override fun View(modifier: Modifier) {
+        val decorator: @Composable (child: ChildRenderer) -> Unit = remember {
+            { childRenderer ->
+                ScaledLayout {
+                    childRenderer.invoke()
+                }
+            }
+        }
+        LazyColumn(
+            modifier = modifier.fillMaxSize(),
+            contentPadding = PaddingValues(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)
+
+        ) {
+            item {
+                SampleItem(
+                    title = "Dating cards NavModel",
+                    subtitle = "Swipe right on the NavModel concept",
+                    onClick = {
+                        samplesContainerBackStack.push(SamplesContainerNode.NavTarget.CardsExample)
+                    },
+                ) {
+                    PermanentChild(
+                        navTarget = NavTarget.CardsExample,
+                        decorator = decorator
+                    )
+                }
+            }
+            item {
+                SampleItem(
+                    title = "What is Appyx?",
+                    subtitle = "Explore some of the main ideas of Appyx in a set of slides",
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .aspectRatio(16f / 9),
+                    onClick = {
+                        samplesContainerBackStack.push(
+                            SamplesContainerNode.NavTarget.OnboardingScreen
+                        )
+                    },
+                ) {
+                    PermanentChild(
+                        navTarget = NavTarget.OnboardingScreen,
+                        decorator = decorator
+                    )
+                }
+            }
+            item {
+                SampleItem(
+                    title = "Compose Navigation",
+                    subtitle = "See Appyx nodes interact with Jetpack Compose Navigation library",
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .aspectRatio(16f / 9),
+                    onClick = {
+                        samplesContainerBackStack.push(
+                            SamplesContainerNode.NavTarget.ComposeNavigationScreen
+                        )
+                    },
+                ) {
+                    PermanentChild(
+                        navTarget = NavTarget.ComposeNavigationScreen,
+                        decorator = decorator
+                    )
+                }
+            }
+        }
+    }
+}

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
@@ -24,14 +24,12 @@ import com.bumble.appyx.core.navigation.EmptyNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.node
-import com.bumble.appyx.navmodel.backstack.BackStack
-import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
 import kotlinx.parcelize.Parcelize
 
 class SamplesSelectorNode(
     buildContext: BuildContext,
-    private val samplesContainerBackStack: BackStack<SamplesContainerNode.NavTarget>
+    private val outputFunc: (Output) -> Unit
 ) : ParentNode<SamplesSelectorNode.NavTarget>(
     navModel = EmptyNavModel<NavTarget, Unit>(),
     buildContext = buildContext
@@ -45,6 +43,12 @@ class SamplesSelectorNode(
 
         @Parcelize
         object CardsExample : NavTarget()
+    }
+
+    sealed class Output {
+        object OpenCardsExample : Output()
+        object OpenOnboarding : Output()
+        object OpenComposeNavigation : Output()
     }
 
     @ExperimentalUnitApi
@@ -88,9 +92,7 @@ class SamplesSelectorNode(
                 SampleItem(
                     title = "Dating cards NavModel",
                     subtitle = "Swipe right on the NavModel concept",
-                    onClick = {
-                        samplesContainerBackStack.push(SamplesContainerNode.NavTarget.CardsExample)
-                    },
+                    onClick = { outputFunc(Output.OpenCardsExample) },
                 ) {
                     PermanentChild(
                         navTarget = NavTarget.CardsExample,
@@ -105,11 +107,7 @@ class SamplesSelectorNode(
                     modifier = Modifier
                         .fillMaxSize()
                         .aspectRatio(16f / 9),
-                    onClick = {
-                        samplesContainerBackStack.push(
-                            SamplesContainerNode.NavTarget.OnboardingScreen
-                        )
-                    },
+                    onClick = { outputFunc(Output.OpenOnboarding) },
                 ) {
                     PermanentChild(
                         navTarget = NavTarget.OnboardingScreen,
@@ -124,11 +122,7 @@ class SamplesSelectorNode(
                     modifier = Modifier
                         .fillMaxSize()
                         .aspectRatio(16f / 9),
-                    onClick = {
-                        samplesContainerBackStack.push(
-                            SamplesContainerNode.NavTarget.ComposeNavigationScreen
-                        )
-                    },
+                    onClick = { outputFunc(Output.OpenComposeNavigation) },
                 ) {
                     PermanentChild(
                         navTarget = NavTarget.ComposeNavigationScreen,

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/backstack/BackstackTeaserNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/backstack/BackstackTeaserNode.kt
@@ -36,18 +36,20 @@ class BackstackTeaserNode(
 
     init {
         lifecycle.coroutineScope.launch {
-            delay(1000)
-            repeat(4) {
-                backStack.push(NavTarget.Child((it + 2) * 100))
-                delay(400)
+            lifecycle.coroutineScope.launchWhenStarted {
+                delay(1000)
+                repeat(4) {
+                    backStack.push(NavTarget.Child((it + 2) * 100))
+                    delay(400)
+                }
+                delay(500)
+                repeat(4) {
+                    backStack.pop()
+                    delay(150)
+                }
+                delay(1000)
+                finish()
             }
-            delay(500)
-            repeat(4) {
-                backStack.pop()
-                delay(150)
-            }
-            delay(1000)
-            finish()
         }
     }
 

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/backstack/BackstackTeaserNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/backstack/BackstackTeaserNode.kt
@@ -18,7 +18,6 @@ import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.pop
 import com.bumble.appyx.navmodel.backstack.operation.push
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import kotlin.random.Random
 
@@ -35,21 +34,19 @@ class BackstackTeaserNode(
 ) {
 
     init {
-        lifecycle.coroutineScope.launch {
-            lifecycle.coroutineScope.launchWhenStarted {
-                delay(1000)
-                repeat(4) {
-                    backStack.push(NavTarget.Child((it + 2) * 100))
-                    delay(400)
-                }
-                delay(500)
-                repeat(4) {
-                    backStack.pop()
-                    delay(150)
-                }
-                delay(1000)
-                finish()
+        lifecycle.coroutineScope.launchWhenStarted {
+            delay(1000)
+            repeat(4) {
+                backStack.push(NavTarget.Child((it + 2) * 100))
+                delay(400)
             }
+            delay(500)
+            repeat(4) {
+                backStack.pop()
+                delay(150)
+            }
+            delay(1000)
+            finish()
         }
     }
 

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/promoter/PromoterTeaserNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/promoter/PromoterTeaserNode.kt
@@ -37,17 +37,19 @@ class PromoterTeaserNode(
 
     init {
         lifecycle.coroutineScope.launch {
-            repeat(4) {
-                promoter.addFirst(NavTarget.Child((it + 1) * 100))
-                promoter.promoteAll()
+            lifecycle.coroutineScope.launchWhenStarted {
+                repeat(4) {
+                    promoter.addFirst(NavTarget.Child((it + 1) * 100))
+                    promoter.promoteAll()
+                }
+                delay(500)
+                repeat(4) {
+                    delay(1500)
+                    promoter.addFirst(NavTarget.Child((it + 5) * 100))
+                    promoter.promoteAll()
+                }
+                finish()
             }
-            delay(500)
-            repeat(4) {
-                delay(1500)
-                promoter.addFirst(NavTarget.Child((it + 5) * 100))
-                promoter.promoteAll()
-            }
-            finish()
         }
     }
 

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/promoter/PromoterTeaserNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/teaser/promoter/PromoterTeaserNode.kt
@@ -12,19 +12,18 @@ import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.coroutineScope
 import com.bumble.appyx.app.node.child.GenericChildNode
-import com.bumble.appyx.navmodel.promoter.navmodel.Promoter
-import com.bumble.appyx.navmodel.promoter.navmodel.operation.addFirst
-import com.bumble.appyx.navmodel.promoter.navmodel.operation.promoteAll
-import com.bumble.appyx.navmodel.promoter.transitionhandler.rememberPromoterTransitionHandler
+import com.bumble.appyx.app.node.teaser.promoter.PromoterTeaserNode.NavTarget
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
-import com.bumble.appyx.app.node.teaser.promoter.PromoterTeaserNode.NavTarget
-import kotlin.random.Random
+import com.bumble.appyx.navmodel.promoter.navmodel.Promoter
+import com.bumble.appyx.navmodel.promoter.navmodel.operation.addFirst
+import com.bumble.appyx.navmodel.promoter.navmodel.operation.promoteAll
+import com.bumble.appyx.navmodel.promoter.transitionhandler.rememberPromoterTransitionHandler
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import kotlin.random.Random
 
 @ExperimentalUnitApi
 class PromoterTeaserNode(
@@ -36,20 +35,18 @@ class PromoterTeaserNode(
 ) {
 
     init {
-        lifecycle.coroutineScope.launch {
-            lifecycle.coroutineScope.launchWhenStarted {
-                repeat(4) {
-                    promoter.addFirst(NavTarget.Child((it + 1) * 100))
-                    promoter.promoteAll()
-                }
-                delay(500)
-                repeat(4) {
-                    delay(1500)
-                    promoter.addFirst(NavTarget.Child((it + 5) * 100))
-                    promoter.promoteAll()
-                }
-                finish()
+        lifecycle.coroutineScope.launchWhenStarted {
+            repeat(4) {
+                promoter.addFirst(NavTarget.Child((it + 1) * 100))
+                promoter.promoteAll()
             }
+            delay(500)
+            repeat(4) {
+                delay(1500)
+                promoter.addFirst(NavTarget.Child((it + 5) * 100))
+                promoter.promoteAll()
+            }
+            finish()
         }
     }
 


### PR DESCRIPTION
## Description
Fixed an issue where the sample app samples list screen elements were still active even when it was not active in the backstack.

This is because the `PermanentChild` was actually being called on `SamplesContainerNode` and not `SamplesSelector`. This meant that the children existed outside of the backstack and were never paused/stopped.

Also prevented the teaser NavModels from running when stopped.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
