### PR TITLE
1.x remove deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pending changes
 
+- [#383](https://github.com/bumble-tech/appyx/pull/383) – **Changed**: Removed deprecated methods in Node, ParentNode and CombinedHandler classes
 - [#376](https://github.com/bumble-tech/appyx/issues/376) – **Changed**: Androidx lifecycle version updated to 2.6.1.
 - [#376](https://github.com/bumble-tech/appyx/issues/376) – **Updated**: Kotlin and Compose compiler version updated to 1.8.10 to align kotlin version used in androidx lifecycle  
 - [#375](https://github.com/bumble-tech/appyx/issues/375) – **Fixed**: SaveableStateHolder does no longer save state for destroyed elements

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/transition/CombinedHandler.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/transition/CombinedHandler.kt
@@ -24,18 +24,6 @@ class CombinedHandler<T, S>(
             }
 }
 
-@Suppress("UnstableCollections")
-@Deprecated(
-    message = "Use rememberCombinedHandler with immutable handlers instead. This function will be removed in 1.1",
-    replaceWith = ReplaceWith(
-        "rememberCombinedHandler<T, S>(handlers.toImmutableList<T, S>())",
-        "com.bumble.appyx.core.collections.toImmutableList",
-    )
-)
-@Composable
-fun <T, S> rememberCombinedHandler(handlers: List<ModifierTransitionHandler<T, S>>): ModifierTransitionHandler<T, S> =
-    remember { CombinedHandler(handlers = handlers) }
-
 @Composable
 fun <T, S> rememberCombinedHandler(
     handlers: ImmutableList<ModifierTransitionHandler<T, S>>

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/Node.kt
@@ -101,14 +101,6 @@ open class Node @VisibleForTesting internal constructor(
         })
     }
 
-    @Deprecated(
-        replaceWith = ReplaceWith("executeAction(action)"),
-        message = "Will be removed in 1.1"
-    )
-    protected suspend inline fun <reified T : Node> executeWorkflow(
-        crossinline action: () -> Unit
-    ): T = executeAction(action)
-
     protected suspend inline fun <reified T : Node> executeAction(
         crossinline action: () -> Unit
     ): T = withContext(lifecycleScope.coroutineContext) {

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -169,15 +169,6 @@ abstract class ParentNode<NavTarget : Any>(
         }
     }
 
-    @Deprecated(
-        replaceWith = ReplaceWith("attachChild(action"),
-        message = "Will be removed in 1.1"
-    )
-    protected suspend inline fun <reified T : Node> attachWorkflow(
-        timeout: Long = ATTACH_WORKFLOW_SYNC_TIMEOUT,
-        crossinline action: () -> Unit
-    ) = attachChild<T>(timeout, action)
-
     /**
      * attachChild executes provided action e.g. backstack.push(NodeANavTarget) and waits for the specific
      * Node of type T to appear in the ParentNode's children list. It should happen almost immediately because it happens


### PR DESCRIPTION
## Description

Some methods were deprecated in 1.0.x and were scheduled for deletion for 1.1.x This PR removes these methods

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
