### PR TITLE
Add ability to define node customisation lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
--
+- [#391](https://github.com/bumble-tech/appyx/pull/391) – **Added**: Introduced `putLazy` and `putSubDirectoryLazy` functions within `NodeCustomisationDirectoryImpl` via `LazyMutableNodeCustomisationDirectory`
 
 ---
 

--- a/libraries/customisations/build.gradle.kts
+++ b/libraries/customisations/build.gradle.kts
@@ -9,3 +9,12 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    testImplementation(libs.junit.api)
+    testRuntimeOnly(libs.junit.engine)
+}

--- a/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/LazyMutableNodeCustomisationDirectory.kt
+++ b/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/LazyMutableNodeCustomisationDirectory.kt
@@ -1,0 +1,11 @@
+package com.bumble.appyx.utils.customisations
+
+import kotlin.reflect.KClass
+
+@Deprecated("This interface will be merged into MutableNodeCustomisationDirectory as part of 1.2")
+interface LazyMutableNodeCustomisationDirectory: MutableNodeCustomisationDirectory {
+
+    fun <T : Any> putSubDirectoryLazy(key: KClass<T>, valueProvider: () -> NodeCustomisationDirectory)
+
+    fun <T : NodeCustomisation> putLazy(key: KClass<T>, valueProvider: () -> T)
+}

--- a/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/MutableNodeCustomisationDirectory.kt
+++ b/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/MutableNodeCustomisationDirectory.kt
@@ -4,7 +4,15 @@ import kotlin.reflect.KClass
 
 interface MutableNodeCustomisationDirectory : NodeCustomisationDirectory {
 
+    @Deprecated(
+        message = "Use putSubDirectoryLazy to avoid potential performance issues",
+        replaceWith = ReplaceWith("putSubDirectoryLazy(key) { value }")
+    )
     fun <T : Any> putSubDirectory(key: KClass<T>, value: NodeCustomisationDirectory)
 
+    @Deprecated(
+        message = "Use putLazy to avoid potential performance issues",
+        replaceWith = ReplaceWith("putLazy(key) { value }")
+    )
     fun <T : NodeCustomisation> put(key: KClass<T>, value: T)
 }

--- a/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImpl.kt
+++ b/libraries/customisations/src/main/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImpl.kt
@@ -1,20 +1,37 @@
 package com.bumble.appyx.utils.customisations
 
+import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl.DirectoryValue.LazyDirectoryValue
+import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl.DirectoryValue.NonLazyDirectoryValue
 import kotlin.reflect.KClass
 
+@Suppress("TooManyFunctions")
 open class NodeCustomisationDirectoryImpl(
     override val parent: NodeCustomisationDirectory? = null
-) : MutableNodeCustomisationDirectory {
+) : LazyMutableNodeCustomisationDirectory {
 
-    private val map: MutableMap<Any, Any> = hashMapOf()
+    private val map: MutableMap<Any, DirectoryValue> = hashMapOf()
 
+    @Deprecated(
+        "Use putLazy to avoid potential performance issues",
+        replaceWith = ReplaceWith("putLazy(key) { value }")
+    )
     override fun <T : NodeCustomisation> put(key: KClass<T>, value: T) {
-        map[key] = value
+        map[key] = NonLazyDirectoryValue(value)
+    }
+
+    override fun <T : NodeCustomisation> putLazy(key: KClass<T>, valueProvider: () -> T) {
+        map[key] = LazyDirectoryValue(lazy(valueProvider))
     }
 
     fun <T : Any> put(vararg values: T) {
         values.forEach {
-            map[it::class] = it
+            map[it::class] = NonLazyDirectoryValue(it)
+        }
+    }
+
+    fun <T : Any> putLazy(vararg values: Lazy<T>) {
+        values.forEach {
+            map[it::class] = LazyDirectoryValue(it)
         }
     }
 
@@ -23,30 +40,60 @@ open class NodeCustomisationDirectoryImpl(
     }
 
     override fun <T : NodeCustomisation> get(key: KClass<T>): T? =
-        map[key] as? T
+        getValue(key)
 
     override fun <T : NodeCustomisation> getRecursively(key: KClass<T>): T? =
         get(key) ?: parent?.get(key)
 
+    @Deprecated(
+        "Use putSubDirectoryLazy to avoid potential performance issues",
+        replaceWith = ReplaceWith("putSubDirectoryLazy(key) { value }")
+    )
     override fun <T : Any> putSubDirectory(key: KClass<T>, value: NodeCustomisationDirectory) {
-        map[key] = value
+        map[key] = NonLazyDirectoryValue(value)
     }
 
-    override fun <T : Any> getSubDirectory(key: KClass<T>): NodeCustomisationDirectory?=
-        map[key] as? NodeCustomisationDirectory
+    override fun <T : Any> putSubDirectoryLazy(
+        key: KClass<T>,
+        valueProvider: () -> NodeCustomisationDirectory
+    ) {
+        map[key] = LazyDirectoryValue(lazy(valueProvider))
+    }
+
+    override fun <T : Any> getSubDirectory(key: KClass<T>): NodeCustomisationDirectory? =
+        getValue(key)
 
     override fun <T : Any> getSubDirectoryOrSelf(key: KClass<T>): NodeCustomisationDirectory {
         val subDir = map.keys.firstOrNull {
             it is KClass<*> && it.java.isAssignableFrom(key.java)
         }
 
-        return map[subDir] as? NodeCustomisationDirectory ?: this
+        return getValue(subDir) ?: this
     }
 
     operator fun KClass<*>.invoke(block: NodeCustomisationDirectoryImpl.() -> Unit) {
         if (map.containsKey(this)) {
             // TODO warning for accidental override?
         }
-        map[this] = NodeCustomisationDirectoryImpl(this@NodeCustomisationDirectoryImpl).apply(block)
+        map[this] = LazyDirectoryValue(lazy {
+            NodeCustomisationDirectoryImpl(this@NodeCustomisationDirectoryImpl).apply(block)
+        })
+    }
+
+    /**
+     * Gets a value from the map, if the value is lazy the lazy value will be initialized.
+     */
+    private fun <T : Any> getValue(key: Any?): T? =
+        map[key].let { value ->
+            when (value) {
+                is LazyDirectoryValue -> value.lazyValue.value
+                is NonLazyDirectoryValue -> value.value
+                null -> null
+            }
+        } as? T
+
+    private sealed class DirectoryValue {
+        data class LazyDirectoryValue(val lazyValue: Lazy<Any>) : DirectoryValue()
+        data class NonLazyDirectoryValue(val value: Any) : DirectoryValue()
     }
 }

