### PR TITLE
Cleanup destroyed elements when animation is finished

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
@@ -49,13 +49,13 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
 
     private var enforcedMode: Operation.Mode? = null
 
-    override fun onAnimationFinished() {
+    override fun relaxExecutionMode() {
         Logger.log("BaseTransitionModel", "Relaxing mode")
         enforcedMode = null
         removeDestroyedElements()
     }
 
-    override fun onAnimationFinished(navElement: NavElement<NavTarget>) {
+    override fun cleanUpElement(navElement: NavElement<NavTarget>) {
         state.getAndUpdate { output ->
             when (output) {
                 is Update<ModelState> -> output.copy(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/BaseTransitionModel.kt
@@ -25,6 +25,8 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
 
     abstract fun ModelState.removeDestroyedElements(): ModelState
 
+    abstract fun ModelState.removeDestroyedElement(navElement: NavElement<NavTarget>): ModelState
+
     abstract fun ModelState.availableElements(): Set<NavElement<NavTarget>>
 
     override fun availableElements(): StateFlow<Set<NavElement<NavTarget>>> =
@@ -51,6 +53,17 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
         Logger.log("BaseTransitionModel", "Relaxing mode")
         enforcedMode = null
         removeDestroyedElements()
+    }
+
+    override fun onAnimationFinished(navElement: NavElement<NavTarget>) {
+        state.getAndUpdate { output ->
+            when (output) {
+                is Update<ModelState> -> output.copy(
+                    currentTargetState = output.currentTargetState.removeDestroyedElement(navElement)
+                )
+                is Keyframes -> output
+            }
+        }
     }
 
     private fun removeDestroyedElements() {
@@ -101,7 +114,8 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
         return when (val currentState = state.value) {
             is Keyframes -> {
                 with(currentState) {
-                    val past = if (currentIndex > 0) queue.subList(0, currentIndex - 1) else emptyList()
+                    val past =
+                        if (currentIndex > 0) queue.subList(0, currentIndex - 1) else emptyList()
                     val remaining = queue.subList(currentIndex, queue.lastIndex + 1)
 
                     if (remaining.all { operation.isApplicable(it.targetState) }) {
@@ -122,7 +136,10 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
                         updateState(newState)
                         true
                     } else {
-                        Logger.log(TAG, "Operation $operation is not applicable on one or more queued states: $remaining")
+                        Logger.log(
+                            TAG,
+                            "Operation $operation is not applicable on one or more queued states: $remaining"
+                        )
                         false
                     }
                 }
@@ -135,7 +152,10 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
                     updateState(newState)
                     true
                 }
-                Logger.log(TAG, "Operation $operation is not applicable on states: $currentState.currentTargetState")
+                Logger.log(
+                    TAG,
+                    "Operation $operation is not applicable on states: $currentState.currentTargetState"
+                )
                 false
             }
         }
@@ -182,8 +202,8 @@ abstract class BaseTransitionModel<NavTarget, ModelState>(
             is Keyframes -> {
                 val newState = Update(
                     currentTargetState = when (direction) {
-                        SettleDirection.REVERT -> currentState.currentSegment.fromState
-                        SettleDirection.COMPLETE -> currentState.currentSegment.targetState
+                        SettleDirection.REVERT -> currentState.currentSegment.fromState.removeDestroyedElements()
+                        SettleDirection.COMPLETE -> currentState.currentSegment.targetState.removeDestroyedElements()
                     },
                     animate = animate
                 )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/Comparable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/Comparable.kt
@@ -1,6 +1,0 @@
-package com.bumble.appyx.interactions.core
-
-interface Comparable<in T> {
-    
-    fun isEqualTo(other: T): Boolean
-}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/Comparable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/Comparable.kt
@@ -1,0 +1,6 @@
+package com.bumble.appyx.interactions.core
+
+interface Comparable<in T> {
+    
+    fun isEqualTo(other: T): Boolean
+}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -119,7 +119,7 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
             interpolator.finishedAnimations
                 .collect {
                     Logger.log("InteractionModel", "$it onAnimation finished")
-                    model.onAnimationFinished(it)
+                    model.cleanUpElement(it)
                 }
         }
     }
@@ -229,7 +229,7 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
 
     private fun onAnimationsFinished() {
         isAnimating = false
-        model.onAnimationFinished()
+        model.relaxExecutionMode()
     }
 
     override fun onStartDrag(position: Offset) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -55,6 +55,7 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
         gestureFactory(zeroSizeTransitionBounds)
 
     private var animationChangesJob: Job? = null
+    private var animationFinishedJob: Job? = null
 
     private var transitionBounds: TransitionBounds = zeroSizeTransitionBounds
         set(value) {
@@ -111,6 +112,14 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
                     } else {
                         onAnimationsStarted()
                     }
+                }
+        }
+        animationFinishedJob?.cancel()
+        animationFinishedJob = scope.launch {
+            interpolator.finishedAnimations
+                .collect {
+                    Logger.log("InteractionModel", "$it onAnimation finished")
+                    model.onAnimationFinished(it)
                 }
         }
     }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
@@ -21,9 +21,9 @@ interface TransitionModel<NavTarget, ModelState> {
 
     fun availableElements(): StateFlow<Set<NavElement<NavTarget>>>
 
-    fun onAnimationFinished()
+    fun relaxExecutionMode()
 
-    fun onAnimationFinished(navElement: NavElement<NavTarget>)
+    fun cleanUpElement(navElement: NavElement<NavTarget>)
 
     fun operation(
         operation: Operation<ModelState>,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/TransitionModel.kt
@@ -23,6 +23,8 @@ interface TransitionModel<NavTarget, ModelState> {
 
     fun onAnimationFinished()
 
+    fun onAnimationFinished(navElement: NavElement<NavTarget>)
+
     fun operation(
         operation: Operation<ModelState>,
         overrideMode: Operation.Mode? = null

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
@@ -1,13 +1,19 @@
 package com.bumble.appyx.interactions.core.ui
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 
-abstract class BaseProps {
+abstract class BaseProps(isAnimatingFlows: List<Flow<Boolean>>) {
+
+    val isAnimatingFlow: Flow<Boolean> = combine(isAnimatingFlows) { booleanArray ->
+        booleanArray.any { it }
+    }
 
     private val _visibilityState by lazy { MutableStateFlow(isVisible()) }
-    val visibilityState: StateFlow<Boolean>  by lazy {  _visibilityState }
+    val visibilityState: StateFlow<Boolean> by lazy { _visibilityState }
 
     fun updateVisibilityState() {
         _visibilityState.update {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/BaseProps.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.update
 
 abstract class BaseProps(isAnimatingFlows: List<Flow<Boolean>>) {
 
-    val isAnimatingFlow: Flow<Boolean> = combine(isAnimatingFlows) { booleanArray ->
+    val isAnimating: Flow<Boolean> = combine(isAnimatingFlows) { booleanArray ->
         booleanArray.any { it }
     }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
@@ -43,11 +43,10 @@ interface Interpolator<NavTarget, ModelState> {
 
     fun mapOutput(
         output: TransitionModel.Output<ModelState>
-    ) =
-        when (output) {
-            is Keyframes -> mapKeyframes(output)
-            is Update -> mapUpdate(output)
-        }
+    ) = when (output) {
+        is Keyframes -> mapKeyframes(output)
+        is Update -> mapUpdate(output)
+    }
 
     fun mapKeyframes(
         keyframes: Keyframes<ModelState>

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/Interpolator.kt
@@ -1,10 +1,8 @@
 package com.bumble.appyx.interactions.core.ui
 
 import androidx.compose.animation.core.SpringSpec
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.lerp
 import com.bumble.appyx.interactions.core.Keyframes
+import com.bumble.appyx.interactions.core.NavElement
 import com.bumble.appyx.interactions.core.Segment
 import com.bumble.appyx.interactions.core.TransitionModel
 import com.bumble.appyx.interactions.core.Update
@@ -18,6 +16,8 @@ interface Interpolator<NavTarget, ModelState> {
 
     val clipToBounds: Boolean
         get() = false
+
+    val finishedAnimations: Flow<NavElement<NavTarget>>
 
     fun overrideAnimationSpec(springSpec: SpringSpec<Float>) {
         // TODO remove default once all implementations have been migrated to BaseInterpolator
@@ -41,7 +41,9 @@ interface Interpolator<NavTarget, ModelState> {
             is Update -> MutableStateFlow(mapUpdate(output))
         }
 
-    fun mapOutput(output: TransitionModel.Output<ModelState>) =
+    fun mapOutput(
+        output: TransitionModel.Output<ModelState>
+    ) =
         when (output) {
             is Keyframes -> mapKeyframes(output)
             is Update -> mapUpdate(output)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/Animatable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/Animatable.kt
@@ -16,7 +16,5 @@ interface Animatable<T> {
         scope: CoroutineScope,
         props: T,
         springSpec: SpringSpec<Float>,
-        onStart: () -> Unit = {},
-        onFinished: () -> Unit = {}
     )
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/AnimatableHolder.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/AnimatableHolder.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 // TODO better name?
 interface AnimatableHolder<T, V : AnimationVector> {
 
-    val isAnimatingFlow: Flow<Boolean>
+    val isAnimating: Flow<Boolean>
 
     suspend fun snapTo(targetValue: T)
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/AnimatableHolder.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/AnimatableHolder.kt
@@ -3,11 +3,18 @@ package com.bumble.appyx.interactions.core.ui.property
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.AnimationVector
+import kotlinx.coroutines.flow.Flow
 
 // TODO better name?
 interface AnimatableHolder<T, V : AnimationVector> {
 
+    val isAnimatingFlow: Flow<Boolean>
+
     suspend fun snapTo(targetValue: T)
 
-    suspend fun animateTo(targetValue: T, animationSpec: AnimationSpec<T>, block: (Animatable<T, V>.() -> Unit))
+    suspend fun animateTo(
+        targetValue: T,
+        animationSpec: AnimationSpec<T>,
+        block: (Animatable<T, V>.() -> Unit)
+    )
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.Easing
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -17,12 +18,14 @@ class Alpha(
     animatable = Animatable(value),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Alpha> {
+), Interpolatable<Alpha>, Comparable<Alpha> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
             this.alpha(animatable.asState().value)
         }
+
+    override fun isEqualTo(other: Alpha) = value == other.value
 
     override suspend fun lerpTo(start: Alpha, end: Alpha, fraction: Float) {
         snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.Easing
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -18,14 +17,12 @@ class Alpha(
     animatable = Animatable(value),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Alpha>, Comparable<Alpha> {
+), Interpolatable<Alpha> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
             this.alpha(animatable.asState().value)
         }
-
-    override fun isEqualTo(other: Alpha) = value == other.value
 
     override suspend fun lerpTo(start: Alpha, end: Alpha, fraction: Float) {
         snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
@@ -36,7 +36,7 @@ abstract class AnimatedProperty<T, V : AnimationVector>(
         get() = animatable.value
 
     private val _isAnimatingFlow = MutableStateFlow(false)
-    override val isAnimatingFlow: Flow<Boolean>
+    override val isAnimating: Flow<Boolean>
         get() = _isAnimatingFlow
 
     /**

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AnimatedProperty.kt
@@ -7,12 +7,13 @@ import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.AnimationVector2D
 import androidx.compose.animation.core.AnimationVector3D
 import androidx.compose.animation.core.AnimationVector4D
-import androidx.compose.animation.core.SpringSpec
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.spring
 import com.bumble.appyx.interactions.Logger
 import com.bumble.appyx.interactions.core.ui.property.Property
+
 abstract class AnimatedProperty<T, V : AnimationVector>(
     protected val animatable: Animatable<T, V>,
     protected val easing: Easing? = null,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import androidx.compose.ui.graphics.lerp as lerpColor
 
@@ -20,19 +19,12 @@ class BackgroundColor(
     animatable = Animatable(value, Color.VectorConverter(value.colorSpace)),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<BackgroundColor>, Comparable<BackgroundColor> {
+), Interpolatable<BackgroundColor> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
             this.background(color = animatable.asState().value)
         }
-
-    override fun isEqualTo(other: BackgroundColor) =
-        value.component1() == other.value.component1() &&
-                value.component2() == other.value.component2() &&
-                value.component3() == other.value.component3() &&
-                value.component4() == other.value.component4() &&
-                value.component5() == other.value.component5()
 
     override suspend fun lerpTo(start: BackgroundColor, end: BackgroundColor, fraction: Float) {
         snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import androidx.compose.ui.graphics.lerp as lerpColor
 
@@ -19,19 +20,29 @@ class BackgroundColor(
     animatable = Animatable(value, Color.VectorConverter(value.colorSpace)),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<BackgroundColor> {
+), Interpolatable<BackgroundColor>, Comparable<BackgroundColor> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
             this.background(color = animatable.asState().value)
         }
 
+    override fun isEqualTo(other: BackgroundColor) =
+        value.component1() == other.value.component1() &&
+                value.component2() == other.value.component2() &&
+                value.component3() == other.value.component3() &&
+                value.component4() == other.value.component4() &&
+                value.component5() == other.value.component5()
+
     override suspend fun lerpTo(start: BackgroundColor, end: BackgroundColor, fraction: Float) {
-        snapTo(lerpColor(
-            start = start.value,
-            stop = end.value,
-            fraction = easingTransform(end.easing, fraction)
-        ))
+        snapTo(
+            lerpColor(
+                start = start.value,
+                stop = end.value,
+                fraction = easingTransform(end.easing, fraction)
+            )
+        )
     }
+
 
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -24,7 +23,7 @@ class Offset(
     animatable = Animatable(value, DpOffset.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Offset>, Comparable<Offset> {
+), Interpolatable<Offset> {
 
     var displacement: State<DpOffset> =
         mutableStateOf(DpOffset(0.dp, 0.dp))
@@ -46,9 +45,6 @@ class Offset(
                 y = displacedValue.value.y
             )
         }
-
-    override fun isEqualTo(other: Offset) =
-        value.x == other.value.x && value.y == other.value.y
 
     override suspend fun lerpTo(start: Offset, end: Offset, fraction: Float) {
         snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Offset.kt
@@ -3,7 +3,6 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector2D
 import androidx.compose.animation.core.Easing
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.State
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -24,7 +24,7 @@ class Offset(
     animatable = Animatable(value, DpOffset.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Offset> {
+), Interpolatable<Offset>, Comparable<Offset> {
 
     var displacement: State<DpOffset> =
         mutableStateOf(DpOffset(0.dp, 0.dp))
@@ -47,12 +47,17 @@ class Offset(
             )
         }
 
+    override fun isEqualTo(other: Offset) =
+        value.x == other.value.x && value.y == other.value.y
+
     override suspend fun lerpTo(start: Offset, end: Offset, fraction: Float) {
-        snapTo(lerpDpOffset(
-            start = start.value,
-            end = end.value,
-            progress = easingTransform(end.easing, fraction)
-        ))
+        snapTo(
+            lerpDpOffset(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
     }
 
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -20,7 +19,7 @@ class RotationZ(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<RotationZ>, Comparable<RotationZ> {
+), Interpolatable<RotationZ> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -29,8 +28,6 @@ class RotationZ(
                 rotationZ = value
             }
         }
-
-    override fun isEqualTo(other: RotationZ) = value == other.value
 
     override suspend fun lerpTo(start: RotationZ, end: RotationZ, fraction: Float) {
         snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.graphicsLayer
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -19,7 +20,7 @@ class RotationZ(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<RotationZ> {
+), Interpolatable<RotationZ>, Comparable<RotationZ> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -29,11 +30,15 @@ class RotationZ(
             }
         }
 
+    override fun isEqualTo(other: RotationZ) = value == other.value
+
     override suspend fun lerpTo(start: RotationZ, end: RotationZ, fraction: Float) {
-        snapTo(lerpFloat(
-            start = start.value,
-            end = end.value,
-            progress = easingTransform(end.easing, fraction)
-        ))
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -20,7 +19,7 @@ class Scale(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Scale>, Comparable<Scale> {
+), Interpolatable<Scale> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -37,6 +36,4 @@ class Scale(
             )
         )
     }
-
-    override fun isEqualTo(other: Scale) = value == other.value
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -19,7 +20,7 @@ class Scale(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<Scale> {
+), Interpolatable<Scale>, Comparable<Scale> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -28,10 +29,14 @@ class Scale(
         }
 
     override suspend fun lerpTo(start: Scale, end: Scale, fraction: Float) {
-        snapTo(lerpFloat(
-            start = start.value,
-            end = end.value,
-            progress = easingTransform(end.easing, fraction)
-        ))
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
     }
+
+    override fun isEqualTo(other: Scale) = value == other.value
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.zIndex
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -20,7 +19,7 @@ class ZIndex(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<ZIndex>, Comparable<ZIndex> {
+), Interpolatable<ZIndex> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -29,12 +28,12 @@ class ZIndex(
         }
 
     override suspend fun lerpTo(start: ZIndex, end: ZIndex, fraction: Float) {
-        snapTo(lerpFloat(
-            start = start.value,
-            end = end.value,
-            progress = easingTransform(end.easing, fraction)
-        ))
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
     }
-
-    override fun isEqualTo(other: ZIndex) = value == other.value
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.zIndex
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 
@@ -19,7 +20,7 @@ class ZIndex(
     animatable = Animatable(value, Float.VectorConverter),
     easing = easing,
     visibilityThreshold = visibilityThreshold
-), Interpolatable<ZIndex> {
+), Interpolatable<ZIndex>, Comparable<ZIndex> {
 
     override val modifier: Modifier
         get() = Modifier.composed {
@@ -34,4 +35,6 @@ class ZIndex(
             progress = easingTransform(end.easing, fraction)
         ))
     }
+
+    override fun isEqualTo(other: ZIndex) = value == other.value
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -90,6 +90,8 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
         update: Update<ModelState>
     ) {
         LaunchedEffect(update, this) {
+            // make sure to use scope created by Launched effect as this scope should be cancelled
+            // when associated FrameModel cease to exist
             launch {
                 if (update.animate) {
                     elementProps.animateTo(
@@ -110,7 +112,8 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
         targetProps: MatchedProps<NavTarget, Props>
     ) {
         LaunchedEffect(this) {
-            //
+            // make sure to use scope created by Launched effect as this scope should be cancelled
+            // when associated FrameModel cease to exist
             launch {
                 elementProps.isAnimatingFlow
                     .distinctUntilChanged()

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -103,7 +103,7 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
         if (elementProps.isEqualTo(targetProps.props).not() && !isStarted) {
             Logger.log(
                 this@BaseInterpolator.javaClass.simpleName,
-                "animation started for element ${targetProps.element.id.substring(0..4)}"
+                "Animation started for element ${targetProps.element.id}"
             )
             animations[targetProps.element.id] = true
         }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -115,7 +115,7 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
             // make sure to use scope created by Launched effect as this scope should be cancelled
             // when associated FrameModel cease to exist
             launch {
-                elementProps.isAnimatingFlow
+                elementProps.isAnimating
                     .distinctUntilChanged()
                     .withPrevious()
                     .collect { values ->

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseInterpolator.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.bumble.appyx.interactions.Logger
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.NavElement
 import com.bumble.appyx.interactions.core.Segment
 import com.bumble.appyx.interactions.core.Update
@@ -20,11 +19,13 @@ import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Animatable
 import com.bumble.appyx.interactions.core.ui.property.HasModifier
+import com.bumble.appyx.withPrevious
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import androidx.compose.animation.core.Animatable as Animatable1
@@ -32,7 +33,7 @@ import androidx.compose.animation.core.Animatable as Animatable1
 abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
     private val scope: CoroutineScope,
     protected val defaultAnimationSpec: SpringSpec<Float> = DefaultAnimationSpec,
-) : Interpolator<NavTarget, ModelState> where Props : BaseProps, Props : HasModifier, Props : Animatable<Props>, Props : Comparable<Props> {
+) : Interpolator<NavTarget, ModelState> where Props : BaseProps, Props : HasModifier, Props : Animatable<Props> {
 
     private val propsCache: MutableMap<String, Props> = mutableMapOf()
     private val animations: MutableMap<String, Boolean> = mutableMapOf()
@@ -74,59 +75,70 @@ abstract class BaseInterpolator<NavTarget : Any, ModelState, Props>(
                 navElement = t1.element,
                 modifier = elementProps.modifier,
                 animationContainer = @Composable {
-                    LaunchedEffect(update, this) {
-                        scope.launch {
-                            if (update.animate) {
-                                onAnimationStarted(elementProps, t1)
-                                elementProps.animateTo(
-                                    scope = this,
-                                    props = t1.props,
-                                    springSpec = currentSpringSpec,
-                                )
-                                onAnimationFinished(elementProps, t1)
-                            } else {
-                                elementProps.snapTo(this, t1.props)
-                            }
-                        }
-                    }
+                    observeElementAnimationChanges(elementProps, t1)
+                    manageAnimations(elementProps, t1, update)
                 },
                 progress = MutableStateFlow(1f),
             )
         }
     }
 
-    private fun onAnimationStarted(
+    @Composable
+    private fun manageAnimations(
         elementProps: Props,
-        targetProps: MatchedProps<NavTarget, Props>
+        targetProps: MatchedProps<NavTarget, Props>,
+        update: Update<ModelState>
     ) {
-        val isStarted = animations.getOrDefault(targetProps.element.id, false)
-        if (elementProps.isEqualTo(targetProps.props).not() && !isStarted) {
-            Logger.log(
-                this@BaseInterpolator.javaClass.simpleName,
-                "Animation started for element ${targetProps.element.id}"
-            )
-            animations[targetProps.element.id] = true
-        }
-        this.isAnimating.update { true }
-    }
-
-    private fun onAnimationFinished(
-        elementProps: Props,
-        targetProps: MatchedProps<NavTarget, Props>
-    ) {
-        val isStarted = animations.getOrDefault(targetProps.element.id, false)
-        if (elementProps.isEqualTo(targetProps.props) && isStarted) {
-            Logger.log(
-                this@BaseInterpolator.javaClass.simpleName,
-                "animation finished for element ${targetProps.element.id.substring(0..4)}"
-            )
-            animations[targetProps.element.id] = false
-            scope.launch {
-                _finishedAnimations.emit(targetProps.element)
+        LaunchedEffect(update, this) {
+            launch {
+                if (update.animate) {
+                    elementProps.animateTo(
+                        scope = this,
+                        props = targetProps.props,
+                        springSpec = currentSpringSpec,
+                    )
+                } else {
+                    elementProps.snapTo(this, targetProps.props)
+                }
             }
         }
-        currentSpringSpec = defaultAnimationSpec
-        this.isAnimating.update { animations.any { it.value } }
+    }
+
+    @Composable
+    private fun observeElementAnimationChanges(
+        elementProps: Props,
+        targetProps: MatchedProps<NavTarget, Props>
+    ) {
+        LaunchedEffect(this) {
+            //
+            launch {
+                elementProps.isAnimatingFlow
+                    .distinctUntilChanged()
+                    .withPrevious()
+                    .collect { values ->
+                        val previous = values.previous ?: return@collect
+                        val current = values.current
+                        if (current && !previous) {
+                            // animation started
+                            animations[targetProps.element.id] = true
+                            isAnimating.update { true }
+                            Logger.log(
+                                this@BaseInterpolator.javaClass.simpleName,
+                                "animation for element ${targetProps.element.id} is started"
+                            )
+                        } else {
+                            // animation finished
+                            _finishedAnimations.emit(targetProps.element)
+                            animations[targetProps.element.id] = false
+                            isAnimating.update { animations.any { it.value } }
+                            Logger.log(
+                                this@BaseInterpolator.javaClass.simpleName,
+                                "animation for element ${targetProps.element.id} is finished"
+                            )
+                        }
+                    }
+            }
+        }
     }
 
     private suspend fun updateGeometry(update: Update<ModelState>) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackStackModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackStackModel.kt
@@ -1,6 +1,5 @@
 package com.bumble.appyx.transitionmodel.backstack
 
-import com.bumble.appyx.interactions.Logger
 import com.bumble.appyx.interactions.core.BaseTransitionModel
 import com.bumble.appyx.interactions.core.NavElement
 import com.bumble.appyx.interactions.core.SavedStateMap
@@ -52,13 +51,8 @@ class BackStackModel<NavTarget : Any>(
     override fun State<NavTarget>.destroyedElements(): Set<NavElement<NavTarget>> =
         destroyed.toSet()
 
-    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> {
-        Logger.log("BackStackModel", "before $this")
-
-        val newState = copy(destroyed = destroyed.filterNot { it == navElement })
-        Logger.log("BackStackModel", "after $newState")
-        return newState
-    }
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> =
+        copy(destroyed = destroyed.filterNot { it == navElement })
 
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> =
         copy(destroyed = emptyList())

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackStackModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackStackModel.kt
@@ -1,5 +1,6 @@
 package com.bumble.appyx.transitionmodel.backstack
 
+import com.bumble.appyx.interactions.Logger
 import com.bumble.appyx.interactions.core.BaseTransitionModel
 import com.bumble.appyx.interactions.core.NavElement
 import com.bumble.appyx.interactions.core.SavedStateMap
@@ -50,6 +51,14 @@ class BackStackModel<NavTarget : Any>(
 
     override fun State<NavTarget>.destroyedElements(): Set<NavElement<NavTarget>> =
         destroyed.toSet()
+
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> {
+        Logger.log("BackStackModel", "before $this")
+
+        val newState = copy(destroyed = destroyed.filterNot { it == navElement })
+        Logger.log("BackStackModel", "after $newState")
+        return newState
+    }
 
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> =
         copy(destroyed = emptyList())

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
@@ -3,7 +3,6 @@ package com.bumble.appyx.transitionmodel.backstack
 import DefaultAnimationSpec
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.ui.Modifier
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.UiContext
@@ -25,7 +24,7 @@ class BackstackFader<NavTarget : Any>(
 
     class Props(
         var alpha: Alpha = Alpha(1f),
-    ) : BaseProps(), Animatable<Props>, HasModifier, Comparable<Props> {
+    ) : BaseProps(listOf(alpha.isAnimatingFlow)), Animatable<Props>, HasModifier {
 
         override fun isVisible() =
             alpha.value > 0.0f
@@ -59,9 +58,6 @@ class BackstackFader<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
-
-        override fun isEqualTo(other: Props) =
-            alpha.isEqualTo(other.alpha)
     }
 
     private val visible = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.transitionmodel.backstack
 import DefaultAnimationSpec
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.ui.Modifier
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.UiContext
@@ -24,7 +25,7 @@ class BackstackFader<NavTarget : Any>(
 
     class Props(
         var alpha: Alpha = Alpha(1f),
-    ) : BaseProps(), Animatable<Props>, HasModifier {
+    ) : BaseProps(), Animatable<Props>, HasModifier, Comparable<Props> {
 
         override fun isVisible() =
             alpha.value > 0.0f
@@ -44,15 +45,11 @@ class BackstackFader<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
             scope.launch {
-                onStart()
                 alpha.animateTo(props.alpha.value, springSpec) {
                     updateVisibilityState()
                 }
-                onFinished()
             }
         }
 
@@ -62,6 +59,9 @@ class BackstackFader<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
+
+        override fun isEqualTo(other: Props) =
+            alpha.isEqualTo(other.alpha)
     }
 
     private val visible = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/BackstackFader.kt
@@ -24,7 +24,7 @@ class BackstackFader<NavTarget : Any>(
 
     class Props(
         var alpha: Alpha = Alpha(1f),
-    ) : BaseProps(listOf(alpha.isAnimatingFlow)), Animatable<Props>, HasModifier {
+    ) : BaseProps(listOf(alpha.isAnimating)), Animatable<Props>, HasModifier {
 
         override fun isVisible() =
             alpha.value > 0.0f

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
@@ -24,7 +24,7 @@ class BackStackCrossfader<NavTarget : Any>(
 
     class Props(
         val alpha: Alpha = Alpha(value = 1f),
-    ) : BaseProps(listOf(alpha.isAnimatingFlow)), HasModifier, Animatable<Props> {
+    ) : BaseProps(listOf(alpha.isAnimating)), HasModifier, Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
@@ -13,7 +13,6 @@ import com.bumble.appyx.transitionmodel.backstack.BackStackModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import com.bumble.appyx.interactions.core.Comparable
 
 class BackStackCrossfader<NavTarget : Any>(
     scope: CoroutineScope
@@ -25,7 +24,7 @@ class BackStackCrossfader<NavTarget : Any>(
 
     class Props(
         val alpha: Alpha = Alpha(value = 1f),
-    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
+    ) : BaseProps(listOf(alpha.isAnimatingFlow)), HasModifier, Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -62,9 +61,6 @@ class BackStackCrossfader<NavTarget : Any>(
         }
 
         override fun isVisible() = alpha.value > 0.0f
-
-        override fun isEqualTo(other: Props) =
-            alpha.isEqualTo(other.alpha)
 
     }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackCrossfader.kt
@@ -13,6 +13,7 @@ import com.bumble.appyx.transitionmodel.backstack.BackStackModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import com.bumble.appyx.interactions.core.Comparable
 
 class BackStackCrossfader<NavTarget : Any>(
     scope: CoroutineScope
@@ -24,7 +25,7 @@ class BackStackCrossfader<NavTarget : Any>(
 
     class Props(
         val alpha: Alpha = Alpha(value = 1f),
-    ) : BaseProps(), HasModifier, Animatable<Props> {
+    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -41,10 +42,7 @@ class BackStackCrossfader<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
-            onStart()
             val a1 = scope.async {
                 alpha.animateTo(
                     props.alpha.value,
@@ -54,7 +52,6 @@ class BackStackCrossfader<NavTarget : Any>(
                 }
             }
             a1.await()
-            onFinished()
         }
 
         override fun lerpTo(scope: CoroutineScope, start: Props, end: Props, fraction: Float) {
@@ -65,6 +62,9 @@ class BackStackCrossfader<NavTarget : Any>(
         }
 
         override fun isVisible() = alpha.value > 0.0f
+
+        override fun isEqualTo(other: Props) =
+            alpha.isEqualTo(other.alpha)
 
     }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.UiContext
@@ -37,7 +36,8 @@ class BackStackSlider<NavTarget : Any>(
         val alpha: Alpha = Alpha(value = 1f),
         val offsetMultiplier: Int = 1,
         val screenWidth: Dp
-    ) : HasModifier, BaseProps(), Animatable<Props>, Comparable<Props> {
+    ) : HasModifier, BaseProps(listOf(offset.isAnimatingFlow, alpha.isAnimatingFlow)),
+        Animatable<Props> {
 
         override fun isVisible() =
             alpha.value > 0.0f && offset.value.x < screenWidth && offset.value.x > -screenWidth
@@ -88,9 +88,6 @@ class BackStackSlider<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
-
-        override fun isEqualTo(other: Props) =
-            offset.isEqualTo(other.offset) && alpha.isEqualTo(other.alpha)
     }
 
     private val outsideLeft = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
@@ -36,7 +36,7 @@ class BackStackSlider<NavTarget : Any>(
         val alpha: Alpha = Alpha(value = 1f),
         val offsetMultiplier: Int = 1,
         val screenWidth: Dp
-    ) : HasModifier, BaseProps(listOf(offset.isAnimatingFlow, alpha.isAnimatingFlow)),
+    ) : HasModifier, BaseProps(listOf(offset.isAnimating, alpha.isAnimating)),
         Animatable<Props> {
 
         override fun isVisible() =

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.MatchedProps
 import com.bumble.appyx.interactions.core.ui.UiContext
@@ -36,7 +37,7 @@ class BackStackSlider<NavTarget : Any>(
         val alpha: Alpha = Alpha(value = 1f),
         val offsetMultiplier: Int = 1,
         val screenWidth: Dp
-    ) : HasModifier, BaseProps(), Animatable<Props> {
+    ) : HasModifier, BaseProps(), Animatable<Props>, Comparable<Props> {
 
         override fun isVisible() =
             alpha.value > 0.0f && offset.value.x < screenWidth && offset.value.x > -screenWidth
@@ -50,8 +51,6 @@ class BackStackSlider<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
             // FIXME this should match the own animationSpec of the model (which can also be supplied
             //  from operation extension methods) rather than created here
@@ -59,7 +58,6 @@ class BackStackSlider<NavTarget : Any>(
                 stiffness = Spring.StiffnessVeryLow / 5,
                 dampingRatio = Spring.DampingRatioLowBouncy,
             )
-            onStart()
             val a1 = scope.async {
                 offset.animateTo(
                     props.offset.value,
@@ -73,7 +71,6 @@ class BackStackSlider<NavTarget : Any>(
                 ) { updateVisibilityState() }
             }
             awaitAll(a1, a2)
-            onFinished()
         }
 
         override suspend fun snapTo(scope: CoroutineScope, props: Props) {
@@ -91,6 +88,9 @@ class BackStackSlider<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
+
+        override fun isEqualTo(other: Props) =
+            offset.isEqualTo(other.offset) && alpha.isEqualTo(other.alpha)
     }
 
     private val outsideLeft = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/CardsModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/CardsModel.kt
@@ -75,6 +75,9 @@ class CardsModel<NavTarget : Any>(
 
     override val initialState: State<NavTarget> = getInitialState(initialItems)
 
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> =
+        copy(votedCards = votedCards.filterNot { it == navElement })
+
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> =
         copy(votedCards = emptyList())
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.Logger
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.Operation
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
@@ -56,7 +57,7 @@ class CardsProps<NavTarget : Any>(
         val rotationZ: RotationZ = RotationZ(value = 0f),
         val zIndex: ZIndex = ZIndex(value = 0f),
         private val width: Float,
-    ) : BaseProps(), HasModifier, Animatable<Props> {
+    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -79,10 +80,7 @@ class CardsProps<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
-            onStart()
             listOf(
                 scope.async {
                     scale.animateTo(
@@ -116,7 +114,6 @@ class CardsProps<NavTarget : Any>(
                         updateVisibilityState()
                     }
                 }).awaitAll()
-            onFinished()
         }
 
         override fun isVisible(): Boolean =
@@ -132,6 +129,12 @@ class CardsProps<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
+
+        override fun isEqualTo(other: Props) =
+            scale.isEqualTo(other.scale) &&
+                    positionalOffsetX.isEqualTo(other.positionalOffsetX) &&
+                    rotationZ.isEqualTo(other.rotationZ) &&
+                    zIndex.isEqualTo(other.zIndex)
     }
 
     private val hidden = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
@@ -56,7 +56,7 @@ class CardsProps<NavTarget : Any>(
         val rotationZ: RotationZ = RotationZ(value = 0f),
         val zIndex: ZIndex = ZIndex(value = 0f),
         private val width: Float,
-    ) : BaseProps(listOf(scale.isAnimatingFlow, positionalOffsetX.isAnimatingFlow)), HasModifier, Animatable<Props> {
+    ) : BaseProps(listOf(scale.isAnimating, positionalOffsetX.isAnimating)), HasModifier, Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsProps.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.Logger
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.Operation
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
@@ -57,7 +56,7 @@ class CardsProps<NavTarget : Any>(
         val rotationZ: RotationZ = RotationZ(value = 0f),
         val zIndex: ZIndex = ZIndex(value = 0f),
         private val width: Float,
-    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
+    ) : BaseProps(listOf(scale.isAnimatingFlow, positionalOffsetX.isAnimatingFlow)), HasModifier, Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -129,12 +128,6 @@ class CardsProps<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
-
-        override fun isEqualTo(other: Props) =
-            scale.isEqualTo(other.scale) &&
-                    positionalOffsetX.isEqualTo(other.positionalOffsetX) &&
-                    rotationZ.isEqualTo(other.rotationZ) &&
-                    zIndex.isEqualTo(other.zIndex)
     }
 
     private val hidden = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/PromoterModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/PromoterModel.kt
@@ -45,6 +45,9 @@ class PromoterModel<NavTarget : Any>(
     override val initialState: State<NavTarget> =
         State(elements = listOf())
 
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> =
+        copy(elements.filterNot { it.first == navElement && it.second == DESTROYED })
+
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> =
         copy(
             this.elements.filter { pair -> pair.second != DESTROYED }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
@@ -1,6 +1,5 @@
 package com.bumble.appyx.transitionmodel.promoter.interpolator
 
-import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -9,17 +8,18 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.NavElement
 import com.bumble.appyx.interactions.core.Segment
 import com.bumble.appyx.interactions.core.Update
 import com.bumble.appyx.interactions.core.ui.*
 import com.bumble.appyx.interactions.core.ui.helper.lerpFloat
 import com.bumble.appyx.transitionmodel.promoter.PromoterModel
 import com.bumble.appyx.transitionmodel.promoter.PromoterModel.State.ElementState
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.math.cos
@@ -35,6 +35,9 @@ class PromoterInterpolator<NavTarget : Any>(
     private val halfWidthDp = (transitionBounds.widthDp.value - childSize.value) / 2
     private val halfHeightDp = (transitionBounds.heightDp.value - childSize.value) / 2
     private val radiusDp = min(halfWidthDp, halfHeightDp) * 1.5f
+
+    override val finishedAnimations: Flow<NavElement<NavTarget>>
+        get() = TODO("Not yet implemented")
 
     // TODO migrate to baseInterpolator
     data class Props(
@@ -174,7 +177,9 @@ class PromoterInterpolator<NavTarget : Any>(
         }
     }
 
-    override fun mapUpdate(update: Update<PromoterModel.State<NavTarget>>): List<FrameModel<NavTarget>> {
+    override fun mapUpdate(
+        update: Update<PromoterModel.State<NavTarget>>
+    ): List<FrameModel<NavTarget>> {
         TODO("Not yet implemented")
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/promoter/interpolator/PromoterInterpolator.kt
@@ -47,7 +47,7 @@ class PromoterInterpolator<NavTarget : Any>(
         val effectiveRadiusRatio: Float,
         val rotationY: Float,
         val rotationZ: Float,
-    ) : BaseProps() {
+    ) : BaseProps(listOf()) {
         override fun isVisible() = true
 
     }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/SpotlightModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/SpotlightModel.kt
@@ -55,8 +55,31 @@ class SpotlightModel<NavTarget : Any>(
             activeIndex = initialActiveIndex
         )
 
-    // TODO support removing destroyed elements
-    override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> = this
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>): State<NavTarget> {
+        val newPositions = positions.map { position ->
+            val newElements = position
+                .elements
+                .filterNot { mapEntry ->
+                    mapEntry.key == navElement && mapEntry.value == DESTROYED
+                }
+
+            position.copy(elements = newElements)
+        }
+        return copy(positions = newPositions)
+    }
+
+    override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget>  {
+        val newPositions = positions.map { position ->
+            val newElements = position
+                .elements
+                .filterNot { mapEntry ->
+                    mapEntry.value == DESTROYED
+                }
+
+            position.copy(elements = newElements)
+        }
+        return copy(positions = newPositions)
+    }
 
     override fun State<NavTarget>.availableElements(): Set<NavElement<NavTarget>> =
         positions

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
@@ -68,7 +67,8 @@ class SpotlightSlider<NavTarget : Any>(
         private val containerWidth: Dp,
         private val screenWidth: Dp,
         private val transitionBounds: TransitionBounds
-    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
+    ) : BaseProps(listOf(offset.isAnimatingFlow, scale.isAnimatingFlow, alpha.isAnimatingFlow)),
+        HasModifier, Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -144,11 +144,6 @@ class SpotlightSlider<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
-
-        override fun isEqualTo(other: Props) =
-            offset.isEqualTo(other.offset) &&
-                    alpha.isEqualTo(other.alpha) &&
-                    scale.isEqualTo(other.scale)
     }
 
     override fun defaultProps(): Props = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -67,7 +67,7 @@ class SpotlightSlider<NavTarget : Any>(
         private val containerWidth: Dp,
         private val screenWidth: Dp,
         private val transitionBounds: TransitionBounds
-    ) : BaseProps(listOf(offset.isAnimatingFlow, scale.isAnimatingFlow, alpha.isAnimatingFlow)),
+    ) : BaseProps(listOf(offset.isAnimating, scale.isAnimating, alpha.isAnimating)),
         HasModifier, Animatable<Props> {
 
         override val modifier: Modifier

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
@@ -67,7 +68,7 @@ class SpotlightSlider<NavTarget : Any>(
         private val containerWidth: Dp,
         private val screenWidth: Dp,
         private val transitionBounds: TransitionBounds
-    ) : BaseProps(), HasModifier, Animatable<Props> {
+    ) : BaseProps(), HasModifier, Animatable<Props>, Comparable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -88,11 +89,8 @@ class SpotlightSlider<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
             scope.launch {
-                onStart()
                 listOf(
                     scope.async {
                         offset.animateTo(
@@ -115,7 +113,6 @@ class SpotlightSlider<NavTarget : Any>(
                         }
                     }
                 ).awaitAll()
-                onFinished()
             }
         }
 
@@ -147,6 +144,11 @@ class SpotlightSlider<NavTarget : Any>(
                 updateVisibilityState()
             }
         }
+
+        override fun isEqualTo(other: Props) =
+            offset.isEqualTo(other.offset) &&
+                    alpha.isEqualTo(other.alpha) &&
+                    scale.isEqualTo(other.scale)
     }
 
     override fun defaultProps(): Props = Props(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/TestDriveModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/TestDriveModel.kt
@@ -39,5 +39,7 @@ class TestDriveModel<NavTarget : Any>(
             elementState = A
         )
 
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>) = this
+
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> = this
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.Logger
-import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.GestureFactory
@@ -44,7 +43,7 @@ class TestDriveUiModel<NavTarget : Any>(
     class Props(
         val offset: Offset = Offset(DpOffset(0.dp, 0.dp)),
         val backgroundColor: BackgroundColor = BackgroundColor(md_red_500),
-    ) : HasModifier, BaseProps(), Animatable<Props>, Comparable<Props> {
+    ) : HasModifier, BaseProps(listOf(offset.isAnimatingFlow, backgroundColor.isAnimatingFlow)), Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -93,10 +92,6 @@ class TestDriveUiModel<NavTarget : Any>(
         }
 
         override fun isVisible() = true
-
-        override fun isEqualTo(other: Props) =
-            offset.isEqualTo(other.offset) &&
-                    backgroundColor.isEqualTo(other.backgroundColor)
     }
 
     companion object {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.Logger
+import com.bumble.appyx.interactions.core.Comparable
 import com.bumble.appyx.interactions.core.inputsource.Gesture
 import com.bumble.appyx.interactions.core.ui.BaseProps
 import com.bumble.appyx.interactions.core.ui.GestureFactory
@@ -43,7 +44,7 @@ class TestDriveUiModel<NavTarget : Any>(
     class Props(
         val offset: Offset = Offset(DpOffset(0.dp, 0.dp)),
         val backgroundColor: BackgroundColor = BackgroundColor(md_red_500),
-    ) : HasModifier, BaseProps(), Animatable<Props> {
+    ) : HasModifier, BaseProps(), Animatable<Props>, Comparable<Props> {
 
         override val modifier: Modifier
             get() = Modifier
@@ -62,10 +63,7 @@ class TestDriveUiModel<NavTarget : Any>(
             scope: CoroutineScope,
             props: Props,
             springSpec: SpringSpec<Float>,
-            onStart: () -> Unit,
-            onFinished: () -> Unit
         ) {
-            onStart()
             listOf(
                 scope.async {
                     offset.animateTo(
@@ -84,7 +82,6 @@ class TestDriveUiModel<NavTarget : Any>(
                     }
                 }
             ).awaitAll()
-            onFinished()
         }
 
         override fun lerpTo(scope: CoroutineScope, start: Props, end: Props, fraction: Float) {
@@ -96,6 +93,10 @@ class TestDriveUiModel<NavTarget : Any>(
         }
 
         override fun isVisible() = true
+
+        override fun isEqualTo(other: Props) =
+            offset.isEqualTo(other.offset) &&
+                    backgroundColor.isEqualTo(other.backgroundColor)
     }
 
     companion object {
@@ -145,8 +146,8 @@ class TestDriveUiModel<NavTarget : Any>(
             delta: androidx.compose.ui.geometry.Offset,
             density: Density
         ): Gesture<NavTarget, TestDriveModel.State<NavTarget>> {
-            val width = with (density) { width.toPx() }
-            val height = with (density) { height.toPx() }
+            val width = with(density) { width.toPx() }
+            val height = with(density) { height.toPx() }
 
             return if (abs(delta.x) > abs(delta.y)) {
                 if (delta.x < 0) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveUiModel.kt
@@ -43,7 +43,7 @@ class TestDriveUiModel<NavTarget : Any>(
     class Props(
         val offset: Offset = Offset(DpOffset(0.dp, 0.dp)),
         val backgroundColor: BackgroundColor = BackgroundColor(md_red_500),
-    ) : HasModifier, BaseProps(listOf(offset.isAnimatingFlow, backgroundColor.isAnimatingFlow)), Animatable<Props> {
+    ) : HasModifier, BaseProps(listOf(offset.isAnimating, backgroundColor.isAnimating)), Animatable<Props> {
 
         override val modifier: Modifier
             get() = Modifier

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
@@ -13,6 +13,8 @@ class TestTransitionModel<NavTarget : Any>(
         elements = initialElements.map { it.asElement() }
     )
 
+    override fun State<NavTarget>.removeDestroyedElement(navElement: NavElement<NavTarget>) = this
+
     override fun State<NavTarget>.removeDestroyedElements(): State<NavTarget> = this
 
     override fun State<NavTarget>.destroyedElements(): Set<NavElement<NavTarget>> = setOf()

--- a/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/backstack/BackStackNode.kt
+++ b/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/backstack/BackStackNode.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.sp
 import com.bumble.appyx.appyxnavigation.colors
 import com.bumble.appyx.appyxnavigation.ui.TextButton
 import com.bumble.appyx.appyxnavigation.ui.appyx_dark
-import com.bumble.appyx.interactions.core.Operation
 import com.bumble.appyx.interactions.core.ui.Interpolator
 import com.bumble.appyx.interactions.core.ui.UiContext
 import com.bumble.appyx.navigation.composable.Children
@@ -103,7 +102,7 @@ class BackStackNode(
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 TextButton(text = "Push") {
-                    backStack.push(NavTarget.Child(Random.nextInt(20)), Operation.Mode.IMMEDIATE)
+                    backStack.push(NavTarget.Child(Random.nextInt(20)))
                 }
                 TextButton(text = "Pop") {
                     backStack.pop()

--- a/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/backstack/BackStackNode.kt
+++ b/samples/appyx-navigation/src/main/kotlin/com/bumble/appyx/appyxnavigation/node/backstack/BackStackNode.kt
@@ -24,7 +24,6 @@ import com.bumble.appyx.appyxnavigation.ui.TextButton
 import com.bumble.appyx.appyxnavigation.ui.appyx_dark
 import com.bumble.appyx.interactions.core.Operation
 import com.bumble.appyx.interactions.core.ui.Interpolator
-import com.bumble.appyx.interactions.core.ui.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.UiContext
 import com.bumble.appyx.navigation.composable.Children
 import com.bumble.appyx.navigation.modality.BuildContext
@@ -104,7 +103,7 @@ class BackStackNode(
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 TextButton(text = "Push") {
-                    backStack.push(NavTarget.Child(Random.nextInt(20)))
+                    backStack.push(NavTarget.Child(Random.nextInt(20)), Operation.Mode.IMMEDIATE)
                 }
                 TextButton(text = "Pop") {
                     backStack.pop()


### PR DESCRIPTION
## Description

1. Animation start and finish is called exactly once even if interruption happens
2. Report finished animations via flow
3. Clean up destroyed elements in `BaseTransitionModel`
4. `AnimatedProperty` now expose `val isAnimatingFlow: Flow<Boolean>`
5. Props class exposed `val isAnimatingFlow: Flow<Boolean>`  as a combination of all `AnimatedProperty` flows

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
