### PR TITLE
Avoid breaking changes by reinstantiating and deprecating API

### DIFF
--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
@@ -100,6 +100,11 @@ open class Node(
         )
     }
 
+    @Deprecated("Will be removed in 1.1. Use executeAction instead")
+    protected suspend inline fun <reified T : Node> executeWorkflow(
+        crossinline action: () -> Unit
+    ): T = executeAction(action)
+
     protected suspend inline fun <reified T : Node> executeAction(
         crossinline action: () -> Unit
     ): T = withContext(lifecycleScope.coroutineContext) {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
@@ -100,7 +100,10 @@ open class Node(
         )
     }
 
-    @Deprecated("Will be removed in 1.1. Use executeAction instead")
+    @Deprecated(
+        replaceWith = ReplaceWith("executeAction(action)"),
+        message = "Will be removed in 1.1"
+    )
     protected suspend inline fun <reified T : Node> executeWorkflow(
         crossinline action: () -> Unit
     ): T = executeAction(action)

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -168,6 +168,12 @@ abstract class ParentNode<NavTarget : Any>(
         }
     }
 
+    @Deprecated("Will be removed in 1.1. Use attachChild instead")
+    protected suspend inline fun <reified T : Node> attachWorkflow(
+        timeout: Long = ATTACH_WORKFLOW_SYNC_TIMEOUT,
+        crossinline action: () -> Unit
+    ) = attachChild<T>(timeout, action)
+
     /**
      * attachChild executes provided action e.g. backstack.push(NodeANavTarget) and waits for the specific
      * Node of type T to appear in the ParentNode's children list. It should happen almost immediately because it happens

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -168,7 +168,10 @@ abstract class ParentNode<NavTarget : Any>(
         }
     }
 
-    @Deprecated("Will be removed in 1.1. Use attachChild instead")
+    @Deprecated(
+        replaceWith = ReplaceWith("attachChild(action"),
+        message = "Will be removed in 1.1"
+    )
     protected suspend inline fun <reified T : Node> attachWorkflow(
         timeout: Long = ATTACH_WORKFLOW_SYNC_TIMEOUT,
         crossinline action: () -> Unit


### PR DESCRIPTION
## Description

Deprecate renamed API instead of deleting it to avoid breaking changes

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