--- a/libraries/customisations/src/test/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImplTest.kt
+++ b/libraries/customisations/src/test/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImplTest.kt
@@ -1,0 +1,83 @@
+package com.bumble.appyx.utils.customisations
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class NodeCustomisationDirectoryImplTest {
+    private val directory = NodeCustomisationDirectoryImpl()
+
+    @Test
+    fun `GIVEN put lazy WHEN get not invoked THEN customisation provider not invoked`() {
+        var providerInvoked = false
+        directory.putLazy(TestCustomisation::class) {
+            providerInvoked = true
+            TestCustomisation("lazy")
+        }
+
+        assertFalse(providerInvoked)
+    }
+
+    @Test
+    fun `GIVEN put lazy WHEN get invoked THEN customisation provider invoked`() {
+        directory.putLazy(TestCustomisation::class) {
+            TestCustomisation("lazy")
+        }
+        assertEquals(TestCustomisation("lazy"), directory.get(TestCustomisation::class))
+    }
+
+    @Test
+    fun `GIVEN put lazy subdirectory WHEN subdirectory not invoked THEN subdirectory block not invoked`() {
+        var customisationDirectoryBlockInvoked = false
+        directory.putSubDirectoryLazy(TestRib::class) {
+            customisationDirectoryBlockInvoked = true
+            NodeCustomisationDirectoryImpl(directory)
+        }
+
+        assertFalse(customisationDirectoryBlockInvoked)
+    }
+
+    @Test
+    fun `GIVEN put lazy subdirectory WHEN subdirectory invoked THEN subdirectory block invoked`() {
+        var customisationDirectoryBlockInvoked = false
+        directory.putSubDirectoryLazy(TestRib::class) {
+            customisationDirectoryBlockInvoked = true
+            NodeCustomisationDirectoryImpl(directory)
+        }
+
+        directory.getSubDirectory(TestRib::class)
+
+        assertTrue(customisationDirectoryBlockInvoked)
+    }
+
+    @Test
+    fun `GIVEN subdirectory created via kclass extension WHEN subdirectory not invoked THEN subdirectory block not invoked`() {
+        var customisationDirectoryBlockInvoked = false
+        directory.apply {
+            TestRib::class {
+                customisationDirectoryBlockInvoked = true
+            }
+        }
+
+        assertFalse(customisationDirectoryBlockInvoked)
+    }
+
+    @Test
+    fun `GIVEN subdirectory created via kclass extension WHEN subdirectory invoked THEN subdirectory block invoked`() {
+        var customisationDirectoryBlockInvoked = false
+        directory.apply {
+            TestRib::class {
+                customisationDirectoryBlockInvoked = true
+            }
+        }
+
+        directory.getSubDirectory(TestRib::class)
+
+        assertTrue(customisationDirectoryBlockInvoked)
+    }
+
+    private data class TestCustomisation(val label: String) : NodeCustomisation
+
+    interface TestRib
+}


### PR DESCRIPTION
## Description
Currently it is not possible to define a node customisation lazily which means that potentially a large amount of classes are instantiated when they are not needed.

This PR aims to add a new API that allows this to be done lazily.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
