### PR TITLE
Use onPlaced instead of onGloballyPositioned to improve performance

### DIFF
--- a/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -63,7 +63,7 @@ fun <NavTarget : Any, NavState : Any> Children(
                     this
                 }
             }
-            .onGloballyPositioned {
+            .onPlaced {
                 uiContext = UiContext(
                     TransitionBounds(
                         density = density,

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import com.bumble.appyx.interactions.core.InteractionModel
@@ -56,7 +56,7 @@ inline fun <reified NavTarget : Any, NavState : Any> ParentNode<NavTarget>.Child
     var uiContext by remember { mutableStateOf<UiContext?>(null) }
 
     LaunchedEffect(uiContext) {
-        uiContext?.let {  interactionModel.updateContext(it) }
+        uiContext?.let { interactionModel.updateContext(it) }
     }
     Box(
         modifier = modifier
@@ -69,7 +69,7 @@ inline fun <reified NavTarget : Any, NavState : Any> ParentNode<NavTarget>.Child
                     this
                 }
             }
-            .onGloballyPositioned {
+            .onPlaced {
                 uiContext = UiContext(
                     TransitionBounds(
                         density = density,


### PR DESCRIPTION
## Description

Use onPlaced as it's cheaper than onGloballyPositioned

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
