### PR TITLE
Fix HTML generation with compose_mpp_sample macro

### DIFF
--- a/compose_mpp_sample.py
+++ b/compose_mpp_sample.py
@@ -1,11 +1,12 @@
 import subprocess
 import shutil
 import os
+from urllib.parse import urljoin, urlparse
 
 
 def compile_project(compile_task):
     """Compile a project using Gradle"""
-    process = subprocess.Popen(args=['./gradlew', '--rerun-tasks', compile_task],
+    process = subprocess.Popen(args=['./gradlew', compile_task],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
     process.communicate()
@@ -52,5 +53,6 @@ def define_env(env):
         compile_project(compile_task)
         site_target_directory = os.path.join(env.variables.config.site_dir, target_directory)
         copy_files(project_output_directory, site_target_directory)
-        html_target_directory = os.path.relpath(site_target_directory, env.variables.config.site_dir)
+        base_url = urlparse(env.variables.config.site_url).path
+        html_target_directory = urljoin(base_url, os.path.relpath(site_target_directory, env.variables.config.site_dir))
         return generate_html(width, height, html_target_directory, html_file_name, classname)


### PR DESCRIPTION
## Description
The iframe path for embedding Compose Multiplatform samples was incorrect.
...

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
