### PR TITLE
Relax ChildAware API requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Pending changes
-–
+
+- [#336](https://github.com/bumble-tech/appyx/pulls/336) – **Updated**: ChildAware API does not enforce Node subtypes only anymore, making it possible to use interfaces as public contracts for child nodes.
 
 ---
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAware.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAware.kt
@@ -4,14 +4,14 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.plugin.NodeAware
 import kotlin.reflect.KClass
 
-interface ChildAware<N: Node> : NodeAware<N> {
+interface ChildAware<N : Node> : NodeAware<N> {
 
-    fun <T : Node> whenChildAttached(
+    fun <T : Any> whenChildAttached(
         child: KClass<T>,
         callback: ChildCallback<T>,
     )
 
-    fun <T1 : Node, T2 : Node> whenChildrenAttached(
+    fun <T1 : Any, T2 : Any> whenChildrenAttached(
         child1: KClass<T1>,
         child2: KClass<T2>,
         callback: ChildrenCallback<T1, T2>,

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareCallbackInfo.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareCallbackInfo.kt
@@ -12,7 +12,7 @@ internal sealed class ChildAwareCallbackInfo {
 
     abstract fun onRegistered(activeNodes: List<Node>)
 
-    class Single<T : Node>(
+    class Single<T : Any>(
         private val child: KClass<T>,
         private val callback: ChildCallback<T>,
         private val parentLifecycle: Lifecycle,
@@ -39,7 +39,7 @@ internal sealed class ChildAwareCallbackInfo {
 
     }
 
-    class Double<T1 : Node, T2 : Node>(
+    class Double<T1 : Any, T2 : Any>(
         private val child1: KClass<T1>,
         private val child2: KClass<T2>,
         private val callback: ChildrenCallback<T1, T2>,

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareImpl.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareImpl.kt
@@ -53,7 +53,7 @@ class ChildAwareImpl<N : Node> : ChildAware<N> {
             }
     }
 
-    override fun <T : Node> whenChildAttached(
+    override fun <T : Any> whenChildAttached(
         child: KClass<T>,
         callback: ChildCallback<T>
     ) {
@@ -64,7 +64,7 @@ class ChildAwareImpl<N : Node> : ChildAware<N> {
         lifecycle.removeWhenDestroyed(info)
     }
 
-    override fun <T1 : Node, T2 : Node> whenChildrenAttached(
+    override fun <T1 : Any, T2 : Any> whenChildrenAttached(
         child1: KClass<T1>,
         child2: KClass<T2>,
         callback: ChildrenCallback<T1, T2>

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -241,11 +241,11 @@ abstract class ParentNode<NavTarget : Any>(
 
     // region ChildAware
 
-    protected fun <T : Node> whenChildAttached(child: KClass<T>, callback: ChildCallback<T>) {
+    protected fun <T : Any> whenChildAttached(child: KClass<T>, callback: ChildCallback<T>) {
         childAware.whenChildAttached(child, callback)
     }
 
-    protected fun <T1 : Node, T2 : Node> whenChildrenAttached(
+    protected fun <T1 : Any, T2 : Any> whenChildrenAttached(
         child1: KClass<T1>,
         child2: KClass<T2>,
         callback: ChildrenCallback<T1, T2>
@@ -253,13 +253,13 @@ abstract class ParentNode<NavTarget : Any>(
         childAware.whenChildrenAttached(child1, child2, callback)
     }
 
-    protected inline fun <reified T : Node> whenChildAttached(
+    protected inline fun <reified T : Any> whenChildAttached(
         noinline callback: ChildCallback<T>,
     ) {
         whenChildAttached(T::class, callback)
     }
 
-    protected inline fun <reified T1 : Node, reified T2 : Node> whenChildrenAttached(
+    protected inline fun <reified T1 : Any, reified T2 : Any> whenChildrenAttached(
         noinline callback: ChildrenCallback<T1, T2>,
     ) {
         whenChildrenAttached(T1::class, T2::class, callback)


### PR DESCRIPTION
## Description

ChildAware API should allow any type instead of `Node` subtypes.
The current implementation is too permissive and does not allow to use interfaces as internode communication contract:

```kotlin
interface Child : Connectable<Input, Output> {
  sealed class Input
  sealed class Output
}

// We can't make ChildNode internal like we did in RIBs
class ChildNode(...): Node(...), Child by NodeConnector() {} 
```

```kotlin
// Somewhere in the parent node
whenChildrenAttached<Child>(...) // <-- Can't use Child interface here right now
whenChildrenAttached<ChildNode>(...) // <-- Have to use node instead with much wider public API
```

With this change it is possible to use `Child` interface to setup node connections, but **still impossible** to make `ChildNode` class internal. To do it we need to change `Builder` classes too, either introduce base `Node` interface like `Rib` interface or come up with something else.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
