### PR TITLE
Fix compile-mpp-sample mkdocs macro

### DIFF
--- a/compose_mpp_sample.py
+++ b/compose_mpp_sample.py
@@ -3,12 +3,11 @@ import shutil
 import os
 
 
-def compile_project(project_directory, compile_task):
+def compile_project(compile_task):
     """Compile a project using Gradle"""
     process = subprocess.Popen(args=['./gradlew', '--rerun-tasks', compile_task],
                                stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE,
-                               cwd=project_directory)
+                               stderr=subprocess.PIPE)
     process.communicate()
     if process.returncode != 0:
         raise ChildProcessError
@@ -42,7 +41,6 @@ def define_env(env):
 
     @env.macro
     def compose_mpp_sample(
-            project_directory,
             project_output_directory,
             compile_task,
             width,
@@ -51,7 +49,7 @@ def define_env(env):
             html_file_name,
             classname,
     ):
-        compile_project(project_directory, compile_task)
+        compile_project(compile_task)
         site_target_directory = os.path.join(env.variables.config.site_dir, target_directory)
         copy_files(project_output_directory, site_target_directory)
         html_target_directory = os.path.relpath(site_target_directory, env.variables.config.site_dir)


### PR DESCRIPTION
## Description

Macro tries to run `gradlew` from project directory instead of using the one at root folder.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
