### PR TITLE
ViewModel POC

### DIFF
--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -5,13 +5,14 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityBoundary
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequestBoundary
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
 
 open class ActivityIntegrationPoint(
-    private val activity: Activity,
+    val activity: ComponentActivity,
     savedInstanceState: Bundle?,
 ) : IntegrationPoint(savedInstanceState = savedInstanceState) {
     private val activityBoundary = ActivityBoundary(activity, requestCodeRegistry)

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
@@ -37,12 +37,14 @@ import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.Integra
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.LazyExamples
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.NavModelExamples
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.Picker
+import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.ViewModelExample
 import com.bumble.appyx.sandbox.client.customisations.CustomisationsNode
 import com.bumble.appyx.sandbox.client.explicitnavigation.ExplicitNavigationExampleActivity
 import com.bumble.appyx.sandbox.client.integrationpoint.IntegrationPointExampleNode
 import com.bumble.appyx.sandbox.client.interop.InteropExampleActivity
 import com.bumble.appyx.sandbox.client.list.LazyListContainerNode
 import com.bumble.appyx.sandbox.client.navmodels.NavModelExamplesNode
+import com.bumble.appyx.sandbox.client.viewmodel.ViewModelNode
 import com.bumble.appyx.utils.customisations.NodeCustomisation
 import kotlinx.parcelize.Parcelize
 
@@ -66,6 +68,9 @@ class ContainerNode internal constructor(
         object Picker : NavTarget()
 
         @Parcelize
+        object ViewModelExample : NavTarget()
+
+        @Parcelize
         object LazyExamples : NavTarget()
 
         @Parcelize
@@ -85,6 +90,7 @@ class ContainerNode internal constructor(
     override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
         when (navTarget) {
             is Picker -> node(buildContext) { modifier -> ExamplesList(modifier) }
+            is ViewModelExample -> ViewModelNode(buildContext)
             is NavModelExamples -> NavModelExamplesNode(buildContext)
             is LazyExamples -> LazyListContainerNode(buildContext)
             is IntegrationPointExample -> IntegrationPointExampleNode(buildContext)
@@ -122,6 +128,7 @@ class ContainerNode internal constructor(
                 label?.let {
                     Text(it, textAlign = TextAlign.Center)
                 }
+                TextButton("ViewModel Example") { backStack.push(ViewModelExample) }
                 TextButton("NavModel Examples") { backStack.push(NavModelExamples) }
                 TextButton("Customisations Example") { backStack.push(Customisations) }
                 TextButton("Explicit navigation example") {

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/MyViewModel.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/MyViewModel.kt
@@ -1,0 +1,46 @@
+package com.bumble.appyx.sandbox.client.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.launch
+
+class MyViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    private val stateFlow = MutableStateFlow(0)
+    val flow: Flow<Int> = stateFlow
+
+    init {
+        viewModelScope.launch {
+            while (true) {
+                stateFlow.getAndUpdate { value ->
+                    value + 1
+                }
+                delay(1000)
+            }
+        }
+    }
+
+    companion object {
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val savedStateHandle = createSavedStateHandle()
+                MyViewModel(
+                    savedStateHandle = savedStateHandle
+                )
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+    }
+}

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/ViewModelExt.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/ViewModelExt.kt
@@ -1,0 +1,34 @@
+package com.bumble.appyx.sandbox.client.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import java.lang.reflect.Method
+
+@Suppress("UNCHECKED_CAST")
+fun <T : ViewModel> ViewModelStore.removeViewModel(modelClass: Class<T>) {
+    val map = this.getPrivateProperty("mMap") as HashMap<String, ViewModel>
+    val iterator = map.iterator()
+    while (iterator.hasNext()) {
+        val next = iterator.next()
+        val viewModel = next.value
+        if (viewModel::class.java == modelClass) {
+            val clearMethod = findViewModelClearMethod()
+            clearMethod.invoke(viewModel)
+            iterator.remove()
+        }
+    }
+}
+
+private fun <T : Any> T.getPrivateProperty(variableName: String): Any? {
+    return javaClass.getDeclaredField(variableName).let { field ->
+        field.isAccessible = true
+        return@let field.get(this)
+    }
+}
+
+private fun findViewModelClearMethod(): Method {
+    val clazz: Class<*> = ViewModel::class.java
+    val clearMethod = clazz.getDeclaredMethod("clear")
+    clearMethod.isAccessible = true
+    return clearMethod
+}

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/ViewModelNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/viewmodel/ViewModelNode.kt
@@ -1,0 +1,48 @@
+package com.bumble.appyx.sandbox.client.viewmodel
+
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.bumble.appyx.core.integrationpoint.ActivityIntegrationPoint
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+
+class ViewModelNode(
+    buildContext: BuildContext,
+) : Node(
+    buildContext = buildContext
+) {
+    private val activity = (integrationPoint as ActivityIntegrationPoint).activity
+    private val viewModel: MyViewModel by activity.viewModels { MyViewModel.Factory }
+
+    init {
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) {
+                if (!activity.isChangingConfigurations) {
+                    activity.viewModelStore.removeViewModel(viewModel.javaClass)
+                }
+            }
+        })
+    }
+
+    @Composable
+    override fun View(modifier: Modifier) {
+        val counter by viewModel.flow.collectAsState(initial = 0)
+        Box(modifier = modifier.fillMaxSize()) {
+            Text(
+                text = counter.toString(),
+                fontSize = 38.sp,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR demonstrates how VM can be used and scoped to a `Node` using reflection API.

By design VM is stored in a `ViewModelStore` class and lives as long as activity lives. 

The desired behaviour is the following:
1. `VM` is created when `Node` is created
2. `VM` is persistent when `Node` is moved in `DESTROY` state and `Activity` is changing configuration
3. `VM` is destroyed when `Node` is moved in `DESTROY` state and `Activity` **IS NOT** changing configuration

This behaviour can not be achieved using public API as it's not possible to clear only one `VM` from `ViewModelStore. It has only one public method – `ViewModelStore.clear()` which clears all `VMs.

I the meantime I'm exploring alternative solutions.

https://user-images.githubusercontent.com/5773436/207447633-65f79414-2313-4d7b-b453-464c4e51de30.mp4



## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
