### PR TITLE
Make interpolator nullable. Fix spotlight crash

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
@@ -7,8 +7,11 @@ import com.bumble.appyx.interactions.core.TransitionModel.SettleDirection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -24,8 +27,10 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
 
     abstract fun ModelState.availableElements(): Set<NavElement<NavTarget>>
 
-    override fun availableElements(): Set<NavElement<NavTarget>> =
-        state.value.currentTargetState.availableElements()
+    override fun availableElements(): StateFlow<Set<NavElement<NavTarget>>> =
+        output
+            .map { it.currentTargetState.availableElements() }
+            .stateIn(scope, SharingStarted.Eagerly, initialState.availableElements())
 
     private val state: MutableStateFlow<Output<ModelState>> by lazy {
         MutableStateFlow(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -252,10 +252,13 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
 
     // TODO plugin?!
     fun destroy() {
+        interpolatorObserverJob?.cancel()
+        screenStateJob.cancel()
         scope.cancel()
     }
 
     fun setNormalisedProgress(progress: Float) {
+
         debug?.setNormalisedProgress(progress)
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -22,10 +22,12 @@ import com.bumble.appyx.interactions.core.ui.UiContext
 import com.bumble.appyx.interactions.core.ui.UiContextAware
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
@@ -44,8 +46,8 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
     private val isDebug: Boolean = false
 ) : Draggable, UiContextAware {
 
-    private var _interpolator: Interpolator<NavTarget, ModelState> =
-        interpolator( UiContext(TransitionBounds(Density(0f), 0, 0), scope))
+    private var interpolatorObserverJob: Job? = null
+    private var _interpolator: Interpolator<NavTarget, ModelState>? = null
 
     private var _gestureFactory: GestureFactory<NavTarget, ModelState> =
         gestureFactory(TransitionBounds(Density(0f), 0, 0))
@@ -69,38 +71,34 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
         gestureFactory = { _gestureFactory }
     )
 
-    val frames: Flow<List<FrameModel<NavTarget>>> =
-        model
-            .output
-            .flatMapLatest { _interpolator.map(it) }
+    private val _frames: MutableStateFlow<List<FrameModel<NavTarget>>> =
+        MutableStateFlow(emptyList())
+    val frames: StateFlow<List<FrameModel<NavTarget>>> = _frames
 
-    val screenState: Flow<ScreenState<NavTarget>> =
-        frames.flatMapLatest { frames ->
-            val frameVisibilityFlows = frames.map { frame ->
-                frame.visibleState
-            }
-            combine(frameVisibilityFlows) { visibilityValues ->
-                val onScreen = mutableSetOf<NavElement<NavTarget>>()
-                val offScreen = mutableSetOf<NavElement<NavTarget>>()
-                visibilityValues.forEachIndexed { index, visibilityValue ->
-                    val navElement = frames[index].navElement
-                    if (visibilityValue) {
-                        onScreen.add(navElement)
-                    } else {
-                        offScreen.add(navElement)
-                    }
+    private var screenStateJob: Job
+    private val _screenState: MutableStateFlow<ScreenState<NavTarget>> =
+        MutableStateFlow(ScreenState(offScreen = model.availableElements().value))
+    val screenState: StateFlow<ScreenState<NavTarget>> = _screenState
+
+
+    init {
+        // before interpolator is ready we consider all nav elements as off screen
+        screenStateJob = scope.launch {
+            model
+                .availableElements()
+                .collect {
+                    _screenState.emit(ScreenState(offScreen = it))
                 }
-                ScreenState(onScreen = onScreen, offScreen = offScreen)
-            }
         }
+    }
 
     private var animationScope: CoroutineScope? = null
     private var isInitialised: Boolean = false
 
-    private fun observeAnimationChanges() {
+    private fun observeAnimationChanges(interpolator: Interpolator<NavTarget, ModelState>) {
         animationChangesJob?.cancel()
         animationChangesJob = scope.launch {
-            _interpolator.isAnimating()
+            interpolator.isAnimating()
                 .collect {
                     if (!it) {
                         Logger.log("InteractionModel", "Finished animating")
@@ -141,27 +139,71 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
     }
 
     override fun updateContext(uiContext: UiContext) {
-        if (this.transitionBounds!=uiContext.transitionBounds){
+        if (this.transitionBounds != uiContext.transitionBounds) {
             this.transitionBounds = uiContext.transitionBounds
             _interpolator = interpolator(uiContext).also {
-                observeAnimationChanges()
+                onInterpolatorReady(it)
             }
             _gestureFactory = gestureFactory(transitionBounds)
         }
     }
 
-    fun availableElements(): Set<NavElement<NavTarget>> = model.availableElements()
+    private fun onInterpolatorReady(interpolator: Interpolator<NavTarget, ModelState>) {
+        observeAnimationChanges(interpolator)
+        observeInterpolator(interpolator)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun observeInterpolator(interpolator: Interpolator<NavTarget, ModelState>) {
+        screenStateJob.cancel()
+        interpolatorObserverJob?.cancel()
+        interpolatorObserverJob = scope.launch {
+            model
+                .output
+                .flatMapLatest { interpolator.mapCore(it) }
+                .flatMapLatest { frames ->
+                    val frameVisibilityFlows = frames.map { frame ->
+                        frame.visibleState
+                    }
+                    combine(frameVisibilityFlows) { visibilityValues ->
+                        val onScreen = mutableSetOf<NavElement<NavTarget>>()
+                        val offScreen = mutableSetOf<NavElement<NavTarget>>()
+                        visibilityValues.forEachIndexed { index, visibilityValue ->
+                            val navElement = frames[index].navElement
+                            if (visibilityValue) {
+                                onScreen.add(navElement)
+                            } else {
+                                offScreen.add(navElement)
+                            }
+                        }
+                        ScreenState(onScreen = onScreen, offScreen = offScreen) to frames
+                    }
+                }
+                .collect { (screenState , frames) ->
+                    // order is important here. We need to report screen state to the ParentNode first
+                    // before frames are consumed by the UI
+                    _screenState.emit(screenState)
+                    _frames.emit(frames)
+                }
+        }
+    }
+
+    fun availableElements(): StateFlow<Set<NavElement<NavTarget>>> = model.availableElements()
 
     fun operation(
         operation: Operation<ModelState>,
         animationSpec: AnimationSpec<Float> = defaultAnimationSpec
     ) {
-       if (operation.mode == IMMEDIATE && animationSpec is SpringSpec<Float>) _interpolator.overrideAnimationSpec(animationSpec)
+        if (operation.mode == IMMEDIATE && animationSpec is SpringSpec<Float>) _interpolator?.overrideAnimationSpec(
+            animationSpec
+        )
         val animatedSource = animated
         val debugSource = debug
         when {
             (isDebug && debugSource != null) -> debugSource.operation(operation)
-            animatedSource == null || DisableAnimations || disableAnimations -> instant.operation(operation)
+            animatedSource == null || DisableAnimations || disableAnimations -> instant.operation(
+                operation
+            )
             else -> animatedSource.operation(operation, animationSpec)
         }
     }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -258,7 +258,6 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
     }
 
     fun setNormalisedProgress(progress: Float) {
-
         debug?.setNormalisedProgress(progress)
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
@@ -19,7 +19,7 @@ interface TransitionModel<NavTarget, ModelState> {
 
     }
 
-    fun availableElements(): Set<NavElement<NavTarget>>
+    fun availableElements(): StateFlow<Set<NavElement<NavTarget>>>
 
     fun onAnimationFinished()
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
@@ -1,13 +1,13 @@
 package com.bumble.appyx.interactions.core.ui
 
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 
 abstract class BaseProps {
 
     private val _visibilityState = MutableStateFlow(true)
-    val visibilityState: Flow<Boolean> = _visibilityState
+    val visibilityState: StateFlow<Boolean> = _visibilityState
 
     protected fun updateVisibilityState() {
         _visibilityState.update {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/FrameModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/FrameModel.kt
@@ -3,7 +3,6 @@ package com.bumble.appyx.interactions.core.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.interactions.core.NavElement
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 data class FrameModel<NavTarget>(
@@ -11,7 +10,7 @@ data class FrameModel<NavTarget>(
     val animationContainer: @Composable () -> Unit,
     val navElement: NavElement<NavTarget>,
     val progress: StateFlow<Float>,
-    val visibleState: Flow<Boolean>
+    val visibleState: StateFlow<Boolean>
 )
 
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -1,11 +1,10 @@
 package com.bumble.appyx.transitionmodel
 
-//import com.bumble.appyx.interactions.Logger
 import DefaultAnimationSpec
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.SpringSpec
-import androidx.compose.runtime.Composable
 import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -118,9 +118,7 @@ class SpotlightSlider<NavTarget : Any>(
         }
 
         // TODO fix with displacement is ready
-        override fun isVisible(): Boolean {
-            return true
-        }
+        override fun isVisible(): Boolean = true
 
         override fun lerpTo(scope: CoroutineScope, start: Props, end: Props, fraction: Float) {
             scope.launch {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -13,7 +13,11 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.core.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.inputsource.Gesture
-import com.bumble.appyx.interactions.core.ui.*
+import com.bumble.appyx.interactions.core.ui.BaseProps
+import com.bumble.appyx.interactions.core.ui.GestureFactory
+import com.bumble.appyx.interactions.core.ui.MatchedProps
+import com.bumble.appyx.interactions.core.ui.TransitionBounds
+import com.bumble.appyx.interactions.core.ui.UiContext
 import com.bumble.appyx.interactions.core.ui.property.Animatable
 import com.bumble.appyx.interactions.core.ui.property.HasModifier
 import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
@@ -115,10 +119,7 @@ class SpotlightSlider<NavTarget : Any>(
 
         // TODO fix with displacement is ready
         override fun isVisible(): Boolean {
-            val currentOffset = (scrollValue() * width.value).dp
-            val visibleRange =
-                currentOffset - activeWindowOffset..currentOffset + activeWindowOffset
-            return offset.value.x in visibleRange
+            return true
         }
 
         override fun lerpTo(scope: CoroutineScope, start: Props, end: Props, fraction: Float) {

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/ParentNode.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/ParentNode.kt
@@ -117,6 +117,11 @@ abstract class ParentNode<NavTarget : Any>(
     override fun updateLifecycleState(state: Lifecycle.State) {
         super.updateLifecycleState(state)
         childNodeLifecycleManager.propagateLifecycleToChildren(state)
+
+        // TODO move to plugins
+        if (state == Lifecycle.State.DESTROYED) {
+            interactionModel.destroy()
+        }
     }
 
     /**

--- a/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/spotlight/SpotlightNode.kt
+++ b/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/spotlight/SpotlightNode.kt
@@ -85,7 +85,7 @@ class SpotlightNode(
     @Composable
     override fun View(modifier: Modifier) {
         Column(
-            modifier =modifier
+            modifier = modifier
                 .fillMaxSize()
                 .background(appyx_dark)
         ) {


### PR DESCRIPTION
## Description

1. Do not create default interpolator with UIContext which doesn't have monotonic frame clock as it leads to sporlight crash 
2. Make interpolator nullable
3. Make sure that screen state is updated before frame state

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
