### PR TITLE
SaveableStateHolder remove state for destroyed elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-–
+- [#375](https://github.com/bumble-tech/appyx/issues/375) – **Fixed**: SaveableStateHolder does no longer save state for destroyed elements
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 plugin-android = "com.android.tools.build:gradle:7.3.1"
 
 detekt-compose = "com.twitter.compose.rules:detekt:0.0.26"
+toolargetool = "com.gu.android:toolargetool:0.3.0"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Child.kt
@@ -19,8 +19,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
-import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.navigation.NavElement
 import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavModel
@@ -29,6 +27,8 @@ import com.bumble.appyx.core.navigation.transition.TransitionBounds
 import com.bumble.appyx.core.navigation.transition.TransitionDescriptor
 import com.bumble.appyx.core.navigation.transition.TransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionParams
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.ParentNode
 import kotlinx.coroutines.flow.map
 
 @Composable

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
@@ -127,18 +127,17 @@ class ChildrenTransitionScope<T : Any, S>(
     ) {
         val saveableStateHolder = rememberSaveableStateHolder()
 
-        val removedElementsFlow = remember {
-            navModel.removedElementKeys().map { list ->
-                list
-                    .filter { clazz.isInstance(it.navTarget) }
-            }
-        }
-        LaunchedEffect(this@ChildrenTransitionScope) {
-            removedElementsFlow.collect { deletedElements ->
-                deletedElements.forEach { navKey ->
-                    saveableStateHolder.removeState(navKey)
+        LaunchedEffect(navModel) {
+            navModel
+                .removedElementKeys()
+                .map { list ->
+                    list.filter { clazz.isInstance(it.navTarget) }
                 }
-            }
+                .collect { deletedKeys ->
+                    deletedKeys.forEach { navKey ->
+                        saveableStateHolder.removeState(navKey)
+                    }
+                }
         }
 
         val visibleElementsFlow = remember {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/Children.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.core.composable
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -15,13 +16,14 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
-import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.navigation.NavModel
+import com.bumble.appyx.core.navigation.removedElementKeys
 import com.bumble.appyx.core.navigation.transition.JumpToEndTransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionBounds
 import com.bumble.appyx.core.navigation.transition.TransitionDescriptor
 import com.bumble.appyx.core.navigation.transition.TransitionHandler
 import com.bumble.appyx.core.navigation.transition.TransitionParams
+import com.bumble.appyx.core.node.ParentNode
 import kotlinx.coroutines.flow.map
 import kotlin.reflect.KClass
 
@@ -123,6 +125,22 @@ class ChildrenTransitionScope<T : Any, S>(
             transitionDescriptor: TransitionDescriptor<T, S>
         ) -> Unit
     ) {
+        val saveableStateHolder = rememberSaveableStateHolder()
+
+        val removedElementsFlow = remember {
+            navModel.removedElementKeys().map { list ->
+                list
+                    .filter { clazz.isInstance(it.navTarget) }
+            }
+        }
+        LaunchedEffect(this@ChildrenTransitionScope) {
+            removedElementsFlow.collect { deletedElements ->
+                deletedElements.forEach { navKey ->
+                    saveableStateHolder.removeState(navKey)
+                }
+            }
+        }
+
         val visibleElementsFlow = remember {
             this@ChildrenTransitionScope
                 .navModel
@@ -135,7 +153,7 @@ class ChildrenTransitionScope<T : Any, S>(
         }
         val children by visibleElementsFlow.collectAsState(emptyList())
 
-        val saveableStateHolder = rememberSaveableStateHolder()
+
         children.forEach { navElement ->
             key(navElement.key.id) {
                 Child(

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavModelExt.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavModelExt.kt
@@ -1,0 +1,24 @@
+package com.bumble.appyx.core.navigation
+
+import com.bumble.appyx.core.withPrevious
+import kotlinx.coroutines.flow.map
+
+fun <NavTarget, State> NavModel<NavTarget, State>.removedElementKeys() =
+    this
+        .elements
+        .withPrevious()
+        .map { values ->
+            val previousKeys = values.previous?.map { it.key }
+            val currentKeys = values.current.map { it.key }
+            if (previousKeys == null) {
+                emptyList()
+            } else {
+                val deletedElements = mutableListOf<NavKey<NavTarget>>()
+                previousKeys.forEach { element ->
+                    if (currentKeys.contains(element).not()) {
+                        deletedElements.add(element)
+                    }
+                }
+                deletedElements
+            }
+        }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavModelExt.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/NavModelExt.kt
@@ -3,22 +3,14 @@ package com.bumble.appyx.core.navigation
 import com.bumble.appyx.core.withPrevious
 import kotlinx.coroutines.flow.map
 
-fun <NavTarget, State> NavModel<NavTarget, State>.removedElementKeys() =
+internal fun <NavTarget, State> NavModel<NavTarget, State>.removedElementKeys() =
     this
         .elements
         .withPrevious()
         .map { values ->
-            val previousKeys = values.previous?.map { it.key }
+            val previousKeys = values.previous?.map { it.key }.orEmpty()
             val currentKeys = values.current.map { it.key }
-            if (previousKeys == null) {
-                emptyList()
-            } else {
-                val deletedElements = mutableListOf<NavKey<NavTarget>>()
-                previousKeys.forEach { element ->
-                    if (currentKeys.contains(element).not()) {
-                        deletedElements.add(element)
-                    }
-                }
-                deletedElements
+            previousKeys.filter { element ->
+                !currentKeys.contains(element)
             }
         }

--- a/samples/sandbox/build.gradle.kts
+++ b/samples/sandbox/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.rxjava2)
     implementation(libs.rxandroid2)
     implementation(libs.rxrelay2)
+    implementation(libs.toolargetool)
 
     testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.junit)

--- a/samples/sandbox/src/main/AndroidManifest.xml
+++ b/samples/sandbox/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
+        android:name=".sandbox.SandboxApplication"
         android:supportsRtl="true"
         android:theme="@style/Theme.Appyx">
         <activity

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/SandboxApplication.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/SandboxApplication.kt
@@ -1,0 +1,12 @@
+package com.bumble.appyx.sandbox
+
+import android.app.Application
+import com.gu.toolargetool.TooLargeTool
+
+class SandboxApplication: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        TooLargeTool.startLogging(this)
+    }
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/375

Remove saveableStateHolder state for destroyed elements

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
