### PR TITLE
Add interface to provide proper default spec

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/InteractionModel.kt
@@ -14,6 +14,7 @@ import com.bumble.appyx.interactions.core.inputsource.AnimatedInputSource
 import com.bumble.appyx.interactions.core.inputsource.DebugProgressInputSource
 import com.bumble.appyx.interactions.core.inputsource.DragProgressInputSource
 import com.bumble.appyx.interactions.core.inputsource.Draggable
+import com.bumble.appyx.interactions.core.inputsource.HasDefaultAnimationSpec
 import com.bumble.appyx.interactions.core.inputsource.InstantInputSource
 import com.bumble.appyx.interactions.core.ui.FrameModel
 import com.bumble.appyx.interactions.core.ui.GestureFactory
@@ -45,12 +46,12 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
     private val model: TransitionModel<NavTarget, ModelState>,
     private val interpolator: (UiContext) -> Interpolator<NavTarget, ModelState>,
     private val gestureFactory: (TransitionBounds) -> GestureFactory<NavTarget, ModelState> = { GestureFactory.Noop() },
+    override val defaultAnimationSpec: AnimationSpec<Float> = DefaultAnimationSpec,
     private val backPressStrategy: BackPressHandlerStrategy<NavTarget, ModelState> = DontHandleBackPress(),
-    val defaultAnimationSpec: AnimationSpec<Float> = DefaultAnimationSpec,
     private val animateSettle: Boolean = false,
     private val disableAnimations: Boolean = false,
     private val isDebug: Boolean = false
-) : Draggable, UiContextAware {
+) : HasDefaultAnimationSpec<Float>, Draggable, UiContextAware {
     init {
         backPressStrategy.init(this, model)
     }
@@ -78,7 +79,8 @@ open class InteractionModel<NavTarget : Any, ModelState : Any>(
     private var debug: DebugProgressInputSource<NavTarget, ModelState>? = null
     private val drag = DragProgressInputSource(
         model = model,
-        gestureFactory = { _gestureFactory }
+        gestureFactory = { _gestureFactory },
+        defaultAnimationSpec = defaultAnimationSpec
     )
 
     private val _frames: MutableStateFlow<List<FrameModel<NavTarget>>> =

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/AnimatedInputSource.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/AnimatedInputSource.kt
@@ -18,9 +18,9 @@ import kotlin.math.floor
 class AnimatedInputSource<NavTarget : Any, ModelState>(
     private val model: TransitionModel<NavTarget, ModelState>,
     private val coroutineScope: CoroutineScope,
-    private val defaultAnimationSpec: AnimationSpec<Float> = spring(),
+    override val defaultAnimationSpec: AnimationSpec<Float> = spring(),
     private val animateSettle: Boolean = false
-) : InputSource<NavTarget, ModelState> {
+) : InputSource<NavTarget, ModelState>, HasDefaultAnimationSpec<Float> {
 
     private val animatable = Animatable(0f)
     // FIXME private lateinit var result: AnimationResult<Float, AnimationVector1D>

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/DragProgressInputSource.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/DragProgressInputSource.kt
@@ -12,7 +12,8 @@ import com.bumble.appyx.interactions.core.ui.GestureFactory
 
 class DragProgressInputSource<NavTarget : Any, State>(
     private val model: TransitionModel<NavTarget, State>,
-    private val gestureFactory: () -> GestureFactory<NavTarget, State>
+    private val gestureFactory: () -> GestureFactory<NavTarget, State>,
+    override val defaultAnimationSpec: AnimationSpec<Float>
 ) : Draggable {
 
     // TODO get rid of this

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/Draggable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/Draggable.kt
@@ -5,7 +5,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 
-interface Draggable {
+interface Draggable : HasDefaultAnimationSpec<Float>{
 
     fun onStartDrag(position: Offset)
 
@@ -13,7 +13,7 @@ interface Draggable {
 
     fun onDragEnd(
         completionThreshold: Float = 0.5f,
-        completeGestureSpec: AnimationSpec<Float> = spring(),
-        revertGestureSpec: AnimationSpec<Float> = spring()
+        completeGestureSpec: AnimationSpec<Float> = defaultAnimationSpec,
+        revertGestureSpec: AnimationSpec<Float> = defaultAnimationSpec
     )
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/HasDefaultAnimationSpec.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/inputsource/HasDefaultAnimationSpec.kt
@@ -1,0 +1,8 @@
+package com.bumble.appyx.interactions.core.inputsource
+
+import androidx.compose.animation.core.AnimationSpec
+
+interface HasDefaultAnimationSpec<T> {
+
+    val defaultAnimationSpec: AnimationSpec<T>
+}


### PR DESCRIPTION
Draggable used a default `spring()` as settling animation spec, not allowing to use the default spec of the model itself.

Fixed by falling back to value provided by interface which the model implements too.