### PR TITLE
PermanentModel.kt restore state correctly

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentInteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentInteractionModel.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.interactions.permanent
 import com.bumble.appyx.interactions.core.model.InteractionModel
 import com.bumble.appyx.interactions.core.model.progress.InstantProgressController
 import com.bumble.appyx.interactions.core.model.transition.Operation
+import com.bumble.appyx.interactions.core.state.MutableSavedStateMap
 import com.bumble.appyx.interactions.permanent.PermanentModel.State
 import com.bumble.appyx.mapState
 import kotlinx.coroutines.CoroutineScope
@@ -13,8 +14,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class PermanentInteractionModel<InteractionTarget : Any>(
-    val model: PermanentModel<InteractionTarget> = PermanentModel(emptyList(), null),
-    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    val model: PermanentModel<InteractionTarget>,
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main),
 ) : InteractionModel<InteractionTarget, State<InteractionTarget>> {
 
     private val instant = InstantProgressController(model = model)
@@ -38,6 +39,10 @@ class PermanentInteractionModel<InteractionTarget : Any>(
 
     override fun destroy() {
         scope.cancel()
+    }
+
+    override fun saveInstanceState(state: MutableSavedStateMap) {
+        model.saveInstanceState(state)
     }
 
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentModel.kt
@@ -10,9 +10,11 @@ import com.bumble.appyx.interactions.core.state.SavedStateMap
 import com.bumble.appyx.interactions.permanent.PermanentModel.State
 
 class PermanentModel<InteractionTarget : Any>(
-    initialTargets: List<InteractionTarget>,
     savedStateMap: SavedStateMap?,
+    initialTargets: List<InteractionTarget> = emptyList(),
+    key: String = KEY_PERMANENT_TRANSITION_MODEL
 ) : BaseTransitionModel<InteractionTarget, State<InteractionTarget>>(
+    key = key,
     savedStateMap = savedStateMap,
 ) {
 
@@ -36,4 +38,8 @@ class PermanentModel<InteractionTarget : Any>(
     override val initialState = State(
         elements = initialTargets.map { it.asElement() }
     )
+
+    private companion object {
+        private const val KEY_PERMANENT_TRANSITION_MODEL = "PermanentTransitionModel"
+    }
 }

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/permanent/PermanentModelTest.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/permanent/PermanentModelTest.kt
@@ -30,16 +30,6 @@ class PermanentModelTest {
 
     @Test
     fun GIVEN_permanent_model_without_savedState_WHEN_created_THEN_state_equals_initial_targets() {
-        val savedStateMap = mutableMapOf<String, Any?>()
-        val permanentModel = PermanentModel<InteractionTarget>(
-            savedStateMap = savedStateMap
-        )
-
-        permanentModel.operation(AddUnique(InteractionTarget.Child1))
-
-        val state = MutableSavedStateMapImpl(savedStateMap) { true }
-        permanentModel.saveInstanceState(state)
-
         val initialTargets = listOf(InteractionTarget.Child2, InteractionTarget.Child3)
 
         val newPermanentModel = PermanentModel(

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/permanent/PermanentModelTest.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/permanent/PermanentModelTest.kt
@@ -1,0 +1,55 @@
+package com.bumble.appyx.interactions.permanent
+
+import com.bumble.appyx.InteractionTarget
+import com.bumble.appyx.interactions.core.state.MutableSavedStateMapImpl
+import com.bumble.appyx.interactions.permanent.operation.AddUnique
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PermanentModelTest {
+
+    @Test
+    fun GIVEN_permanent_model_with_savedState_WHEN_created_THEN_restores_state_correctly() {
+        val savedStateMap = mutableMapOf<String, Any?>()
+        val permanentModel = PermanentModel<InteractionTarget>(
+            savedStateMap = savedStateMap
+        )
+
+        permanentModel.operation(AddUnique(InteractionTarget.Child1))
+
+        val state = MutableSavedStateMapImpl(savedStateMap) { true }
+        permanentModel.saveInstanceState(state)
+
+        val newPermanentModel = PermanentModel<InteractionTarget>(savedStateMap = state.savedState)
+
+        assertEquals(
+            listOf(InteractionTarget.Child1),
+            newPermanentModel.output.value.currentTargetState.elements.map { it.interactionTarget }
+        )
+    }
+
+    @Test
+    fun GIVEN_permanent_model_without_savedState_WHEN_created_THEN_state_equals_initial_targets() {
+        val savedStateMap = mutableMapOf<String, Any?>()
+        val permanentModel = PermanentModel<InteractionTarget>(
+            savedStateMap = savedStateMap
+        )
+
+        permanentModel.operation(AddUnique(InteractionTarget.Child1))
+
+        val state = MutableSavedStateMapImpl(savedStateMap) { true }
+        permanentModel.saveInstanceState(state)
+
+        val initialTargets = listOf(InteractionTarget.Child2, InteractionTarget.Child3)
+
+        val newPermanentModel = PermanentModel(
+            initialTargets = initialTargets,
+            savedStateMap = null
+        )
+
+        assertEquals(
+            initialTargets,
+            newPermanentModel.output.value.currentTargetState.elements.map { it.interactionTarget }
+        )
+    }
+}

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/ParentNode.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/ParentNode.kt
@@ -19,6 +19,7 @@ import com.bumble.appyx.interactions.core.plugin.Plugin
 import com.bumble.appyx.interactions.core.state.MutableSavedStateMap
 import com.bumble.appyx.interactions.core.ui.helper.InteractionModelSetup
 import com.bumble.appyx.interactions.permanent.PermanentInteractionModel
+import com.bumble.appyx.interactions.permanent.PermanentModel
 import com.bumble.appyx.interactions.permanent.operation.addUnique
 import com.bumble.appyx.navigation.Appyx
 import com.bumble.appyx.navigation.children.ChildAware
@@ -58,7 +59,9 @@ abstract class ParentNode<InteractionTarget : Any>(
     plugins = plugins + interactionModel + childAware
 ), Resolver<InteractionTarget> {
 
-    private val permanentInteractionModel = PermanentInteractionModel<InteractionTarget>()
+    private val permanentInteractionModel = PermanentInteractionModel<InteractionTarget>(
+        model = PermanentModel(buildContext.savedStateMap)
+    )
     val interactionModel: InteractionModel<InteractionTarget, *> =
         interactionModel + permanentInteractionModel
 

--- a/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/permanentchild/PermanentChildNode.kt
+++ b/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/permanentchild/PermanentChildNode.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumble.appyx.interactions.permanent.PermanentInteractionModel
+import com.bumble.appyx.interactions.permanent.PermanentModel
 import com.bumble.appyx.navigation.colors
 import com.bumble.appyx.navigation.modality.BuildContext
 import com.bumble.appyx.navigation.node.Node
@@ -31,7 +32,7 @@ class PermanentChildNode(
     buildContext: BuildContext,
 ) : ParentNode<PermanentChildNode.InteractionTarget>(
     buildContext = buildContext,
-    interactionModel = PermanentInteractionModel()
+    interactionModel = PermanentInteractionModel(model = PermanentModel(buildContext.savedStateMap))
 ) {
     sealed class InteractionTarget : Parcelable {
         @Parcelize


### PR DESCRIPTION
## Description

Permanent model was not passed a saved state and wasn't restoring state corectly

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
