### PR TITLE
Fix backstack crash

### DIFF
--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/backstack/BackStackExampleNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/backstack/BackStackExampleNode.kt
@@ -345,20 +345,23 @@ class BackStackExampleNode(
             Button(
                 enabled = selectedOperation.value != null && !areThereMissingParams.value,
                 onClick = {
-                    val element =
+
+                    fun getElement() =
                         selectedChildRadioButton.value.toChild(random = defaultOrRandomRadioButton.value.random)
+
                     when (selectedOperation.value) {
-                        PUSH -> backStack.push(element)
+                        PUSH -> backStack.push(getElement())
                         POP -> backStack.pop()
-                        REPLACE -> backStack.replace(element)
-                        NEW_ROOT -> backStack.newRoot(element)
-                        SINGLE_TOP -> backStack.singleTop(element)
+                        REPLACE -> backStack.replace(getElement())
+                        NEW_ROOT -> backStack.newRoot(getElement())
+                        SINGLE_TOP -> backStack.singleTop(getElement())
                         REMOVE -> {
                             backStack.remove(backStackState.value.first { it.key.id == selectedId.value }.key)
                             selectedId.value = ""
                         }
-                        null -> Unit
+                        else -> Unit
                     }
+
                 }
             ) {
                 Text(text = "Perform")

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/backstack/BackStackExampleNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/backstack/BackStackExampleNode.kt
@@ -311,6 +311,7 @@ class BackStackExampleNode(
     }
 
     @Composable
+    @Suppress("ComplexMethod")
     private fun MissingParamsColumn(
         selectedOperation: MutableState<Operation?>,
         selectedChildRadioButton: MutableState<String>,


### PR DESCRIPTION
## Description

Popping backstack in samples caused crash. This is a quick fix to avoid crash

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
