### PR TITLE
Introduced RetainedInstanceStore to keep data during config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending changes
 
+- [#361](https://github.com/bumble-tech/appyx/pull/361) – **Added**: Introduced `RetainedInstanceStore`. This provides developers the ability to retain objects between configuration changes.
 - [#336](https://github.com/bumble-tech/appyx/pulls/336) – **Updated**: ChildAware API does not enforce Node subtypes only anymore, making it possible to use interfaces as public contracts for child nodes.
 
 ---

--- a/documentation/apps/configuration.md
+++ b/documentation/apps/configuration.md
@@ -1,0 +1,49 @@
+# Configuration change
+
+To retain objects during configuration change you can use the `RetainedInstanceStore` class.
+
+## How does it work?
+
+The `RetainedInstanceStore` stores the objects within a singleton. The node manages whether the content should be removed by checking whether the `Activity` is being recreated due to a configuration change or not.
+
+These are the following scenarios:
+- If the `Activity` is recreated: the retained instance is returned instead of a new instance.
+- If the `Activity` is destroyed: the retained instance is removed and disposed.
+
+## Example
+
+Here is an example of how you can use the `RetainedInstanceStore`:
+
+```kotlin
+import com.bumble.appyx.core.builder.Builder
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.store.getRetainedInstance
+import com.bumble.appyx.interop.rx2.store.getRetainedDisposable
+
+class RetainedInstancesBuilder : Builder<String>() {
+
+    override fun build(buildContext: BuildContext, payload: String): Node {
+        val retainedNonDisposable = buildContext.getRetainedInstance(
+            factory = { NonDisposableClass(payload) },
+            disposer = { feature.cleanUp() }
+        ) 
+        val retainedFeature = buildContext.getRetainedDisposable {
+            RetainedInstancesFeature(payload)
+        }
+
+        val view = RetainedInstancesViewImpl()
+        val interactor = RetainedInstancesInteractor(
+            feature = retainedFeature,
+            nonDisposable = retainedNonDisposable,
+            view = view
+        )
+
+        return RetainedInstancesNode(
+            buildContext = buildContext,
+            view = view,
+            plugins = listOf(interactor)
+        )
+    }
+}
+```

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/RetainedInstanceStoreTest.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/RetainedInstanceStoreTest.kt
@@ -1,0 +1,137 @@
+package com.bumble.appyx.core.node
+
+import androidx.lifecycle.Lifecycle
+import com.bumble.appyx.core.AppyxTestScenario
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.store.RetainedInstanceStore
+import com.bumble.appyx.core.store.getRetainedInstance
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class RetainedInstanceStoreTest {
+    private val stubRetainedInstanceStore = StubRetainedInstanceStore()
+    private var beforeNodeCreatedFunc: ((BuildContext) -> Unit)? = null
+
+    @get:Rule
+    val rule = AppyxTestScenario { buildContext ->
+        beforeNodeCreatedFunc?.invoke(buildContext)
+        TestParentNode(buildContext, stubRetainedInstanceStore)
+    }
+
+    @Test
+    fun WHEN_activity_finished_THEN_retained_instance_store_content_is_removed() {
+        rule.start()
+
+        rule.activityScenario.moveToState(Lifecycle.State.DESTROYED)
+
+        assertTrue(stubRetainedInstanceStore.clearStoreCalled)
+    }
+
+    @Test
+    fun WHEN_activity_recreated_THEN_retained_instance_store_content_is_not_removed() {
+        rule.start()
+
+        rule.activityScenario.recreate()
+
+        assertFalse(stubRetainedInstanceStore.clearStoreCalled)
+    }
+
+    @Test
+    fun GIVEN_counter_stored_and_incremented_AND_activity_finished_WHEN_stored_counter_incremented_THEN_counter_value_is_1() {
+        var nodeBuildInvocationCount = 0
+        var factoryInvocationCount = 0
+        var disposerCalled = false
+        var buildContext: BuildContext? = null
+
+        val getRetainedCounterFunc = {
+            requireNotNull(buildContext) { "Build context not set" }
+                .getRetainedInstance(
+                    disposer = {
+                        disposerCalled = true
+                    },
+                    factory = {
+                        factoryInvocationCount++
+                        Counter()
+                    }
+                )
+        }
+        beforeNodeCreatedFunc = {
+            buildContext = it
+            nodeBuildInvocationCount++
+        }
+        rule.start()
+        getRetainedCounterFunc().increment()
+        rule.activityScenario.moveToState(Lifecycle.State.DESTROYED)
+
+        getRetainedCounterFunc().increment()
+
+        assertEquals(1, getRetainedCounterFunc().value)
+        assertEquals(1, nodeBuildInvocationCount)
+        assertEquals(2, factoryInvocationCount)
+        assertTrue(disposerCalled)
+    }
+
+    @Test
+    fun GIVEN_counter_stored_and_incremented_AND_activity_recreated_WHEN_stored_counter_incremented_THEN_counter_value_is_2() {
+        var nodeBuildInvocationCount = 0
+        var factoryInvocationCount = 0
+        var disposerCalled = false
+        var buildContext: BuildContext? = null
+
+        val getRetainedCounterFunc = {
+            requireNotNull(buildContext) { "Build context not set" }
+                .getRetainedInstance(
+                    disposer = {
+                        disposerCalled = true
+                    },
+                    factory = {
+                        factoryInvocationCount++
+                        Counter()
+                    }
+                )
+        }
+        beforeNodeCreatedFunc = {
+            buildContext = it
+            nodeBuildInvocationCount++
+        }
+        rule.start()
+        getRetainedCounterFunc().increment()
+        rule.activityScenario.recreate()
+
+        getRetainedCounterFunc().increment()
+
+        assertEquals(2, getRetainedCounterFunc().value)
+        assertEquals(2, nodeBuildInvocationCount)
+        assertEquals(1, factoryInvocationCount)
+        assertFalse(disposerCalled)
+    }
+
+    class Counter {
+        var value: Int = 0
+            private set
+
+        fun increment() {
+            value++
+        }
+    }
+
+    class TestParentNode(
+        buildContext: BuildContext,
+        retainedInstanceStore: RetainedInstanceStore,
+    ) : Node(
+        buildContext = buildContext,
+        retainedInstanceStore = retainedInstanceStore,
+    )
+
+    class StubRetainedInstanceStore : RetainedInstanceStore by RetainedInstanceStore {
+        var clearStoreCalled: Boolean = false
+
+        override fun clearStore(storeId: String) {
+            clearStoreCalled = true
+            RetainedInstanceStore.clearStore(storeId)
+        }
+    }
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/ActivityIntegrationPoint.kt
@@ -23,6 +23,9 @@ open class ActivityIntegrationPoint(
     override val permissionRequester: PermissionRequester
         get() = permissionRequestBoundary
 
+    override val isChangingConfigurations: Boolean
+        get() = activity.isChangingConfigurations
+
     fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         activityBoundary.onActivityResult(requestCode, resultCode, data)
     }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPoint.kt
@@ -18,6 +18,8 @@ abstract class IntegrationPoint(
 
     abstract val permissionRequester: PermissionRequester
 
+    abstract val isChangingConfigurations: Boolean
+
     fun onSaveInstanceState(outState: Bundle) {
         requestCodeRegistry.onSaveInstanceState(outState)
     }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/integrationpoint/IntegrationPointStub.kt
@@ -18,6 +18,9 @@ class IntegrationPointStub : IntegrationPoint(savedInstanceState = null) {
     override val permissionRequester: PermissionRequester
         get() = error(ERROR)
 
+    override val isChangingConfigurations: Boolean
+        get() = false
+
     override fun handleUpNavigation() {
         error(ERROR)
     }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/modality/BuildContext.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/modality/BuildContext.kt
@@ -1,9 +1,11 @@
 package com.bumble.appyx.core.modality
 
+import com.bumble.appyx.core.state.MutableSavedStateMap
+import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.utils.customisations.NodeCustomisation
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectory
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl
-import com.bumble.appyx.core.state.SavedStateMap
+import java.util.UUID
 
 data class BuildContext(
     val ancestryInfo: AncestryInfo,
@@ -11,6 +13,8 @@ data class BuildContext(
     val customisations: NodeCustomisationDirectory,
 ) {
     companion object {
+        private const val IDENTIFIER_KEY = "build.context.identifier"
+
         fun root(
             savedStateMap: SavedStateMap?,
             customisations: NodeCustomisationDirectory = NodeCustomisationDirectoryImpl()
@@ -22,6 +26,18 @@ data class BuildContext(
             )
     }
 
-    fun <T : NodeCustomisation> getOrDefault(defaultCustomisation: T) : T =
+    val identifier: String by lazy {
+        if (savedStateMap == null) {
+            UUID.randomUUID().toString()
+        } else {
+            savedStateMap[IDENTIFIER_KEY] as String? ?: error("onSaveInstanceState() was not called")
+        }
+    }
+
+    fun <T : NodeCustomisation> getOrDefault(defaultCustomisation: T): T =
         customisations.getRecursivelyOrDefault(defaultCustomisation)
+
+    fun onSaveInstanceState(state: MutableSavedStateMap) {
+        state[IDENTIFIER_KEY] = identifier
+    }
 }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStore.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStore.kt
@@ -1,0 +1,35 @@
+package com.bumble.appyx.core.store
+
+/**
+ * A simple storage to preserve any objects during configuration change events.
+ * `factory` function will be invoked immediately on the same thread
+ * only if an object of the same class within the same Node does not exist.
+ *
+ * The framework will manage the lifecycle of provided objects
+ * and invoke `disposer` function to destroy objects properly.
+ *
+ * Sample usage:
+ * ```kotlin
+ * val feature = RetainedInstanceStore.get(
+ *     storeId = buildContext.identifier,
+ *     factory = { FeatureImpl() },
+ *     disposer = { feature.dispose() }
+ * }
+ * ```
+ * or
+ *  * ```kotlin
+ *  * val feature = buildContext.getRetainedInstance(
+ *  *     factory = { FeatureImpl() },
+ *  *     disposer = { feature.dispose() }
+ *  * }
+ *  * ```
+ */
+interface RetainedInstanceStore {
+
+    fun <T : Any> get(storeId: String, key: String, disposer: (T) -> Unit = {}, factory: () -> T): T
+
+    fun clearStore(storeId: String)
+
+    companion object : RetainedInstanceStore by RetainedInstanceStoreImpl()
+
+}

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreExt.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreExt.kt
@@ -1,0 +1,50 @@
+package com.bumble.appyx.core.store
+
+import com.bumble.appyx.core.modality.BuildContext
+
+/**
+ * Obtains or creates an instance of a class using the class name as the key.
+ * If you need multiple instances of an object with the same key, do not use this extension.
+ */
+inline fun <reified T : Any> RetainedInstanceStore.get(
+    storeId: String,
+    noinline disposer: (T) -> Unit = {},
+    noinline factory: () -> T
+): T =
+    get(
+        storeId = storeId,
+        key = T::class.java.name,
+        disposer = disposer,
+        factory = factory
+    )
+
+/**
+ * Obtains or creates an instance of a class using the class name as the key, and uses the
+ * identifier from the BuildContext.
+ *
+ * If you need multiple instances of an object with the same key, do not use this extension.
+ */
+inline fun <reified T : Any> BuildContext.getRetainedInstance(
+    noinline disposer: (T) -> Unit = {},
+    noinline factory: () -> T
+) =
+    RetainedInstanceStore.get(
+        storeId = identifier,
+        disposer = disposer,
+        factory = factory
+    )
+
+/**
+ * Obtains or creates an instance of a class using the identifier from the BuildContext.
+ */
+inline fun <reified T : Any> BuildContext.getRetainedInstance(
+    key: String,
+    noinline disposer: (T) -> Unit = {},
+    noinline factory: () -> T
+) =
+    RetainedInstanceStore.get(
+        storeId = identifier,
+        key = key,
+        disposer = disposer,
+        factory = factory
+    )

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreImpl.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreImpl.kt
@@ -1,0 +1,26 @@
+package com.bumble.appyx.core.store
+
+internal class RetainedInstanceStoreImpl : RetainedInstanceStore {
+
+    private val map: MutableMap<String, MutableMap<String, ValueHolder<*>>> = HashMap()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> get(storeId: String, key: String, disposer: (T) -> Unit, factory: () -> T): T =
+        map
+            .getOrPut(storeId) { HashMap() }
+            .getOrPut(key) { ValueHolder(factory(), disposer) }
+            .value as T
+
+    override fun clearStore(storeId: String) {
+        map.remove(storeId)?.values?.forEach { it.dispose() }
+    }
+
+    private class ValueHolder<T : Any>(
+        val value: T,
+        private val disposer: (T) -> Unit
+    ) {
+        fun dispose() {
+            disposer(value)
+        }
+    }
+}

--- a/libraries/core/src/test/kotlin/com/bumble/appyx/core/node/NodeTest.kt
+++ b/libraries/core/src/test/kotlin/com/bumble/appyx/core/node/NodeTest.kt
@@ -1,9 +1,13 @@
 package com.bumble.appyx.core.node
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.NodeTest.TestNode.Companion.StatusExecuted
+import com.bumble.appyx.core.store.RetainedInstanceStore
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
+import com.bumble.appyx.testing.unit.common.util.TestIntegrationPoint
+import com.bumble.appyx.testing.unit.common.util.TestUpNavigationHandler
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -23,11 +27,12 @@ class NodeTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val testScope = TestScope(UnconfinedTestDispatcher())
+    private val retainedInstanceStore: RetainedInstanceStoreStub = RetainedInstanceStoreStub()
 
     @Test
     fun `executeWorkflow WHEN called THEN executes action returns current node`() =
         testScope.runTest {
-            val node = TestNode()
+            val node = TestNode(retainedInstanceStore)
             assertNull(node.status)
 
             node.changeStatus()
@@ -35,8 +40,42 @@ class NodeTest {
             assertEquals(node.status, StatusExecuted)
         }
 
+    @Test
+    fun `When node is destroyed AND not changing configurations THEN RetainedInstanceStore cleared`() =
+        testScope.runTest {
+            val node = TestNode(retainedInstanceStore)
+            node.integrationPoint = TestIntegrationPoint(
+                upNavigationHandler = TestUpNavigationHandler(),
+                isChangingConfigurations = false
+            )
+            node.onBuilt()
+            node.updateLifecycleState(Lifecycle.State.CREATED)
 
-    private class TestNode : Node(BuildContext.root(null)) {
+            node.updateLifecycleState(Lifecycle.State.DESTROYED)
+
+            assertEquals(node.id, retainedInstanceStore.clearStoreId)
+        }
+
+    @Test
+    fun `When node is destroyed AND changing configurations THEN RetainedInstanceStore not cleared`() =
+        testScope.runTest {
+            val node = TestNode(retainedInstanceStore)
+            node.integrationPoint = TestIntegrationPoint(
+                upNavigationHandler = TestUpNavigationHandler(),
+                isChangingConfigurations = true
+            )
+            node.onBuilt()
+            node.updateLifecycleState(Lifecycle.State.CREATED)
+
+            node.updateLifecycleState(Lifecycle.State.DESTROYED)
+
+            assertEquals(null, retainedInstanceStore.clearStoreId)
+        }
+
+    private class TestNode(retainedInstanceStore: RetainedInstanceStore) : Node(
+        buildContext = BuildContext.root(null),
+        retainedInstanceStore = retainedInstanceStore,
+    ) {
 
         var status: String? = null
             private set
@@ -51,5 +90,17 @@ class NodeTest {
             const val StatusExecuted = "executed"
         }
 
+    }
+
+    private class RetainedInstanceStoreStub : RetainedInstanceStore {
+        var clearStoreId: String? = null
+
+        override fun <T : Any> get(storeId: String, key: String, disposer: (T) -> Unit, factory: () -> T): T {
+            error("Not needed for this test")
+        }
+
+        override fun clearStore(storeId: String) {
+            clearStoreId = storeId
+        }
     }
 }

--- a/libraries/core/src/test/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreTest.kt
+++ b/libraries/core/src/test/kotlin/com/bumble/appyx/core/store/RetainedInstanceStoreTest.kt
@@ -1,0 +1,84 @@
+package com.bumble.appyx.core.store
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RetainedInstanceStoreTest {
+
+    private val identifier = "identifier"
+    private val store = RetainedInstanceStoreImpl()
+
+    @Test
+    fun `GIVEN object stored WHEN get with same identifier THEN same instance is retrieved`() {
+        val obj = Any()
+        store.get(identifier) { obj }
+
+        val retrieved = store.get(identifier) { Any() }
+
+        assertSame(obj, retrieved)
+    }
+
+    @Test
+    fun `GIVEN object stored WHEN get with same identifier THEN factory not called`() {
+        var factoryCalled = false
+        store.get(identifier) { Any() }
+
+        store.get(identifier) {
+            factoryCalled = true
+            Any()
+        }
+
+        assertFalse(factoryCalled)
+    }
+
+    @Test
+    fun `GIVEN two objects with different types stored WHEN get with same identifier THEN both objects returned`() {
+        store.get(identifier) { 1 }
+        store.get(identifier) { 2L }
+
+        val integerValue = store.get(identifier) { 5 }
+        val longValue = store.get(identifier) { 6L }
+
+        assertEquals(1, integerValue)
+        assertEquals(2L, longValue)
+    }
+
+    @Test
+    fun `GIVEN two objects stored with same type AND different keys WHEN get with same identifier THEN both objects returned`() {
+        store.get(storeId = identifier, key = "1") { 1 }
+        store.get(storeId = identifier, key = "2") { 2 }
+
+        val integerValue1 = store.get(storeId = identifier, key = "1") { 5 }
+        val integerValue2 = store.get(storeId = identifier, key = "2") { 6L }
+
+        assertEquals(1, integerValue1)
+        assertEquals(2, integerValue2)
+    }
+
+    @Test
+    fun `GIVEN object stored WHEN clearStore with same identifier THEN object is disposed`() {
+        val obj = Any()
+        var disposed = false
+        store.get(identifier, disposer = { disposed = true }) { obj }
+
+        store.clearStore(identifier)
+
+        assertTrue(disposed)
+    }
+
+    @Test
+    fun `GIVEN object stored WHEN clearStore with different identifier THEN object is not disposed`() {
+        val obj = Any()
+        val otherIdentifier = "other"
+        var disposed = false
+        store.get(identifier) { obj }
+        store.get(otherIdentifier, disposer = { disposed = true }) { obj }
+
+        store.clearStore(identifier)
+
+        assertFalse(disposed)
+    }
+}

--- a/libraries/interop-rx2/src/main/kotlin/com/bumble/appyx/interop/rx2/store/RetainedInstanceStoreExt.kt
+++ b/libraries/interop-rx2/src/main/kotlin/com/bumble/appyx/interop/rx2/store/RetainedInstanceStoreExt.kt
@@ -1,0 +1,42 @@
+package com.bumble.appyx.interop.rx2.store
+
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.store.RetainedInstanceStore
+import com.bumble.appyx.core.store.get
+import com.bumble.appyx.core.store.getRetainedInstance
+import io.reactivex.disposables.Disposable
+
+/**
+ * Obtains or creates an instance of a class via the [get] extension.
+ * The disposable will be disposed when the disposer function is called.
+ */
+inline fun <reified T : Disposable> RetainedInstanceStore.getDisposable(
+    storeId: String,
+    noinline factory: () -> T
+): T =
+    get(
+        storeId = storeId,
+        disposer = { it.dispose() },
+        factory = factory
+    )
+
+/**
+ * Obtains or creates an instance of a class via the [getRetainedInstance] extension.
+ * The disposable will be disposed when the disposer function is called.
+ *
+ * If you need multiple instances of an object with the same key, do not use this extension.
+ */
+inline fun <reified T : Disposable> BuildContext.getRetainedDisposable(
+    noinline factory: () -> T
+) =
+    getRetainedInstance(disposer = { it.dispose() }, factory = factory)
+
+/**
+ * Obtains or creates an instance of a class via the [getRetainedInstance] extension.
+ * The disposable will be disposed when the disposer function is called.
+ */
+inline fun <reified T : Disposable> BuildContext.getRetainedDisposable(
+    key: String,
+    noinline factory: () -> T
+) =
+    getRetainedInstance(key = key, disposer = { it.dispose() }, factory = factory)

--- a/libraries/interop-rx3/src/main/kotlin/com/bumble/appyx/interop/rx3/store/RetainedInstanceStoreExt.kt
+++ b/libraries/interop-rx3/src/main/kotlin/com/bumble/appyx/interop/rx3/store/RetainedInstanceStoreExt.kt
@@ -1,0 +1,42 @@
+package com.bumble.appyx.interop.rx3.store
+
+import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.store.RetainedInstanceStore
+import com.bumble.appyx.core.store.get
+import com.bumble.appyx.core.store.getRetainedInstance
+import io.reactivex.rxjava3.disposables.Disposable
+
+/**
+ * Obtains or creates an instance of a class via the [get] extension.
+ * The disposable will be disposed when the disposer function is called.
+ */
+inline fun <reified T : Disposable> RetainedInstanceStore.getDisposable(
+    storeId: String,
+    noinline factory: () -> T
+): T =
+    get(
+        storeId = storeId,
+        disposer = { it.dispose() },
+        factory = factory
+    )
+
+/**
+ * Obtains or creates an instance of a class via the [getRetainedInstance] extension.
+ * The disposable will be disposed when the disposer function is called.
+ *
+ * If you need multiple instances of an object with the same key, do not use this extension.
+ */
+inline fun <reified T : Disposable> BuildContext.getRetainedDisposable(
+    noinline factory: () -> T
+) =
+    getRetainedInstance(disposer = { it.dispose() }, factory = factory)
+
+/**
+ * Obtains or creates an instance of a class via the [getRetainedInstance] extension.
+ * The disposable will be disposed when the disposer function is called.
+ */
+inline fun <reified T : Disposable> BuildContext.getRetainedDisposable(
+    key: String,
+    noinline factory: () -> T
+) =
+    getRetainedInstance(key = key, disposer = { it.dispose() }, factory = factory)

--- a/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/TestIntegrationPoint.kt
+++ b/libraries/testing-unit-common/src/main/kotlin/com/bumble/appyx/testing/unit/common/util/TestIntegrationPoint.kt
@@ -6,7 +6,8 @@ import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequ
 import com.bumble.appyx.core.navigation.upnavigation.UpNavigationHandler
 
 class TestIntegrationPoint(
-    private val upNavigationHandler: UpNavigationHandler
+    private val upNavigationHandler: UpNavigationHandler,
+    override val isChangingConfigurations: Boolean = false
 ) : IntegrationPoint(savedInstanceState = null), UpNavigationHandler by upNavigationHandler {
 
     var rootFinished: Boolean = false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Lifecycle: apps/lifecycle.md
       - Plugins: apps/plugins.md
       - ChildAware API: apps/childaware.md
+      - Configuration changes: apps/configuration.md
   - FAQ: faq.md
 
 

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/container/ContainerNode.kt
@@ -35,6 +35,8 @@ import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.Blocker
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.Customisations
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.IntegrationPointExample
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.LazyExamples
+import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.MviCoreExample
+import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.MviCoreLeafExample
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.NavModelExamples
 import com.bumble.appyx.sandbox.client.container.ContainerNode.NavTarget.Picker
 import com.bumble.appyx.sandbox.client.customisations.CustomisationsNode
@@ -42,6 +44,8 @@ import com.bumble.appyx.sandbox.client.explicitnavigation.ExplicitNavigationExam
 import com.bumble.appyx.sandbox.client.integrationpoint.IntegrationPointExampleNode
 import com.bumble.appyx.sandbox.client.interop.InteropExampleActivity
 import com.bumble.appyx.sandbox.client.list.LazyListContainerNode
+import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleBuilder
+import com.bumble.appyx.sandbox.client.mvicoreexample.leaf.MviCoreLeafBuilder
 import com.bumble.appyx.sandbox.client.navmodels.NavModelExamplesNode
 import com.bumble.appyx.utils.customisations.NodeCustomisation
 import kotlinx.parcelize.Parcelize
@@ -79,6 +83,12 @@ class ContainerNode internal constructor(
 
         @Parcelize
         object Customisations : NavTarget()
+
+        @Parcelize
+        object MviCoreExample : NavTarget()
+
+        @Parcelize
+        object MviCoreLeafExample : NavTarget()
     }
 
     @Suppress("ComplexMethod")
@@ -90,6 +100,11 @@ class ContainerNode internal constructor(
             is IntegrationPointExample -> IntegrationPointExampleNode(buildContext)
             is BlockerExample -> BlockerExampleNode(buildContext)
             is Customisations -> CustomisationsNode(buildContext)
+            is MviCoreExample -> MviCoreExampleBuilder().build(buildContext, "MVICore initial state")
+            is MviCoreLeafExample -> MviCoreLeafBuilder().build(
+                buildContext,
+                "MVICore leaf initial state"
+            )
         }
 
     @Composable
@@ -139,6 +154,8 @@ class ContainerNode internal constructor(
                 }
                 TextButton("Lazy Examples") { backStack.push(LazyExamples) }
                 TextButton("Blocker") { backStack.push(BlockerExample) }
+                TextButton("MVICore Example") { backStack.push(MviCoreExample) }
+                TextButton("MVICore Leaf Example") { backStack.push(MviCoreLeafExample) }
             }
         }
     }

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleBuilder.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleBuilder.kt
@@ -3,7 +3,7 @@ package com.bumble.appyx.sandbox.client.mvicoreexample
 import com.bumble.appyx.core.builder.Builder
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.plugin.disposeOnDestroyPlugin
+import com.bumble.appyx.interop.rx2.store.getRetainedDisposable
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget.Child1
@@ -12,7 +12,9 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeat
 class MviCoreExampleBuilder : Builder<String>() {
 
     override fun build(buildContext: BuildContext, payload: String): Node {
-        val feature = MviCoreExampleFeature(payload)
+        val feature = buildContext.getRetainedDisposable {
+            MviCoreExampleFeature(payload)
+        }
 
         val backStack = BackStack<NavTarget>(
             initialElement = Child1,
@@ -29,7 +31,7 @@ class MviCoreExampleBuilder : Builder<String>() {
             buildContext = buildContext,
             backStack = backStack,
             view = view,
-            plugins = listOf(interactor, disposeOnDestroyPlugin(feature))
+            plugins = listOf(interactor)
         )
     }
 }

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafBuilder.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafBuilder.kt
@@ -3,13 +3,15 @@ package com.bumble.appyx.sandbox.client.mvicoreexample.leaf
 import com.bumble.appyx.core.builder.Builder
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.plugin.disposeOnDestroyPlugin
+import com.bumble.appyx.interop.rx2.store.getRetainedDisposable
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature
 
 class MviCoreLeafBuilder : Builder<String>() {
 
     override fun build(buildContext: BuildContext, payload: String): Node {
-        val feature = MviCoreExampleFeature(payload)
+        val feature = buildContext.getRetainedDisposable {
+            MviCoreExampleFeature(payload)
+        }
         val view = MviCoreLeafViewImpl()
         val interactor = MviCoreLeafInteractor(
             view = view,
@@ -19,7 +21,7 @@ class MviCoreLeafBuilder : Builder<String>() {
         return MviCoreLeafNode(
             buildContext = buildContext,
             view = view,
-            plugins = listOf(interactor, disposeOnDestroyPlugin(feature))
+            plugins = listOf(interactor)
         )
     }
 }


### PR DESCRIPTION
## Description
Copied the RetainedInstanceStore concept from RIBs so that objects can be retained during a configuration change.

Also re-added the MVICore screens to the sandbox to demonstrate the behaviour

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
