### PR TITLE
Up navigation interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
--
+- [#425](https://github.com/bumble-tech/appyx/pull/425) – **Fixed**: Up navigation should be properly propagated from Appyx to RIBs
 
 ---
 

--- a/libraries/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/interop/ribs/InteropNodeImplTest.kt
+++ b/libraries/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/interop/ribs/InteropNodeImplTest.kt
@@ -32,4 +32,17 @@ class InteropNodeImplTest {
         rule.onNodeWithTag(oldChild).assertExists()
     }
 
+    @Test
+    fun appyx_up_navigation_is_propagated_to_ribs() {
+        var oldChild = ""
+        rule.activityRule.scenario.onActivity {
+            oldChild = it.ribsNode.current()
+            it.ribsNode.push()
+            it.ribsNode.navigateUpFromActiveAppyxChild()
+        }
+
+        // up navigation propagated to RIBs and it pops backstack
+        rule.onNodeWithTag(oldChild).assertExists()
+    }
+
 }

--- a/libraries/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/interop/ribs/RibsNode.kt
+++ b/libraries/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/interop/ribs/RibsNode.kt
@@ -48,6 +48,14 @@ class RibsNode(
         return id
     }
 
+    fun navigateUpFromActiveAppyxChild() {
+        children
+            .find { it.isActive }
+            // use Appyx node here, not RIBs!
+            ?.let { (it as? InteropNode<AppyxNode>)?.appyxNode }
+            ?.navigateUp() ?: error("No active child")
+    }
+
     class View(
         androidView: ViewGroup,
         lifecycle: Lifecycle,

--- a/libraries/interop-ribs/src/main/kotlin/com/bumble/appyx/interop/ribs/UpHandlingAppyxIntegrationPoint.kt
+++ b/libraries/interop-ribs/src/main/kotlin/com/bumble/appyx/interop/ribs/UpHandlingAppyxIntegrationPoint.kt
@@ -1,0 +1,32 @@
+package com.bumble.appyx.interop.ribs
+
+import com.badoo.ribs.util.RIBs
+import com.bumble.appyx.core.integrationpoint.IntegrationPoint
+import com.bumble.appyx.core.integrationpoint.activitystarter.ActivityStarter
+import com.bumble.appyx.core.integrationpoint.permissionrequester.PermissionRequester
+
+internal class UpHandlingAppyxIntegrationPoint(
+    private val delegate: IntegrationPoint,
+) : IntegrationPoint(null) {
+    private lateinit var upNavigationListener: () -> Unit
+
+    override val activityStarter: ActivityStarter get() = delegate.activityStarter
+    override val permissionRequester: PermissionRequester get() = delegate.permissionRequester
+    override val isChangingConfigurations: Boolean get() = delegate.isChangingConfigurations
+    override fun onRootFinished() = delegate.onRootFinished()
+
+    override fun handleUpNavigation() {
+        if (::upNavigationListener.isInitialized) {
+            upNavigationListener()
+        } else {
+            RIBs.errorHandler.handleNonFatalError(
+                "Up navigation from initialization sequence is not supported"
+            )
+        }
+    }
+
+    fun setUpNavigationListener(listener: () -> Unit) {
+        upNavigationListener = listener
+    }
+
+}


### PR DESCRIPTION
## Description

Up navigation from interop node is handled by `Activity` instead of RIB parent.
This PR properly propagate the call to RIB parent.

Unhandled case: invoking `navigateUp` from `onBuilt`, but looks like it does not work anyway in RIBs too (have tried once), so decided to just report exception.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
