### PR TITLE
Easing per field

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
@@ -60,17 +60,4 @@ interface Interpolator<NavTarget, ModelState>  {
     fun mapUpdate(
         update: Update<ModelState>
     ): List<FrameModel<NavTarget>>
-
-    // TODO extract along with other interpolation helpers
-    companion object {
-        fun lerpFloat(start: Float, end: Float, progress: Float): Float =
-            start + progress * (end - start)
-
-        fun lerpDpOffset(start: DpOffset, end: DpOffset, progress: Float): DpOffset =
-            DpOffset(lerp(start.x, end.x, progress), lerp(start.y, end.y, progress))
-
-        fun lerpDp(start: Dp, end: Dp, progress: Float): Dp =
-            Dp(lerpFloat(start.value, end.value, progress))
-
-    }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasing.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasing.kt
@@ -19,6 +19,7 @@ class MappedEasing(
 
     override fun transform(fraction: Float): Float =
         when {
+            fraction < 0 -> easing.transform(0f)
             (0f..min).contains(fraction) -> easing.transform(0f)
             (min..max).contains(fraction) -> easing.transform(
                 mapFloat(fraction, min, max, 0f, 1f)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasing.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasing.kt
@@ -1,0 +1,28 @@
+package com.bumble.appyx.interactions.core.ui.easing
+
+import androidx.compose.animation.core.Easing
+import com.bumble.appyx.interactions.core.ui.helper.mapFloat
+
+/**
+ * Expects two params such that: 0 <= min < max <= 1
+ *
+ * Delegates easing transform to the passed in easing, such that:
+ * - In the range [0, min]   – easing will be called with 0
+ * - In the range [min, max] - easing will be called with [0, 1] mapped from this range
+ * - In the range [max, 1]   - easing will be called with 1
+ */
+class MappedEasing(
+    private val min: Float,
+    private val max: Float,
+    private val easing: Easing
+) : Easing {
+
+    override fun transform(fraction: Float): Float =
+        when {
+            (0f..min).contains(fraction) -> easing.transform(0f)
+            (min..max).contains(fraction) -> easing.transform(
+                mapFloat(fraction, min, max, 0f, 1f)
+            )
+            else -> easing.transform(1f)
+        }
+}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Lerp.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Lerp.kt
@@ -1,0 +1,14 @@
+package com.bumble.appyx.interactions.core.ui.helper
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.lerp
+
+fun lerpFloat(start: Float, end: Float, progress: Float): Float =
+    start + progress * (end - start)
+
+fun lerpDpOffset(start: DpOffset, end: DpOffset, progress: Float): DpOffset =
+    DpOffset(lerp(start.x, end.x, progress), lerp(start.y, end.y, progress))
+
+fun lerpDp(start: Dp, end: Dp, progress: Float): Dp =
+    Dp(lerpFloat(start.value, end.value, progress))

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Map.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Map.kt
@@ -1,0 +1,16 @@
+package com.bumble.appyx.interactions.core.ui.helper
+
+
+/**
+ * Maps a value from a range of [min, max] to [destMin, destMax]
+ */
+fun mapFloat(v: Float, min: Float, max: Float, destMin: Float, destMax: Float): Float =
+    lerpFloat(
+        start = destMin,
+        end = destMax,
+        normFloat(
+            v = v.coerceIn(min, max),
+            min = min,
+            max = max
+        )
+    )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Norm.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/helper/Norm.kt
@@ -1,0 +1,10 @@
+package com.bumble.appyx.interactions.core.ui.helper
+
+
+/**
+ * Normalises a value.
+ *
+ * A value on the range of expected [min, max] values will be mapped to [0, 1]
+ */
+fun normFloat(v: Float, min: Float, max: Float): Float =
+    (v - min) / (max - min)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -6,7 +6,7 @@ import androidx.compose.animation.core.Easing
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Alpha(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
@@ -9,9 +10,11 @@ import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Alpha(
-    value: Float
+    value: Float,
+    easing: Easing? = null
 ) : AnimatedProperty<Float, AnimationVector1D>(
-    animatable = Animatable(value)
+    animatable = Animatable(value),
+    easing = easing
 ), Interpolatable<Alpha> {
 
     override val modifier: Modifier
@@ -20,6 +23,12 @@ class Alpha(
         }
 
     override suspend fun lerpTo(start: Alpha, end: Alpha, fraction: Float) {
-        snapTo(lerpFloat(start.value, end.value, fraction))
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
@@ -7,12 +7,13 @@ import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.AnimationVector2D
 import androidx.compose.animation.core.AnimationVector3D
 import androidx.compose.animation.core.AnimationVector4D
-import androidx.compose.runtime.State
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.LinearEasing
 import com.bumble.appyx.interactions.Logger
 import com.bumble.appyx.interactions.core.ui.property.Property
-
 abstract class AnimatedProperty<T, V : AnimationVector>(
-    protected val animatable: Animatable<T, V>
+    protected val animatable: Animatable<T, V>,
+    protected val easing: Easing? = null
 ) : Property<T, V> {
 
     /**
@@ -27,6 +28,16 @@ abstract class AnimatedProperty<T, V : AnimationVector>(
 
     override val value: T
         get() = animatable.value
+
+    /**
+     * Takes the supplied [Easing] as a priority to transform [fraction].
+     * Falls back to using the default [Easing] if a priority wasn't specified.
+     * Falls back to a simple [LinearEasing] if none of those were specified.
+     */
+    fun easingTransform(priority: Easing? = null, fraction: Float): Float {
+        val resolved = priority ?: this.easing ?: LinearEasing
+        return resolved.transform(fraction)
+    }
 
     override suspend fun snapTo(targetValue: T) {
         lastVelocity = calculateVelocity(targetValue)
@@ -116,3 +127,4 @@ abstract class AnimatedProperty<T, V : AnimationVector>(
         internal const val MillisToNanos: Long = 1_000_000L
     }
 }
+

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 import androidx.compose.animation.VectorConverter
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector4D
+import androidx.compose.animation.core.Easing
 import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -11,9 +12,11 @@ import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import androidx.compose.ui.graphics.lerp as lerpColor
 
 class BackgroundColor(
-    value: Color
+    value: Color,
+    easing: Easing? = null
 ) : AnimatedProperty<Color, AnimationVector4D>(
-    animatable = Animatable(value, Color.VectorConverter(value.colorSpace))
+    animatable = Animatable(value, Color.VectorConverter(value.colorSpace)),
+    easing = easing
 ), Interpolatable<BackgroundColor> {
 
     override val modifier: Modifier
@@ -22,7 +25,7 @@ class BackgroundColor(
         }
 
     override suspend fun lerpTo(start: BackgroundColor, end: BackgroundColor, fraction: Float) {
-        snapTo(lerpColor(start.value, end.value, fraction))
+        snapTo(lerpColor(start.value, end.value, easingTransform(end.easing, fraction)))
     }
 
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
@@ -2,12 +2,13 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector2D
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
@@ -17,8 +18,10 @@ import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Offset(
     value: DpOffset,
+    easing: Easing? = null
 ) : AnimatedProperty<DpOffset, AnimationVector2D>(
-    animatable = Animatable(value, DpOffset.VectorConverter)
+    animatable = Animatable(value, DpOffset.VectorConverter),
+    easing = easing
 ), Interpolatable<Offset> {
 
     var displacement: State<DpOffset> =
@@ -43,7 +46,11 @@ class Offset(
         }
 
     override suspend fun lerpTo(start: Offset, end: Offset, fraction: Float) {
-        snapTo(lerpDpOffset(start.value, end.value, fraction))
+        snapTo(lerpDpOffset(
+            start = start.value,
+            end = end.value,
+            progress = easingTransform(end.easing, fraction)
+        ))
     }
 
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpDpOffset
+import com.bumble.appyx.interactions.core.ui.helper.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Offset(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -11,9 +12,11 @@ import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class RotationZ(
-    value: Float
+    value: Float,
+    easing: Easing? = null
 ) : AnimatedProperty<Float, AnimationVector1D>(
-    animatable = Animatable(value, Float.VectorConverter)
+    animatable = Animatable(value, Float.VectorConverter),
+    easing = easing
 ), Interpolatable<RotationZ> {
 
     override val modifier: Modifier
@@ -25,6 +28,10 @@ class RotationZ(
         }
 
     override suspend fun lerpTo(start: RotationZ, end: RotationZ, fraction: Float) {
-        snapTo(lerpFloat(start.value, end.value, fraction))
+        snapTo(lerpFloat(
+            start = start.value,
+            end = end.value,
+            progress = easingTransform(end.easing, fraction)
+        ))
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class RotationZ(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -11,9 +12,11 @@ import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Scale(
-    value: Float
+    value: Float,
+    easing: Easing? = null
 ) : AnimatedProperty<Float, AnimationVector1D>(
-    animatable = Animatable(value, Float.VectorConverter)
+    animatable = Animatable(value, Float.VectorConverter),
+    easing = easing
 ), Interpolatable<Scale> {
 
     override val modifier: Modifier
@@ -23,6 +26,10 @@ class Scale(
         }
 
     override suspend fun lerpTo(start: Scale, end: Scale, fraction: Float) {
-        snapTo(lerpFloat(start.value, end.value, fraction))
+        snapTo(lerpFloat(
+            start = start.value,
+            end = end.value,
+            progress = easingTransform(end.easing, fraction)
+        ))
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class Scale(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.zIndex
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class ZIndex(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -11,9 +12,11 @@ import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
 class ZIndex(
-    value: Float
+    value: Float,
+    easing: Easing? = null
 ) : AnimatedProperty<Float, AnimationVector1D>(
-    animatable = Animatable(value, Float.VectorConverter)
+    animatable = Animatable(value, Float.VectorConverter),
+    easing = easing
 ), Interpolatable<ZIndex> {
 
     override val modifier: Modifier
@@ -23,6 +26,10 @@ class ZIndex(
         }
 
     override suspend fun lerpTo(start: ZIndex, end: ZIndex, fraction: Float) {
-        snapTo(lerpFloat(start.value, end.value, fraction))
+        snapTo(lerpFloat(
+            start = start.value,
+            end = end.value,
+            progress = easingTransform(end.easing, fraction)
+        ))
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -1,6 +1,5 @@
 package com.bumble.appyx.transitionmodel
 
-//import com.bumble.appyx.interactions.Logger
 import DefaultAnimationSpec
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.SpringSpec
@@ -16,6 +15,7 @@ import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.FrameModel
 import com.bumble.appyx.interactions.core.ui.Interpolator
 import com.bumble.appyx.interactions.core.ui.MatchedProps
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Animatable
 import com.bumble.appyx.interactions.core.ui.property.HasModifier
 import kotlinx.coroutines.CoroutineScope
@@ -205,7 +205,7 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
         // will be different for the targetValue.
         // This means that the Segment was specifically created to interpolate the geometry value (probably a gesture)
         // and that it's important to follow the interpolation by snapping.
-        else GeometryBehaviour.SNAP to Interpolator.lerpFloat(fromValue, targetValue, segmentProgress)
+        else GeometryBehaviour.SNAP to lerpFloat(fromValue, targetValue, segmentProgress)
     }
 
     private enum class GeometryBehaviour {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.core.Segment
 import com.bumble.appyx.interactions.core.Update
 import com.bumble.appyx.interactions.core.ui.*
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.transitionmodel.promoter.PromoterModel
 import com.bumble.appyx.transitionmodel.promoter.PromoterModel.State.ElementState
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightFader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightFader.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.Update
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.FrameModel
 import com.bumble.appyx.interactions.core.ui.Interpolator
-import com.bumble.appyx.interactions.core.ui.Interpolator.Companion.lerpFloat
+import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.TransitionParams
 import com.bumble.appyx.interactions.core.ui.property.impl.Alpha

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasingTest.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/ui/easing/MappedEasingTest.kt
@@ -1,0 +1,90 @@
+package com.bumble.appyx.interactions.core.ui.easing
+
+import androidx.compose.animation.core.LinearEasing
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class MappedEasingTest {
+
+    companion object {
+        private const val lt_min = 0.2f
+        private const val min = 0.6f
+        private const val halfway_min_max = 0.7f
+        private const val max = 0.8f
+        private const val gt_max = 0.9f
+    }
+
+    private val mappedEasing = MappedEasing(
+        min = min,
+        max = max,
+        easing = LinearEasing
+    )
+
+    @Test
+    fun WHEN_fraction_negative_THEN_easing_invoked_with_0() {
+        val actual = mappedEasing.transform(-1f)
+        val expected = 0f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_0_THEN_easing_invoked_with_0() {
+        val actual = mappedEasing.transform(0f)
+        val expected = 0f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_less_than_min_THEN_easing_invoked_with_0() {
+        val actual = mappedEasing.transform(lt_min)
+        val expected = 0f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_equals_min_THEN_easing_invoked_with_0() {
+        val actual = mappedEasing.transform(min)
+        val expected = 0f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_between_min_max_THEN_easing_invoked_with_mapped_value() {
+        val actual = mappedEasing.transform(halfway_min_max)
+        val expected = 0.5f
+        val diff = abs(actual - expected)
+        val tolerance = 0.0001f
+
+        assertTrue(diff < tolerance)
+    }
+
+    @Test
+    fun WHEN_fraction_equals_max_THEN_easing_invoked_with_1f() {
+        val actual = mappedEasing.transform(max)
+        val expected = 1f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_greater_than_max_THEN_easing_invoked_with_1f() {
+        val actual = mappedEasing.transform(gt_max)
+        val expected = 1f
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun WHEN_fraction_greater_than_1_THEN_easing_invoked_with_1f() {
+        val actual = mappedEasing.transform(2f)
+        val expected = 1f
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
1. Allows easing to be used when interpolating progress. Easing can be defined per property field.
2. Easing can be set globally (if applied on default props), or per target props; if none set, `LinearEasing` will be used as a fallback
3. Added a `MappedEasing` class that allows to use any `Easing` as a step function on a subrange of the total progress. See attached video that demonstrates a `MappedEasing(0.4f, 0.6f, LinearEasing)` on color change, while offset change is left with unspecified easing (hence linear). This should allow easy implementation of material design specs for container transitions, where fade and move are done with different timings and easing curves.


https://user-images.githubusercontent.com/238198/218845800-7f9548f5-a12e-4a2d-b5d6-90eb907cc5e1.mp4

