### PR TITLE
Fix PermanentChild behaviour in test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending changes
 
+- [#268](https://github.com/bumble-tech/appyx/pull/268) – **Fixed**: `PermanentChild` now does not crash in UI tests with `ComposeTestRule`.
 
 ---
 

--- a/libraries/core/src/androidTest/AndroidManifest.xml
+++ b/libraries/core/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application>
 
         <activity
-            android:name="com.bumble.appyx.core.plugin.BackPressHandlerTestActivity"
+            android:name="com.bumble.appyx.core.InternalAppyxTestActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
     </application>

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/AppyxTestScenario.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/AppyxTestScenario.kt
@@ -1,4 +1,4 @@
-package com.bumble.appyx.core.plugin
+package com.bumble.appyx.core
 
 import androidx.annotation.WorkerThread
 import androidx.compose.runtime.Composable
@@ -25,18 +25,21 @@ class AppyxTestScenario<T : Node>(
 ) : ComposeTestRule by composeTestRule {
 
     @get:WorkerThread
-    val activityScenario: ActivityScenario<BackPressHandlerTestActivity> by lazy {
+    val activityScenario: ActivityScenario<InternalAppyxTestActivity> by lazy {
         val awaitNode = CountDownLatch(1)
         AppyxTestActivity.composableView = { activity ->
             decorator {
-                NodeHost(integrationPoint = activity.appyxIntegrationPoint, factory = { buildContext ->
-                    node = nodeFactory.create(buildContext)
-                    awaitNode.countDown()
-                    node
-                })
+                NodeHost(
+                    integrationPoint = activity.appyxIntegrationPoint,
+                    factory = { buildContext ->
+                        node = nodeFactory.create(buildContext)
+                        awaitNode.countDown()
+                        node
+                    },
+                )
             }
         }
-        val scenario = ActivityScenario.launch(BackPressHandlerTestActivity::class.java)
+        val scenario = ActivityScenario.launch(InternalAppyxTestActivity::class.java)
         require(awaitNode.await(10, TimeUnit.SECONDS)) {
             "Timeout while waiting for node initialization"
         }

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/InternalAppyxTestActivity.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/InternalAppyxTestActivity.kt
@@ -1,4 +1,4 @@
-package com.bumble.appyx.core.plugin
+package com.bumble.appyx.core
 
 import android.os.Bundle
 import androidx.activity.OnBackPressedCallback
@@ -7,7 +7,7 @@ import com.bumble.appyx.testing.ui.rules.AppyxTestActivity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
-class BackPressHandlerTestActivity : AppyxTestActivity() {
+class InternalAppyxTestActivity : AppyxTestActivity() {
 
     private val callback = object : OnBackPressedCallback(handleBackPress.value) {
         override fun handleOnBackPressed() {

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
@@ -1,0 +1,77 @@
+package com.bumble.appyx.core.node
+
+import android.os.Parcelable
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.hasTestTag
+import com.bumble.appyx.core.AppyxTestScenario
+import com.bumble.appyx.core.children.nodeOrNull
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.EmptyNavModel
+import kotlinx.parcelize.Parcelize
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class PermanentChildTest {
+
+    @get:Rule
+    val rule = AppyxTestScenario { buildContext ->
+        TestParentNode(buildContext)
+    }
+
+    @Test
+    fun permanent_child_is_rendered() {
+        rule.start()
+
+        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertExists()
+    }
+
+    @Test
+    fun permanent_child_is_reused_when_visibility_switched() {
+        rule.start()
+        rule.node.renderPermanentChild = false
+        val childNodes = rule.node.children.value.values.map { it.nodeOrNull }
+
+        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertDoesNotExist()
+
+        rule.node.renderPermanentChild = true
+
+        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertExists()
+        assertEquals(childNodes, rule.node.children.value.values.map { it.nodeOrNull })
+    }
+
+    class TestParentNode(
+        buildContext: BuildContext,
+    ) : ParentNode<TestParentNode.NavTarget>(
+        buildContext = buildContext,
+        navModel = EmptyNavModel<NavTarget, Any>(),
+    ) {
+
+        @Parcelize
+        object NavTarget : Parcelable
+
+        var renderPermanentChild by mutableStateOf(true)
+
+        override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
+            node(buildContext) { modifier ->
+                BasicText(
+                    text = navTarget.toString(),
+                    modifier = modifier.testTag(NavTarget::class.java.name),
+                )
+            }
+
+        @Composable
+        override fun View(modifier: Modifier) {
+            if (renderPermanentChild) {
+                PermanentChild(NavTarget)
+            }
+        }
+    }
+
+}

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/plugin/BackPressHandlerTest.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/plugin/BackPressHandlerTest.kt
@@ -17,6 +17,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 import com.bumble.appyx.Appyx
+import com.bumble.appyx.core.AppyxTestScenario
+import com.bumble.appyx.core.InternalAppyxTestActivity
 import com.bumble.appyx.core.children.nodeOrNull
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.modality.BuildContext
@@ -50,7 +52,7 @@ class BackPressHandlerTest {
     @After
     fun after() {
         Appyx.exceptionHandler = null
-        BackPressHandlerTestActivity.reset()
+        InternalAppyxTestActivity.reset()
     }
 
     @Test
@@ -132,7 +134,7 @@ class BackPressHandlerTest {
 
     @Test
     fun appyx_handles_back_press_before_activity_handler() {
-        BackPressHandlerTestActivity.handleBackPress.value = true
+        InternalAppyxTestActivity.handleBackPress.value = true
         rule.start()
         pushChildB()
 
@@ -145,7 +147,7 @@ class BackPressHandlerTest {
 
     @Test
     fun activity_handles_back_press_if_appyx_cant() {
-        BackPressHandlerTestActivity.handleBackPress.value = true
+        InternalAppyxTestActivity.handleBackPress.value = true
         rule.start()
         disablePlugin()
 
@@ -153,7 +155,7 @@ class BackPressHandlerTest {
         Espresso.onIdle()
         rule.waitForIdle()
 
-        assertThat(BackPressHandlerTestActivity.onBackPressedHandled, equalTo(true))
+        assertThat(InternalAppyxTestActivity.onBackPressedHandled, equalTo(true))
     }
 
     @Test

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/operation/AddUnique.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/operation/AddUnique.kt
@@ -7,6 +7,9 @@ import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
+/**
+ * Adds [NavTarget] into [PermanentNavModel] only if it is not there yet.
+ */
 @Parcelize
 data class AddUnique<NavTarget : Any>(
     private val navTarget: @RawValue NavTarget,

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/operation/AddUnique.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/permanent/operation/AddUnique.kt
@@ -1,0 +1,35 @@
+package com.bumble.appyx.core.navigation.model.permanent.operation
+
+import com.bumble.appyx.core.navigation.NavElement
+import com.bumble.appyx.core.navigation.NavElements
+import com.bumble.appyx.core.navigation.NavKey
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+
+@Parcelize
+data class AddUnique<NavTarget : Any>(
+    private val navTarget: @RawValue NavTarget,
+) : PermanentOperation<NavTarget> {
+
+    override fun isApplicable(elements: NavElements<NavTarget, Int>): Boolean =
+        !elements.any { it.key.navTarget == navTarget }
+
+    override fun invoke(
+        elements: NavElements<NavTarget, Int>
+    ): NavElements<NavTarget, Int> =
+        if (elements.any { it.key.navTarget == navTarget }) {
+            elements
+        } else {
+            elements + NavElement(
+                key = NavKey(navTarget),
+                fromState = 0,
+                targetState = 0,
+                operation = this,
+            )
+        }
+}
+
+fun <NavTarget : Any> PermanentNavModel<NavTarget>.addUnique(navTarget: NavTarget) {
+    accept(AddUnique(navTarget))
+}


### PR DESCRIPTION
## Description

`PermanentChild` throws exception in UI tests due unsynchronized changes from `collect`.

Added new `PermanentChild.addUnique` API to use from `PermanentChild`.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
