### PR TITLE
Make Node a viewmodel store owner

### DIFF
--- a/libraries/core/build.gradle.kts
+++ b/libraries/core/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.java8)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.compose.foundation.layout)
+    api("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")
 
     testImplementation(project(":libraries:testing-junit4"))
     testImplementation(libs.androidx.arch.core.testing)

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integration/NodeHost.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integration/NodeHost.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bumble.appyx.core.integrationpoint.IntegrationPoint
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
@@ -19,6 +21,7 @@ import com.bumble.appyx.core.node.build
 import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectory
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl
+import com.bumble.appyx.viewmodel.IntegrationPointViewModel
 
 /**
  * Composable function to host [Node].
@@ -39,6 +42,8 @@ fun <N : Node> NodeHost(
     }
     node.Compose(modifier = modifier)
     val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val viewmodelStoreOwner = LocalViewModelStoreOwner.current
+    val viewModel = IntegrationPointViewModel.getInstance(viewmodelStoreOwner!!)
     DisposableEffect(lifecycle) {
         node.updateLifecycleState(lifecycle.currentState)
         val observer = LifecycleEventObserver { source, _ ->

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integration/NodeHost.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integration/NodeHost.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bumble.appyx.core.integrationpoint.IntegrationPoint
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
@@ -21,7 +19,6 @@ import com.bumble.appyx.core.node.build
 import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectory
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl
-import com.bumble.appyx.viewmodel.IntegrationPointViewModel
 
 /**
  * Composable function to host [Node].
@@ -42,8 +39,6 @@ fun <N : Node> NodeHost(
     }
     node.Compose(modifier = modifier)
     val lifecycle = LocalLifecycleOwner.current.lifecycle
-    val viewmodelStoreOwner = LocalViewModelStoreOwner.current
-    val viewModel = IntegrationPointViewModel.getInstance(viewmodelStoreOwner!!)
     DisposableEffect(lifecycle) {
         node.updateLifecycleState(lifecycle.currentState)
         val observer = LifecycleEventObserver { source, _ ->

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -5,13 +5,15 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityBoundary
 import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequestBoundary
 import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
+import com.bumble.appyx.viewmodel.IntegrationPointViewModel
 
 open class ActivityIntegrationPoint(
-    private val activity: Activity,
+    private val activity: ComponentActivity,
     savedInstanceState: Bundle?,
 ) : IntegrationPoint(savedInstanceState = savedInstanceState) {
     private val activityBoundary = ActivityBoundary(activity, requestCodeRegistry)
@@ -22,6 +24,10 @@ open class ActivityIntegrationPoint(
 
     override val permissionRequester: PermissionRequester
         get() = permissionRequestBoundary
+
+    val viewModel = IntegrationPointViewModel.getInstance(activity)
+
+    fun isChangingConfigurations(): Boolean = activity.isChangingConfigurations
 
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         activityBoundary.onActivityResult(requestCode, resultCode, data)

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/viewmodel/IntegrationPointViewModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/viewmodel/IntegrationPointViewModel.kt
@@ -1,0 +1,30 @@
+package com.bumble.appyx.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.get
+
+class IntegrationPointViewModel : ViewModel() {
+    private val viewModelStores = mutableMapOf<String, ViewModelStore>()
+    fun clear(nodeId: String) {
+        val viewModelStore = viewModelStores.remove(nodeId)
+        viewModelStore?.clear()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelStores.values.forEach { it.clear() }
+        viewModelStores.clear()
+    }
+
+    fun getViewModelStoreForNode(nodeId: String): ViewModelStore =
+        viewModelStores.getOrPut(nodeId) { ViewModelStore() }
+
+    companion object {
+        fun getInstance(viewModelStoreOwner: ViewModelStoreOwner): IntegrationPointViewModel {
+            return ViewModelProvider(viewModelStoreOwner).get()
+        }
+    }
+}

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/MyViewModel.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/MyViewModel.kt
@@ -1,0 +1,35 @@
+package com.bumble.appyx.app.node.samples
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.launch
+
+class MyViewModel() : ViewModel() {
+
+    private val stateFlow = MutableStateFlow(0)
+    val flow: Flow<Int> = stateFlow
+
+    init {
+        viewModelScope.launch {
+            while (true) {
+                stateFlow.getAndUpdate { value ->
+                    value + 1
+                }
+                delay(1000)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+    }
+}

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
@@ -7,14 +7,17 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bumble.appyx.app.node.backstack.InsideTheBackStack
 import com.bumble.appyx.app.node.cards.CardsExampleNode
 import com.bumble.appyx.app.node.helper.screenNode
@@ -26,8 +29,8 @@ import com.bumble.appyx.core.navigation.EmptyNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.node
-import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
 import com.bumble.appyx.interactions.App
+import com.bumble.appyx.sample.navigtion.compose.ComposeNavigationRoot
 import kotlinx.parcelize.Parcelize
 
 class SamplesSelectorNode(
@@ -97,6 +100,8 @@ class SamplesSelectorNode(
 
     @Composable
     override fun View(modifier: Modifier) {
+        val viewModel = viewModel<MyViewModel>()
+        val counter = viewModel.flow.collectAsState(initial = 0)
         val decorator: @Composable (child: ChildRenderer) -> Unit = remember {
             { childRenderer ->
                 ScaledLayout {
@@ -110,6 +115,9 @@ class SamplesSelectorNode(
             verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)
 
         ) {
+            item {
+                Text(text = "Counter: ${counter.value}")
+            }
             item {
                 CardItem(decorator)
             }


### PR DESCRIPTION
## Description

Its a hacky draft showcasing possible way to integrate viewmodel with Appyx.
In this case Node implements ViewmodelStore interface, allowing devs to use the same viewmodel extenstion methods used for Composables, Fragments & Activity.

On the root of the tree in ActivityIntegrationPoint we have a viewmodel that stores all of the viewmodel stores for nodes, where node id is the key in that storage. That viewmodel itself survives configuration change, with its contents.

Node clears it's ViewmodelStore when destroyed. To differentiate DESTROY event when we're recreating activity, and DESTROY when Node is actually destroyed  we have to check activtiy.isChanging configuration. ComposeNavigation for example does it a bit different - it associates ViewmodelStore with backstack entry and clears it once removed from backstack. But for Appyx this approach is not suitable since we'll have to have this kind of logic in every navmodel.

Pros: Using same viewmodel() methods from androidx
Cons: Having viewmodel logic in Node

Alternative:
Create custom integration point, eg ViewModelIntegrationPoint and set of extetion functions to the node to create viewmodels inside node. Crash(?) when node.integrationPoint doesn't cast to ViewModelIntegrationPoint.

DI: Yuri already mentioned in #303 but I'm not sure what we can do about that
> Anyway in both variants we have another problem – we change DI flow. We usually pass all dependencies into Node ready to use, but here we have to instantiate ViewModel inside Node, comparing to everything else that is done outside. Not like a bad thing, something that I want to come to later.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
