### PR TITLE
Remove dependency analysis from ci reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: reports
-          path: '**/build/reports'
+          path: |
+            **/build/reports/
+            !**/build/reports/dependency-analysis/
 
   instrumentation-tests:
     name: Instrumentation tests


### PR DESCRIPTION
## Description
Removed the dependency analysis reports from CI as they are not useful (at the moment) and increase the file size of the ZIP from roughly 3MB to 200MB

-------
**Failure job with dependency analysis**
https://github.com/bumble-tech/appyx/actions/runs/3312319396

![image](https://user-images.githubusercontent.com/1333155/197520719-202b62e1-4dbc-46f2-a033-6a785403bc4a.png)
-------
**Failure job without dependency analysis**
https://github.com/bumble-tech/appyx/actions/runs/3312440201

![image](https://user-images.githubusercontent.com/1333155/197520651-bc471e4f-a49b-4bd3-9a29-a4969b672421.png)
-------

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
