### PR TITLE
Move clipToBounds from MotionController to Children

### DIFF
--- a/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/Utils.kt
+++ b/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/Utils.kt
@@ -44,7 +44,8 @@ fun <InteractionTarget : Any> ComposeContentTestRule.setupTestDrive(
 
 fun <InteractionTarget : Any, ModelState : Any> ComposeContentTestRule.setupInteractionModel(
     interactionModel: BaseInteractionModel<InteractionTarget, ModelState>,
-    fraction: Float = 1.0f
+    fraction: Float = 1.0f,
+    clipToBounds: Boolean = false
 ) {
     setContent {
         Surface(
@@ -55,7 +56,8 @@ fun <InteractionTarget : Any, ModelState : Any> ComposeContentTestRule.setupInte
             InteractionModelSetup(interactionModel)
             TestChildrenUi(
                 fraction = fraction,
-                interactionModel = interactionModel
+                interactionModel = interactionModel,
+                clipToBounds = clipToBounds
             )
         }
     }
@@ -70,7 +72,8 @@ fun randomColor(): Color {
 @Composable
 private fun <NavTarget : Any, ModelState : Any> TestChildrenUi(
     fraction: Float = 1.0f,
-    interactionModel: BaseInteractionModel<NavTarget, ModelState>
+    interactionModel: BaseInteractionModel<NavTarget, ModelState>,
+    clipToBounds: Boolean
 ) {
     BoxWithConstraints {
         val padding = this.maxWidth * (1.0f - fraction) / 2
@@ -82,6 +85,7 @@ private fun <NavTarget : Any, ModelState : Any> TestChildrenUi(
                     color = randomColor()
                 ),
             interactionModel = interactionModel,
+            clipToBounds = clipToBounds,
         ) {
             Box(
                 modifier = Modifier

--- a/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/transitionmodel/spotlight/SpotlightTest.kt
+++ b/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/transitionmodel/spotlight/SpotlightTest.kt
@@ -43,11 +43,8 @@ class SpotlightTest(private val testParam: TestParam) {
 
     @Test
     fun spotlight_calculates_visible_elements_correctly_when_clipToBounds_is_false() {
-        createBackStackSlider(
-            initialActiveIndex = 1f,
-            clipToBounds = false
-        )
-        composeTestRule.setupInteractionModel(spotlight, 0.67f)
+        createBackStackSlider(initialActiveIndex = 1f)
+        composeTestRule.setupInteractionModel(spotlight, 0.67f, clipToBounds = false)
         checkInteractionTargetsOnScreen(setOf(NavTarget.Child1, NavTarget.Child2, NavTarget.Child3))
 
         if (testParam.operationMode == Operation.Mode.KEYFRAME) {
@@ -64,11 +61,8 @@ class SpotlightTest(private val testParam: TestParam) {
 
     @Test
     fun spotlight_calculates_visible_elements_correctly_when_clipToBounds_is_true() {
-        createBackStackSlider(
-            initialActiveIndex = 1f,
-            clipToBounds = true
-        )
-        composeTestRule.setupInteractionModel(spotlight, 0.67f)
+        createBackStackSlider(initialActiveIndex = 1f)
+        composeTestRule.setupInteractionModel(spotlight, 0.67f, clipToBounds = true)
 
         if (testParam.operationMode == Operation.Mode.KEYFRAME) {
             val animationDuration = 1000
@@ -99,7 +93,6 @@ class SpotlightTest(private val testParam: TestParam) {
     private fun createBackStackSlider(
         disableAnimations: Boolean = false,
         initialActiveIndex: Float = 0f,
-        clipToBounds: Boolean = false
     ) {
         spotlight = Spotlight(
             model = SpotlightModel(
@@ -113,7 +106,7 @@ class SpotlightTest(private val testParam: TestParam) {
                 initialActiveIndex = initialActiveIndex,
                 savedStateMap = null
             ),
-            motionController = { SpotlightSlider(uiContext = it, clipToBounds = clipToBounds) },
+            motionController = { SpotlightSlider(uiContext = it) },
             scope = CoroutineScope(Dispatchers.Unconfined),
             disableAnimations = disableAnimations,
         )

--- a/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -38,6 +38,7 @@ import kotlin.math.roundToInt
 fun <InteractionTarget : Any, ModelState : Any> Children(
     interactionModel: BaseInteractionModel<InteractionTarget, ModelState>,
     modifier: Modifier = Modifier,
+    clipToBounds: Boolean = false,
     element: @Composable (ElementUiModel<InteractionTarget>) -> Unit = {
         Element(elementUiModel = it)
     },
@@ -56,7 +57,6 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
         modifier = modifier
             .fillMaxSize()
             .composed {
-                val clipToBounds by interactionModel.clipToBounds.collectAsState()
                 if (clipToBounds) {
                     clipToBounds()
                 } else {
@@ -65,7 +65,8 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
             }
             .onPlaced {
                 uiContext = UiContext(
-                    TransitionBounds(
+                    coroutineScope = coroutineScope,
+                    transitionBounds = TransitionBounds(
                         density = density,
                         widthPx = it.size.width,
                         heightPx = it.size.height,
@@ -73,7 +74,7 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                         screenWidthPx = screenWidthPx,
                         screenHeightPx = screenHeightPx
                     ),
-                    coroutineScope
+                    clipToBounds = clipToBounds
                 )
             }
     ) {

--- a/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/TestDriveExperiment.kt
+++ b/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/TestDriveExperiment.kt
@@ -165,14 +165,15 @@ fun <InteractionTarget : Any> TestDriveUi(
                     .collectAsState(null)
                 is Update -> remember(output) { mutableStateOf(output.currentTargetState) }
             }
+        // FIXME this should be internalised probably
         val targetProps = targetState.value?.elementState?.toUiState(
-            uiContext = UiContext(zeroSizeTransitionBounds, rememberCoroutineScope())
+            uiContext = UiContext(rememberCoroutineScope(), zeroSizeTransitionBounds, clipToBounds = false)
         )
         targetProps?.let {
             Box(
                 modifier = Modifier
                     .size(60.dp)
-                    .offset(targetProps.offset.value.x, targetProps.offset.value.y)
+                    .offset(targetProps.position.value.x, targetProps.position.value.y)
                     .border(2.dp, targetProps.backgroundColor.value)
             ) {
                 Text(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
@@ -98,9 +98,6 @@ open class BaseInteractionModel<InteractionTarget : Any, ModelState : Any>(
         MutableStateFlow(InteractionModel.Elements(offScreen = model.elements.value))
     override val elements: StateFlow<InteractionModel.Elements<InteractionTarget>> = _elements
 
-    private val _clipToBounds: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val clipToBounds: StateFlow<Boolean> = _clipToBounds
-
     init {
         // Before motionController is ready we consider all elements as off-screen
         elementsJob = scope.launch {
@@ -177,7 +174,6 @@ open class BaseInteractionModel<InteractionTarget : Any, ModelState : Any>(
     }
 
     private fun onMotionControllerReady(motionController: MotionController<InteractionTarget, ModelState>) {
-        _clipToBounds.update { motionController.clipToBounds }
         observeAnimationChanges(motionController)
         observeMotionController(motionController)
     }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/MotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/MotionController.kt
@@ -15,9 +15,6 @@ import kotlinx.coroutines.flow.map
 
 interface MotionController<InteractionTarget, ModelState> {
 
-    val clipToBounds: Boolean
-        get() = false
-
     val finishedAnimations: Flow<Element<InteractionTarget>>
 
     fun overrideAnimationSpec(springSpec: SpringSpec<Float>) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/context/UiContext.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/context/UiContext.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 
 @Immutable
 data class UiContext(
+    val coroutineScope: CoroutineScope,
     val transitionBounds: TransitionBounds,
-    val coroutineScope: CoroutineScope
+    val clipToBounds: Boolean
 )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 class Position(
     val initialOffset: DpOffset,
     easing: Easing? = null,
-    val clipToBounds: Boolean = false,
+    val clipToBounds: Boolean,
     val bounds: TransitionBounds? = null,
     val displacement: StateFlow<DpOffset> = MutableStateFlow(DpOffset.Zero),
     visibilityThreshold: DpOffset = DpOffset(1.dp, 1.dp),

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/backstack/interpolator/BackStackSlider.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.launch
 
 class BackStackSlider<InteractionTarget : Any>(
     uiContext: UiContext,
-    override val clipToBounds: Boolean = true,
 ) : BaseMotionController<InteractionTarget, BackStackModel.State<InteractionTarget>, BackStackSlider.UiState>(
     uiContext = uiContext,
 ) {
@@ -27,17 +26,15 @@ class BackStackSlider<InteractionTarget : Any>(
 
     override fun defaultUiState(uiContext: UiContext, initialUiState: UiState?): UiState =
         UiState(
-            clipToBounds = clipToBounds,
             uiContext = uiContext,
         )
 
     data class UiState(
-        val clipToBounds: Boolean,
         val uiContext: UiContext,
         val offset: Position = Position(
             initialOffset = DpOffset(0.dp, 0.dp),
             bounds = uiContext.transitionBounds,
-            clipToBounds = clipToBounds
+            clipToBounds = uiContext.clipToBounds
         ),
         val alpha: Alpha = Alpha(value = 1f),
         val offsetMultiplier: Int = 1
@@ -88,20 +85,26 @@ class BackStackSlider<InteractionTarget : Any>(
 
     private val outsideLeft = UiState(
         uiContext = uiContext,
-        offset = Position(initialOffset = DpOffset(-width, 0.dp)),
-        clipToBounds = clipToBounds
+        offset = Position(
+            initialOffset = DpOffset(-width, 0.dp),
+            clipToBounds = uiContext.clipToBounds
+        ),
     )
 
     private val outsideRight = UiState(
         uiContext = uiContext,
-        offset = Position(initialOffset = DpOffset(width, 0.dp)),
-        clipToBounds = clipToBounds
+        offset = Position(
+            initialOffset = DpOffset(width, 0.dp),
+            clipToBounds = uiContext.clipToBounds
+        ),
     )
 
     private val noOffset = UiState(
         uiContext = uiContext,
-        offset = Position(initialOffset = DpOffset(0.dp, 0.dp)),
-        clipToBounds = clipToBounds
+        offset = Position(
+            initialOffset = DpOffset(0.dp, 0.dp),
+            clipToBounds = uiContext.clipToBounds
+        ),
     )
 
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/cards/interpolator/CardsMotionController.kt
@@ -47,10 +47,8 @@ class CardsMotionController<InteractionTarget : Any>(
         val uiContext: UiContext,
         val scale: Scale = Scale(value = 1f),
         val position: Position = Position(
-            initialOffset = DpOffset(
-                0.dp,
-                0.dp
-            ),
+            initialOffset = DpOffset.Zero,
+            clipToBounds = uiContext.clipToBounds
         ),
         val rotationZ: RotationZ = RotationZ(value = 0f),
         val zIndex: ZIndex = ZIndex(value = 0f)
@@ -137,9 +135,10 @@ class CardsMotionController<InteractionTarget : Any>(
         uiContext = uiContext,
         position = Position(
             initialOffset = DpOffset(
-                (-voteCardPositionMultiplier * uiContext.transitionBounds.widthDp.value).dp,
-                0.dp
+                x = (-voteCardPositionMultiplier * uiContext.transitionBounds.widthDp.value).dp,
+                y = 0.dp
             ),
+            clipToBounds = uiContext.clipToBounds
         ),
         scale = Scale(1f),
         zIndex = ZIndex(2f),
@@ -150,9 +149,10 @@ class CardsMotionController<InteractionTarget : Any>(
         uiContext = uiContext,
         position = Position(
             initialOffset = DpOffset(
-                (voteCardPositionMultiplier * uiContext.transitionBounds.widthDp.value).dp,
-                0.dp
+                x = (voteCardPositionMultiplier * uiContext.transitionBounds.widthDp.value).dp,
+                y = 0.dp
             ),
+            clipToBounds = uiContext.clipToBounds
         ),
         scale = Scale(1f),
         zIndex = ZIndex(2f),

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/spotlight/interpolator/SpotlightSlider.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.launch
 
 class SpotlightSlider<InteractionTarget : Any>(
     private val uiContext: UiContext,
-    override val clipToBounds: Boolean = false,
     private val orientation: Orientation = Orientation.Horizontal, // TODO support RTL
 ) : BaseMotionController<InteractionTarget, SpotlightModel.State<InteractionTarget>, SpotlightSlider.UiState>(
     uiContext = uiContext
@@ -111,8 +110,8 @@ class SpotlightSlider<InteractionTarget : Any>(
     override fun defaultUiState(uiContext: UiContext, initialUiState: UiState?): UiState = UiState(
         position = Position(
             initialOffset = initialUiState?.position?.initialOffset ?: DpOffset.Zero,
-            clipToBounds = clipToBounds,
             bounds = uiContext.transitionBounds,
+            clipToBounds = uiContext.clipToBounds,
             displacement = geometry.valueFlow
                 .mapState(uiContext.coroutineScope) { value ->
                     DpOffset((value * width.value).dp, 0.dp)
@@ -123,7 +122,8 @@ class SpotlightSlider<InteractionTarget : Any>(
 
     private val created = defaultUiState(uiContext, null).copy(
         position = Position(
-            DpOffset(0.dp, width),
+            initialOffset = DpOffset(0.dp, width),
+            clipToBounds = uiContext.clipToBounds
         ),
         scale = Scale(0f),
         alpha = Alpha(1f),
@@ -132,12 +132,16 @@ class SpotlightSlider<InteractionTarget : Any>(
     )
 
     private val standard = defaultUiState(uiContext, null).copy(
-        position = Position(DpOffset.Zero)
+        position = Position(
+            initialOffset = DpOffset.Zero,
+            clipToBounds = uiContext.clipToBounds
+        )
     )
 
     private val destroyed = defaultUiState(uiContext, null).copy(
         position = Position(
-            DpOffset(0.dp, -width)
+            initialOffset = DpOffset(x = 0.dp, y = -width),
+            clipToBounds = uiContext.clipToBounds
         ),
         scale = Scale(0f),
         alpha = Alpha(0f),
@@ -154,10 +158,11 @@ class SpotlightSlider<InteractionTarget : Any>(
                     element = it.key,
                     uiState = UiState(
                         position = Position(
-                            DpOffset(
-                                dpOffset(index).x,
-                                target.position.value.y
-                            )
+                            initialOffset = DpOffset(
+                                x = dpOffset(index).x,
+                                y = target.position.value.y
+                            ),
+                            clipToBounds = uiContext.clipToBounds
                         ),
                         scale = target.scale,
                         alpha = target.alpha,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/testdrive/interpolator/TestDriveMotionController.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.Logger
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.context.zeroSizeTransitionBounds
 import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor
@@ -29,7 +28,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.abs
 
 class TestDriveMotionController<InteractionTarget : Any>(
@@ -44,23 +42,24 @@ class TestDriveMotionController<InteractionTarget : Any>(
     // TODO extract
     class UiState(
         val uiContext: UiContext,
-        val offset: Position = Position(
-            initialOffset = DpOffset(0.dp, 0.dp)
+        val position: Position = Position(
+            initialOffset = DpOffset.Zero,
+            clipToBounds = uiContext.clipToBounds
         ),
         val backgroundColor: BackgroundColor = BackgroundColor(md_red_500),
     ) : BaseUiState<UiState>(
-        motionProperties = listOf(offset, backgroundColor),
+        motionProperties = listOf(position, backgroundColor),
         coroutineScope = uiContext.coroutineScope
     ) {
 
         override val modifier: Modifier
             get() = Modifier
-                .then(offset.modifier)
+                .then(position.modifier)
                 .then(backgroundColor.modifier)
 
         override suspend fun snapTo(scope: CoroutineScope, uiState: UiState) {
             scope.launch {
-                offset.snapTo(uiState.offset.value)
+                position.snapTo(uiState.position.value)
                 backgroundColor.snapTo(uiState.backgroundColor.value)
             }
         }
@@ -72,8 +71,8 @@ class TestDriveMotionController<InteractionTarget : Any>(
         ) {
             listOf(
                 scope.async {
-                    offset.animateTo(
-                        uiState.offset.value,
+                    position.animateTo(
+                        uiState.position.value,
                         spring(springSpec.dampingRatio, springSpec.stiffness)
                     )
                 },
@@ -88,7 +87,7 @@ class TestDriveMotionController<InteractionTarget : Any>(
 
         override fun lerpTo(scope: CoroutineScope, start: UiState, end: UiState, fraction: Float) {
             scope.launch {
-                offset.lerpTo(start.offset, end.offset, fraction)
+                position.lerpTo(start.position, end.position, fraction)
                 backgroundColor.lerpTo(start.backgroundColor, end.backgroundColor, fraction)
             }
         }
@@ -103,42 +102,34 @@ class TestDriveMotionController<InteractionTarget : Any>(
         fun TestDriveModel.State.ElementState.toUiState(uiContext: UiContext): UiState =
             when (this) {
                 A -> UiState(
-                    uiContext = UiContext(
-                        zeroSizeTransitionBounds,
-                        uiContext.coroutineScope
-                    ),
-                    offset = Position(
+                    uiContext = uiContext,
+                    position = Position(
                         initialOffset = offsetA,
+                        clipToBounds = uiContext.clipToBounds
                     ),
                     backgroundColor = BackgroundColor(md_red_500)
                 )
                 B -> UiState(
-                    uiContext = UiContext(
-                        zeroSizeTransitionBounds,
-                        uiContext.coroutineScope
-                    ),
-                    offset = Position(
-                        initialOffset = offsetB
+                    uiContext = uiContext,
+                    position = Position(
+                        initialOffset = offsetB,
+                        clipToBounds = uiContext.clipToBounds
                     ),
                     backgroundColor = BackgroundColor(md_light_green_500)
                 )
                 C -> UiState(
-                    uiContext = UiContext(
-                        zeroSizeTransitionBounds,
-                        uiContext.coroutineScope
-                    ),
-                    offset = Position(
-                        initialOffset = offsetC
+                    uiContext = uiContext,
+                    position = Position(
+                        initialOffset = offsetC,
+                        clipToBounds = uiContext.clipToBounds
                     ),
                     backgroundColor = BackgroundColor(md_yellow_500)
                 )
                 D -> UiState(
-                    uiContext = UiContext(
-                        zeroSizeTransitionBounds,
-                        CoroutineScope(EmptyCoroutineContext)
-                    ),
-                    offset = Position(
-                        initialOffset = offsetD
+                    uiContext = uiContext,
+                    position = Position(
+                        initialOffset = offsetD,
+                        clipToBounds = uiContext.clipToBounds
                     ),
                     backgroundColor = BackgroundColor(md_light_blue_500)
                 )

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
@@ -34,6 +34,7 @@ import kotlin.math.roundToInt
 inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Children(
     interactionModel: BaseInteractionModel<InteractionTarget, ModelState>,
     modifier: Modifier = Modifier,
+    clipToBounds: Boolean = false,
     gestureSpec: GestureSpec = GestureSpec(),
     noinline block: @Composable ChildrenTransitionScope<InteractionTarget, ModelState>.() -> Unit = {
         children { child, frameModel ->
@@ -60,17 +61,15 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
     Box(
         modifier = modifier
             .fillMaxSize()
-            .composed {
-                val clipToBounds by interactionModel.clipToBounds.collectAsState()
+            .apply {
                 if (clipToBounds) {
                     clipToBounds()
-                } else {
-                    this
                 }
             }
             .onPlaced {
                 uiContext = UiContext(
-                    TransitionBounds(
+                    coroutineScope = coroutineScope,
+                    transitionBounds = TransitionBounds(
                         density = density,
                         widthPx = it.size.width,
                         heightPx = it.size.height,
@@ -78,7 +77,7 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
                         screenWidthPx = screenWidthPx,
                         screenHeightPx = screenHeightPx
                     ),
-                    coroutineScope
+                    clipToBounds = clipToBounds
                 )
             }
     ) {


### PR DESCRIPTION
Move `clipToBounds` to UI (`Children`, which then passes it through `UiContext`). Simplifies the model not having to know about this flag, and will further simplify creating properties (next PR).