### PR TITLE
Updated accompanist to 0.28.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 androidCompileSdk = "33"
 androidMinSdk = "21"
 androidTargetSdk = "32"
+accompanist = "0.28.0"
 androidx-lifecycle = "2.5.1"
 androidx-navigation-compose = "2.5.1"
 coil = "2.2.1"
@@ -18,7 +19,6 @@ detekt = "1.21.0"
 dependencyAnalysis = "1.13.1"
 
 [libraries]
-accompanist-systemui = "com.google.accompanist:accompanist-systemuicontroller:0.17.0"
 androidx-activity-compose = "androidx.activity:activity-compose:1.3.1"
 androidx-appcompat = "androidx.appcompat:appcompat:1.3.1"
 androidx-arch-core-testing = "androidx.arch.core:core-testing:2.1.0"
@@ -40,7 +40,8 @@ compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-google-accompanist-flow = "com.google.accompanist:accompanist-flowlayout:0.25.1"
+google-accompanist-systemui = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
+google-accompanist-flow = { module = "com.google.accompanist:accompanist-flowlayout", version.ref = "accompanist" }
 google-material = "com.google.android.material:material:1.4.0"
 junit = "junit:junit:4.13.2"
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }

--- a/samples/sandbox/build.gradle.kts
+++ b/samples/sandbox/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation(project(":samples:common"))
     // The testing activity needs to be in the main manifest, otherwise it cannot be launched.
     debugImplementation(project(":libraries:testing-ui-activity"))
-    implementation(libs.accompanist.systemui)
+    implementation(libs.google.accompanist.systemui)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.appcompat)


### PR DESCRIPTION
## Description
Updated internal accompanist library to 0.28.0 (does not need an update to the changelog)

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
