### PR TITLE
Fix accidentally overriding animation spec

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -192,7 +192,7 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
 
     fun operation(
         operation: Operation<ModelState>,
-        animationSpec: AnimationSpec<Float> = defaultAnimationSpec
+        animationSpec: AnimationSpec<Float>? = null
     ) {
         if (operation.mode == IMMEDIATE && animationSpec is SpringSpec<Float>) _interpolator?.overrideAnimationSpec(
             animationSpec
@@ -204,7 +204,7 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
             animatedSource == null || DisableAnimations || disableAnimations -> instant.operation(
                 operation
             )
-            else -> animatedSource.operation(operation, animationSpec)
+            else -> animatedSource.operation(operation, animationSpec ?: defaultAnimationSpec)
         }
     }
 


### PR DESCRIPTION
Fix accidentally overriding animation spec in ui with default spec of progress.

Before the fix:
`overrideAnimationSpec` passes `animationSpec` that if wasn't specified from client code, will immediately override the default spec in ui with the progress spec.

After the fix:
`overrideAnimationSpec` passes `animationSpec` – and if it was left `null`, it won't override in the interpolator, so it can use its own default