### PR TITLE
Displacement for all MotionProperty

### DIFF
--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/MutableUiState.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/MutableUiState.kt
@@ -3,7 +3,6 @@ package com.bumble.appyx.components.internal.testdrive.ui
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.ui.Modifier
-import com.bumble.appyx.components.demos.testdrive.ui.TargetUiState
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor
 import com.bumble.appyx.interactions.core.ui.property.impl.Position

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/TargetUiState.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/TargetUiState.kt
@@ -1,6 +1,5 @@
-package com.bumble.appyx.components.demos.testdrive.ui
+package com.bumble.appyx.components.internal.testdrive.ui
 
-import com.bumble.appyx.components.internal.testdrive.ui.MutableUiState
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor
 import com.bumble.appyx.interactions.core.ui.property.impl.Position

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/TestDriveMotionController.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/TestDriveMotionController.kt
@@ -11,7 +11,6 @@ import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.Eleme
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.ElementState.C
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.ElementState.D
 import com.bumble.appyx.components.internal.testdrive.operation.MoveTo
-import com.bumble.appyx.components.demos.testdrive.ui.TargetUiState
 import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/MutableUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/MutableUiState.kt
@@ -18,9 +18,6 @@ class MutableUiState(
     val position: Position,
     val scale: Scale,
     val alpha: Alpha,
-//        val zIndex: Float = 1f,               FIXME
-//        val aspectRatio: Float = 0.42f,       FIXME
-//        val rotation: Float = 0f,             FIXME
 ) : BaseMutableUiState<MutableUiState, TargetUiState>(
     uiContext = uiContext,
     motionProperties = listOf(scale, alpha, position)

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -1,6 +1,5 @@
 package com.bumble.appyx.components.spotlight.ui.slider
 
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
@@ -18,7 +17,6 @@ import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
-import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.GenericFloatProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
@@ -35,7 +33,7 @@ class SpotlightSlider<InteractionTarget : Any>(
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
     private val scrollX = GenericFloatProperty(uiContext, 0f) // TODO sync this with the model's initial value rather than assuming 0
-    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, MotionProperty<Float, AnimationVector1D>>> =
+    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX
         )
@@ -78,7 +76,7 @@ class SpotlightSlider<InteractionTarget : Any>(
     }
 
     override fun mutableUiStateFor(uiContext: UiContext, targetUiState: TargetUiState): MutableUiState =
-        targetUiState.toMutableState(uiContext, scrollX.valueFlow, width)
+        targetUiState.toMutableState(uiContext, scrollX.renderValueFlow, width)
 
 
     class Gestures<InteractionTarget>(

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/TargetUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/TargetUiState.kt
@@ -9,8 +9,10 @@ import com.bumble.appyx.interactions.core.ui.property.impl.Position
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.mapState
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.math.abs
 
 class TargetUiState(
+    private val positionInList: Int = 0,
     val position: Position.Target,
     val scale: Scale.Target,
     val alpha: Alpha.Target,
@@ -23,6 +25,7 @@ class TargetUiState(
         positionInList: Int,
         elementWidth: Dp
     ) : this(
+        positionInList = positionInList,
         position = Position.Target(
             base.position.value.copy(
                 x = (positionInList * elementWidth.value).dp
@@ -33,7 +36,9 @@ class TargetUiState(
     )
 
     /**
-     * Take the dynamically changing scroll into account
+     * Takes the dynamically changing scroll into account when calculating values.
+     *
+     * TODO support RTL and Orientation.Vertical
      */
     fun toMutableState(
         uiContext: UiContext,
@@ -43,14 +48,16 @@ class TargetUiState(
         MutableUiState(
             uiContext = uiContext,
             position = Position(
-                uiContext = uiContext,
-                target = position,
-                displacement = scrollX
-                    .mapState(uiContext.coroutineScope) { value ->
-                        DpOffset((value * elementWidth.value).dp, 0.dp)
-                    },
+                uiContext, position,
+                scrollX.mapState(uiContext.coroutineScope) {
+                    DpOffset((it * elementWidth.value).dp, 0.dp)
+                },
             ),
-            scale = Scale(uiContext, scale),
+            scale = Scale(uiContext, scale,
+                displacement = scrollX.mapState(uiContext.coroutineScope) {
+                    (abs(positionInList - it) - 0.15f).coerceIn(0f, 0.25f)
+                }
+            ),
             alpha = Alpha(uiContext, alpha),
         )
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/MutableUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/MutableUiState.kt
@@ -1,0 +1,82 @@
+package com.bumble.appyx.components.spotlight.ui.sliderrotation
+
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
+import com.bumble.appyx.interactions.core.ui.property.impl.Position
+import com.bumble.appyx.interactions.core.ui.property.impl.RotationY
+import com.bumble.appyx.interactions.core.ui.property.impl.Scale
+import com.bumble.appyx.interactions.core.ui.state.BaseMutableUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+
+class MutableUiState(
+    uiContext: UiContext,
+    val position: Position,
+    val scale: Scale,
+    val rotationY: RotationY,
+    val alpha: Alpha,
+//        val zIndex: Float = 1f,               FIXME
+//        val aspectRatio: Float = 0.42f,       FIXME
+//        val rotation: Float = 0f,             FIXME
+) : BaseMutableUiState<MutableUiState, TargetUiState>(
+    uiContext = uiContext,
+    motionProperties = listOf(scale, alpha, position)
+) {
+    override val modifier: Modifier
+        get() = Modifier.then(position.modifier)
+            .then(scale.modifier)
+            .then(rotationY.modifier)
+            .then(alpha.modifier)
+
+    override suspend fun snapTo(scope: CoroutineScope, target: TargetUiState) {
+        scope.launch {
+            position.snapTo(target.position.value)
+            scale.snapTo(target.scale.value)
+            rotationY.snapTo(target.rotationY.value)
+            alpha.snapTo(target.alpha.value)
+        }
+    }
+
+    override suspend fun animateTo(
+        scope: CoroutineScope,
+        target: TargetUiState,
+        springSpec: SpringSpec<Float>,
+    ) {
+        scope.launch {
+            listOf(
+                scope.async {
+                    position.animateTo(
+                        target.position.value,
+                        spring(springSpec.dampingRatio, springSpec.stiffness)
+                    )
+                    scale.animateTo(
+                        target.scale.value,
+                        spring(springSpec.dampingRatio, springSpec.stiffness)
+                    )
+                    rotationY.animateTo(
+                        target.rotationY.value,
+                        spring(springSpec.dampingRatio, springSpec.stiffness)
+                    )
+                    alpha.animateTo(
+                        target.alpha.value,
+                        spring(springSpec.dampingRatio, springSpec.stiffness)
+                    )
+                }
+            ).awaitAll()
+        }
+    }
+
+    override fun lerpTo(scope: CoroutineScope, start: TargetUiState, end: TargetUiState, fraction: Float) {
+        scope.launch {
+            position.lerpTo(start.position, end.position, fraction)
+            scale.lerpTo(start.scale, end.scale, fraction)
+            rotationY.lerpTo(start.rotationY, end.rotationY, fraction)
+            alpha.lerpTo(start.alpha, end.alpha, fraction)
+        }
+    }
+}

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
@@ -1,0 +1,85 @@
+package com.bumble.appyx.components.spotlight.ui.sliderrotation
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.bumble.appyx.components.spotlight.SpotlightModel.State
+import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.CREATED
+import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.DESTROYED
+import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.STANDARD
+import com.bumble.appyx.components.spotlight.operation.Next
+import com.bumble.appyx.components.spotlight.operation.Previous
+import com.bumble.appyx.interactions.core.model.transition.Operation.Mode.KEYFRAME
+import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.gesture.Gesture
+import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
+import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
+import com.bumble.appyx.interactions.core.ui.property.impl.GenericFloatProperty
+import com.bumble.appyx.interactions.core.ui.property.impl.Position
+import com.bumble.appyx.interactions.core.ui.property.impl.RotationY
+import com.bumble.appyx.interactions.core.ui.property.impl.Scale
+import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
+import com.bumble.appyx.transitionmodel.BaseMotionController
+
+class SpotlightSliderRotation<InteractionTarget : Any>(
+    uiContext: UiContext,
+    private val orientation: Orientation = Orientation.Horizontal, // TODO support RTL
+) : BaseMotionController<InteractionTarget, State<InteractionTarget>, MutableUiState, TargetUiState>(
+    uiContext = uiContext
+) {
+    private val width: Dp = uiContext.transitionBounds.widthDp
+    private val height: Dp = uiContext.transitionBounds.heightDp
+    private val scrollX = GenericFloatProperty(uiContext, 0f) // TODO sync this with the model's initial value rather than assuming 0
+    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
+        listOf(
+            { state: State<InteractionTarget> -> state.activeIndex } to scrollX
+        )
+
+    private val created: TargetUiState = TargetUiState(
+        position = Position.Target(DpOffset(0.dp, width)),
+        scale = Scale.Target(0f),
+        rotationY = RotationY.Target(0f),
+        alpha = Alpha.Target(1f),
+    )
+
+    private val standard: TargetUiState = TargetUiState(
+        position = Position.Target(DpOffset.Zero),
+        scale = Scale.Target(1f),
+        rotationY = RotationY.Target(0f),
+        alpha = Alpha.Target(1f),
+    )
+
+    private val destroyed: TargetUiState = TargetUiState(
+        position = Position.Target(DpOffset(x = 0.dp, y = -height)),
+        scale = Scale.Target(0f),
+        rotationY = RotationY.Target(0f),
+        alpha = Alpha.Target(0f),
+    )
+
+    override fun State<InteractionTarget>.toUiTargets(): List<MatchedTargetUiState<InteractionTarget, TargetUiState>> {
+        return positions.flatMapIndexed { index, position ->
+            position.elements.map {
+                MatchedTargetUiState(
+                    element = it.key,
+                    targetUiState = TargetUiState(
+                        base = when (it.value) {
+                            CREATED -> created
+                            STANDARD -> standard
+                            DESTROYED -> destroyed
+                        },
+                        positionInList = index,
+                        elementWidth = width
+                    )
+                )
+            }
+        }
+    }
+
+    override fun mutableUiStateFor(uiContext: UiContext, targetUiState: TargetUiState): MutableUiState =
+        targetUiState.toMutableState(uiContext, scrollX.renderValueFlow, width)
+}
+

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/TargetUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/TargetUiState.kt
@@ -1,0 +1,74 @@
+package com.bumble.appyx.components.spotlight.ui.sliderrotation
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.math.cutOffCenter
+import com.bumble.appyx.interactions.core.ui.math.cutOffCenterSigned
+import com.bumble.appyx.interactions.core.ui.math.scaleUpTo
+import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
+import com.bumble.appyx.interactions.core.ui.property.impl.Position
+import com.bumble.appyx.interactions.core.ui.property.impl.RotationY
+import com.bumble.appyx.interactions.core.ui.property.impl.Scale
+import com.bumble.appyx.mapState
+import kotlinx.coroutines.flow.StateFlow
+
+class TargetUiState(
+    private val positionInList: Int = 0,
+    val position: Position.Target,
+    val scale: Scale.Target,
+    val rotationY: RotationY.Target,
+    val alpha: Alpha.Target,
+) {
+    /**
+     * Take item's own position in the list of elements into account
+     */
+    constructor(
+        base: TargetUiState,
+        positionInList: Int,
+        elementWidth: Dp
+    ) : this(
+        positionInList = positionInList,
+        position = Position.Target(
+            base.position.value.copy(
+                x = (positionInList * elementWidth.value).dp
+            )
+        ),
+        scale = base.scale,
+        rotationY = base.rotationY,
+        alpha = base.alpha,
+    )
+
+    /**
+     * Takes the dynamically changing scroll into account when calculating values.
+     *
+     * TODO support RTL and Orientation.Vertical
+     */
+    fun toMutableState(
+        uiContext: UiContext,
+        scrollX: StateFlow<Float>,
+        elementWidth: Dp
+    ): MutableUiState {
+        return MutableUiState(
+            uiContext = uiContext,
+            position = Position(
+                uiContext, position,
+                scrollX.mapState(uiContext.coroutineScope) {
+                    DpOffset((it * elementWidth.value).dp, 0.dp)
+                },
+            ),
+            scale = Scale(uiContext, scale,
+                displacement = scrollX.mapState(uiContext.coroutineScope) { scroll ->
+                    scaleUpTo(cutOffCenter(positionInList.toFloat(), scroll, 0.15f), -0.1f, 1f)
+                }
+            ),
+            rotationY = RotationY(uiContext, rotationY,
+                displacement = scrollX.mapState(uiContext.coroutineScope) { scroll ->
+                    scaleUpTo(cutOffCenterSigned(positionInList.toFloat(), scroll, 0.15f), 15f, 1f)
+                }
+            ),
+            alpha = Alpha(uiContext, alpha),
+        )
+    }
+}

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/MutableUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/MutableUiState.kt
@@ -1,12 +1,10 @@
-package com.bumble.appyx.components.spotlight.ui.sliderrotation
+package com.bumble.appyx.components.spotlight.ui.sliderscale
 
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
-import com.bumble.appyx.interactions.core.ui.property.impl.RotationY
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.interactions.core.ui.state.BaseMutableUiState
 import kotlinx.coroutines.CoroutineScope
@@ -18,24 +16,18 @@ class MutableUiState(
     uiContext: UiContext,
     val position: Position,
     val scale: Scale,
-    val rotationY: RotationY,
-    val alpha: Alpha,
 ) : BaseMutableUiState<MutableUiState, TargetUiState>(
     uiContext = uiContext,
-    motionProperties = listOf(scale, alpha, position)
+    motionProperties = listOf(scale, position)
 ) {
     override val modifier: Modifier
         get() = Modifier.then(position.modifier)
             .then(scale.modifier)
-            .then(rotationY.modifier)
-            .then(alpha.modifier)
 
     override suspend fun snapTo(scope: CoroutineScope, target: TargetUiState) {
         scope.launch {
             position.snapTo(target.position.value)
             scale.snapTo(target.scale.value)
-            rotationY.snapTo(target.rotationY.value)
-            alpha.snapTo(target.alpha.value)
         }
     }
 
@@ -55,14 +47,6 @@ class MutableUiState(
                         target.scale.value,
                         spring(springSpec.dampingRatio, springSpec.stiffness)
                     )
-                    rotationY.animateTo(
-                        target.rotationY.value,
-                        spring(springSpec.dampingRatio, springSpec.stiffness)
-                    )
-                    alpha.animateTo(
-                        target.alpha.value,
-                        spring(springSpec.dampingRatio, springSpec.stiffness)
-                    )
                 }
             ).awaitAll()
         }
@@ -72,8 +56,6 @@ class MutableUiState(
         scope.launch {
             position.lerpTo(start.position, end.position, fraction)
             scale.lerpTo(start.scale, end.scale, fraction)
-            rotationY.lerpTo(start.rotationY, end.rotationY, fraction)
-            alpha.lerpTo(start.alpha, end.alpha, fraction)
         }
     }
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
@@ -1,4 +1,4 @@
-package com.bumble.appyx.components.spotlight.ui.sliderrotation
+package com.bumble.appyx.components.spotlight.ui.sliderscale
 
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.ui.unit.Dp
@@ -9,15 +9,13 @@ import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.C
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.DESTROYED
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.STANDARD
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.GenericFloatProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
-import com.bumble.appyx.interactions.core.ui.property.impl.RotationY
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
 import com.bumble.appyx.transitionmodel.BaseMotionController
 
-class SpotlightSliderRotation<InteractionTarget : Any>(
+class SpotlightSliderScale<InteractionTarget : Any>(
     uiContext: UiContext,
     private val orientation: Orientation = Orientation.Horizontal, // TODO support RTL
 ) : BaseMotionController<InteractionTarget, State<InteractionTarget>, MutableUiState, TargetUiState>(
@@ -34,22 +32,16 @@ class SpotlightSliderRotation<InteractionTarget : Any>(
     private val created: TargetUiState = TargetUiState(
         position = Position.Target(DpOffset(0.dp, width)),
         scale = Scale.Target(0f),
-        rotationY = RotationY.Target(0f),
-        alpha = Alpha.Target(1f),
     )
 
     private val standard: TargetUiState = TargetUiState(
         position = Position.Target(DpOffset.Zero),
         scale = Scale.Target(1f),
-        rotationY = RotationY.Target(0f),
-        alpha = Alpha.Target(1f),
     )
 
     private val destroyed: TargetUiState = TargetUiState(
         position = Position.Target(DpOffset(x = 0.dp, y = -height)),
         scale = Scale.Target(0f),
-        rotationY = RotationY.Target(0f),
-        alpha = Alpha.Target(0f),
     )
 
     override fun State<InteractionTarget>.toUiTargets(): List<MatchedTargetUiState<InteractionTarget, TargetUiState>> {

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/TargetUiState.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/TargetUiState.kt
@@ -1,10 +1,9 @@
-package com.bumble.appyx.components.spotlight.ui.slider
+package com.bumble.appyx.components.spotlight.ui.sliderscale
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.mapState
@@ -15,7 +14,6 @@ class TargetUiState(
     private val positionInList: Int = 0,
     val position: Position.Target,
     val scale: Scale.Target,
-    val alpha: Alpha.Target,
 ) {
     /**
      * Take item's own position in the list of elements into account
@@ -32,7 +30,6 @@ class TargetUiState(
             )
         ),
         scale = base.scale,
-        alpha = base.alpha,
     )
 
     /**
@@ -44,8 +41,8 @@ class TargetUiState(
         uiContext: UiContext,
         scrollX: StateFlow<Float>,
         elementWidth: Dp
-    ): MutableUiState =
-        MutableUiState(
+    ): MutableUiState {
+        return MutableUiState(
             uiContext = uiContext,
             position = Position(
                 uiContext, position,
@@ -53,7 +50,11 @@ class TargetUiState(
                     DpOffset((it * elementWidth.value).dp, 0.dp)
                 },
             ),
-            scale = Scale(uiContext, scale),
-            alpha = Alpha(uiContext, alpha),
+            scale = Scale(uiContext, scale,
+                displacement = scrollX.mapState(uiContext.coroutineScope) {
+                    (abs(positionInList - it) - 0.15f).coerceIn(0f, 0.25f)
+                }
+            )
         )
+    }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/ScrollMath.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/ScrollMath.kt
@@ -1,0 +1,30 @@
+package com.bumble.appyx.interactions.core.ui.math
+
+import kotlin.math.abs
+import kotlin.math.sign
+
+/**
+ * Will result in a graph like:
+ *
+ *  \     /
+ *   \___/
+ *
+ * Where the length of ___ = 2 x halfCenterRange
+ */
+fun cutOffCenter(ownValue: Float, movingValue: Float, halfCenterRange: Float) =
+    (abs(ownValue - movingValue) - halfCenterRange).coerceAtLeast(0f)
+
+/**
+ * Will result in a graph like:
+ *
+ *        /
+ *    ___/
+ *  /
+ *
+ * Where the length of ___ = 2 x halfCenterRange
+ */
+fun cutOffCenterSigned(ownValue: Float, movingValue: Float, halfCenterRange: Float) =
+    cutOffCenter(ownValue, movingValue, halfCenterRange) * sign(ownValue - movingValue)
+
+fun scaleUpTo(v: Float, scale: Float, slope: Float) =
+    (slope * scale * v).coerceIn(-abs(scale), abs(scale))

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
@@ -17,20 +17,34 @@ import com.bumble.appyx.interactions.SystemClock
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.mapState
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
 /**
  * Keeps a value change in motion by calculating the rate of change of the wrapped Animatable value
  * even when snapping. This is used to seamlessly switch to animation with a natural initial velocity
  * rather than zero.
+ *
+ * @param uiContext
+ * @param animatable The backing [Animatable] to animate internal values with.
+ * @param easing The [Easing] function to apply when setting interpolated values.
+ * See [easingTransform].
+ * @param visibilityThreshold The visibility threshold that will be passed to [Animatable]
+ * when animating.
+ * @param displacement A flow of values to apply as a displacement on top of the internal values
+ * that are backed by the internal [Animatable].
  */
 abstract class MotionProperty<T, V : AnimationVector>(
     protected val uiContext: UiContext,
-    protected val animatable: Animatable<T, V>,
+    private val animatable: Animatable<T, V>,
     val easing: Easing? = null,
     private val visibilityThreshold: T? = null,
+    private val displacement: StateFlow<T>
 ) {
+
     private var lastVelocity = animatable.velocity
 
     /**
@@ -42,17 +56,51 @@ abstract class MotionProperty<T, V : AnimationVector>(
     private var lastTime = 0L
 
     /**
-     * Mapper which resolves visibility of the property. If property has no influence on the visibility
-     * do not change default visibilityMapper.
+     * Mapper which resolves the visibility of the property. If property has no influence on the
+     * visibility, it should always return true.
      */
     open val visibilityMapper: ((T) -> Boolean) = { true }
 
-    private val _valueFlow = MutableStateFlow(animatable.value)
-    val valueFlow: StateFlow<T>
-        get() = _valueFlow
+    private val internalValueFlow = MutableStateFlow(animatable.value)
 
-    val value: T
+
+    /**
+     * Contains the unmodified internal value of the [MotionProperty] backed by its [Animatable].
+     * Useful if you need information on animation targets, i.e. what this [MotionProperty] thinks
+     * it should display before that value being modified by any displacements.
+     *
+     * If you need render-ready values (for Modifiers, checking visibility, etc.) then you need
+     * to use [renderValue] instead.
+     */
+    val internalValue: T
         get() = animatable.value
+
+    /**
+     * Contains the render-ready flow of values with displacements already applied.
+     *
+     * @see [renderValue]
+     */
+    val renderValueFlow: StateFlow<T>
+        get() = displacement.combine(
+            internalValueFlow
+        ) { displacement, value ->
+            calculateRenderValue(value, displacement)
+        }.stateIn(
+            scope = uiContext.coroutineScope,
+            started = SharingStarted.Eagerly,
+            initialValue = internalValueFlow.value
+        )
+
+    /**
+     * @return Should return the result of a subtraction [base - displacement] interpreted for <T>
+     */
+    abstract fun calculateRenderValue(base: T, displacement: T): T
+
+    /**
+     * Render-ready value that contains applied displacements on top of the [internalValue].
+     */
+    val renderValue: T
+        get() = renderValueFlow.value
 
     abstract val modifier: Modifier
 
@@ -60,19 +108,13 @@ abstract class MotionProperty<T, V : AnimationVector>(
     val isAnimating: StateFlow<Boolean>
         get() = _isAnimatingFlow
 
-    /**
-     * Source of the value which will be used to resolve visibility. By default it's animatable
-     * flow but it can be overridden if the motion property visibility depends.
-     */
-    open val valueSource: StateFlow<T> = valueFlow
-
     val isVisibleFlow: StateFlow<Boolean>
-        get() = valueSource.mapState(uiContext.coroutineScope) { value ->
+        get() = renderValueFlow.mapState(uiContext.coroutineScope) { value ->
             visibilityMapper.invoke(value)
         }
 
     private fun onValueChanged() {
-        _valueFlow.update { value }
+        internalValueFlow.update { internalValue }
     }
 
     /**
@@ -159,7 +201,7 @@ abstract class MotionProperty<T, V : AnimationVector>(
         val animationSpec1 = insertVisibilityThreshold(animationSpec)
         AppyxLogger.d("MotionProperty", "Starting with initialVelocity = $previousVelocity")
         _isAnimatingFlow.update {
-            targetValue != value
+            targetValue != internalValue
         }
         val result = animatable.animateTo(
             targetValue = targetValue,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
@@ -80,8 +80,8 @@ abstract class MotionProperty<T, V : AnimationVector>(
      *
      * @see [renderValue]
      */
-    val renderValueFlow: StateFlow<T>
-        get() = displacement.combine(
+    val renderValueFlow: StateFlow<T> =
+        displacement.combine(
             internalValueFlow
         ) { displacement, value ->
             calculateRenderValue(value, displacement)
@@ -108,10 +108,11 @@ abstract class MotionProperty<T, V : AnimationVector>(
     val isAnimating: StateFlow<Boolean>
         get() = _isAnimatingFlow
 
-    val isVisibleFlow: StateFlow<Boolean>
-        get() = renderValueFlow.mapState(uiContext.coroutineScope) { value ->
+    val isVisibleFlow: StateFlow<Boolean> by lazy {
+        renderValueFlow.mapState(uiContext.coroutineScope) { value ->
             visibilityMapper.invoke(value)
         }
+    }
 
     private fun onValueChanged() {
         internalValueFlow.update { internalValue }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.interactions.core.ui.property.impl
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Easing
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
@@ -10,16 +11,20 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class Alpha(
     uiContext: UiContext,
     target: Target,
-    visibilityThreshold: Float = 0.01f
+    visibilityThreshold: Float = 0.01f,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
     uiContext = uiContext,
     animatable = Animatable(target.value),
     easing = target.easing,
-    visibilityThreshold = visibilityThreshold
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Alpha.Target> {
 
     class Target(
@@ -27,13 +32,16 @@ class Alpha(
         val easing: Easing? = null,
     )
 
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
     override val visibilityMapper: ((Float) -> Boolean) = { alpha ->
         alpha > 0.0f
     }
 
     override val modifier: Modifier
         get() = Modifier.composed {
-            this.alpha(animatable.asState().value)
+            this.alpha(renderValueFlow.collectAsState().value)
         }
 
     override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector4D
 import androidx.compose.animation.core.Easing
 import androidx.compose.foundation.background
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
@@ -12,17 +13,21 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import androidx.compose.ui.graphics.lerp as lerpColor
 
 class BackgroundColor(
     uiContext: UiContext,
     target: Target,
-    visibilityThreshold: Color = Color(1, 1, 1, 1)
+    displacement: StateFlow<Color> = MutableStateFlow(Color.Unspecified),
+    visibilityThreshold: Color = Color(1, 1, 1, 1),
 ) : MotionProperty<Color, AnimationVector4D>(
     uiContext = uiContext,
     animatable = Animatable(target.value, Color.VectorConverter(target.value.colorSpace)),
     easing = target.easing,
-    visibilityThreshold = visibilityThreshold
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Target> {
 
     class Target(
@@ -30,9 +35,18 @@ class BackgroundColor(
         val easing: Easing? = null,
     )
 
+    /**
+     * This class currently doesn't support color displacement.
+     * Another MotionProperty class based on a non-compose Color class that has
+     * more functionality (e.g. ajalt/colormath) can implement HSV or other color displacements
+     * as required.
+     */
+    override fun calculateRenderValue(base: Color, displacement: Color): Color =
+        base
+
     override val modifier: Modifier
         get() = Modifier.composed {
-            this.background(color = animatable.asState().value)
+            this.background(color = renderValueFlow.collectAsState().value)
         }
 
     override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/GenericFloatProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/GenericFloatProperty.kt
@@ -7,14 +7,21 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class GenericFloatProperty(
     uiContext: UiContext,
-    value: Float
+    value: Float,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
     uiContext = uiContext,
-    animatable = Animatable(value)
+    animatable = Animatable(value),
+    displacement = displacement
 ), Interpolatable<GenericFloatProperty> {
+
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
 
     override val modifier: Modifier
         get() = Modifier
@@ -22,8 +29,8 @@ class GenericFloatProperty(
     override suspend fun lerpTo(start: GenericFloatProperty, end: GenericFloatProperty, fraction: Float) {
         snapTo(
             lerpFloat(
-                start = start.value,
-                end = end.value,
+                start = start.internalValue,
+                end = end.internalValue,
                 progress = easingTransform(end.easing, fraction)
             )
         )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.combineState
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpDpOffset
@@ -23,19 +22,23 @@ import kotlinx.coroutines.flow.StateFlow
 class Position(
     uiContext: UiContext,
     val target: Target,
-    private val displacement: StateFlow<DpOffset> = MutableStateFlow(DpOffset.Zero),
+    displacement: StateFlow<DpOffset> = MutableStateFlow(DpOffset.Zero),
     visibilityThreshold: DpOffset = DpOffset(1.dp, 1.dp),
 ) : MotionProperty<DpOffset, AnimationVector2D>(
     uiContext = uiContext,
     animatable = Animatable(target.value, DpOffset.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Position.Target> {
 
     class Target(
         val value: DpOffset,
         val easing: Easing? = null,
     )
+
+    override fun calculateRenderValue(base: DpOffset, displacement: DpOffset): DpOffset =
+        base - displacement
 
     override val visibilityMapper: (DpOffset) -> Boolean = { displacedValue ->
         val bounds = uiContext.transitionBounds
@@ -51,14 +54,6 @@ class Position(
             && itemOffsetRangeY.hasIntersection(visibleOffsetRangeY)
         isVisible
     }
-
-    override val valueSource: StateFlow<DpOffset>
-        get() = displacement.combineState(valueFlow, uiContext.coroutineScope) { displacement, dpOffset ->
-            DpOffset(
-                x = dpOffset.x - displacement.x,
-                y = dpOffset.y - displacement.y
-            )
-        }
 
     private fun calculateItemOffsetRangeX(
         displacedValue: DpOffset,
@@ -101,10 +96,10 @@ class Position(
 
     override val modifier: Modifier
         get() = Modifier.composed {
-            val displacedValue = valueSource.collectAsState()
+            val value = renderValueFlow.collectAsState()
             this.offset(
-                x = displacedValue.value.x,
-                y = displacedValue.value.y
+                x = value.value.x,
+                y = value.value.y
             )
         }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
@@ -1,0 +1,58 @@
+package com.bumble.appyx.interactions.core.ui.property.impl
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.graphicsLayer
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.math.lerpFloat
+import com.bumble.appyx.interactions.core.ui.property.Interpolatable
+import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import com.bumble.appyx.interactions.core.ui.property.impl.RotationX.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class RotationX(
+    uiContext: UiContext,
+    target: Target,
+    visibilityThreshold: Float = 1f,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
+) : MotionProperty<Float, AnimationVector1D>(
+    uiContext = uiContext,
+    animatable = Animatable(target.value, Float.VectorConverter),
+    easing = target.easing,
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
+), Interpolatable<Target> {
+
+    class Target(
+        val value: Float,
+        val easing: Easing? = null,
+    )
+
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
+    override val modifier: Modifier
+        get() = Modifier.composed {
+            val value by renderValueFlow.collectAsState()
+            this.graphicsLayer {
+                rotationX = value
+            }
+        }
+
+    override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
+    }
+}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
@@ -1,0 +1,58 @@
+package com.bumble.appyx.interactions.core.ui.property.impl
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.graphicsLayer
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.math.lerpFloat
+import com.bumble.appyx.interactions.core.ui.property.Interpolatable
+import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import com.bumble.appyx.interactions.core.ui.property.impl.RotationY.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class RotationY(
+    uiContext: UiContext,
+    target: Target,
+    visibilityThreshold: Float = 1f,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
+) : MotionProperty<Float, AnimationVector1D>(
+    uiContext = uiContext,
+    animatable = Animatable(target.value, Float.VectorConverter),
+    easing = target.easing,
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
+), Interpolatable<Target> {
+
+    class Target(
+        val value: Float,
+        val easing: Easing? = null,
+    )
+
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
+    override val modifier: Modifier
+        get() = Modifier.composed {
+            val value by renderValueFlow.collectAsState()
+            this.graphicsLayer {
+                rotationY = value
+            }
+        }
+
+    override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {
+        snapTo(
+            lerpFloat(
+                start = start.value,
+                end = end.value,
+                progress = easingTransform(end.easing, fraction)
+            )
+        )
+    }
+}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -13,16 +14,20 @@ import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.RotationZ.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class RotationZ(
     uiContext: UiContext,
     target: Target,
-    visibilityThreshold: Float = 1f
+    visibilityThreshold: Float = 1f,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
     uiContext = uiContext,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
-    visibilityThreshold = visibilityThreshold
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Target> {
 
     class Target(
@@ -30,9 +35,12 @@ class RotationZ(
         val easing: Easing? = null,
     )
 
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
     override val modifier: Modifier
         get() = Modifier.composed {
-            val value by animatable.asState()
+            val value by renderValueFlow.collectAsState()
             this.graphicsLayer {
                 rotationZ = value
             }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
@@ -13,16 +13,20 @@ import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class Scale(
     uiContext: UiContext,
     target: Target,
-    visibilityThreshold: Float = 0.01f
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
+    visibilityThreshold: Float = 0.01f,
 ) : MotionProperty<Float, AnimationVector1D>(
     uiContext = uiContext,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
-    visibilityThreshold = visibilityThreshold
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Target> {
 
     class Target(
@@ -30,14 +34,16 @@ class Scale(
         val easing: Easing? = null,
     )
 
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
     override val visibilityMapper: ((Float) -> Boolean) = { scale ->
         scale > 0.0f
     }
 
     override val modifier: Modifier
         get() = Modifier.composed {
-            val value by animatable.asState()
-            this.scale(value)
+            this.scale(renderValueFlow.collectAsState().value)
         }
 
     override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.VectorConverter
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.zIndex
@@ -13,16 +13,20 @@ import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.ZIndex.Target
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class ZIndex(
     uiContext: UiContext,
     target: Target,
-    visibilityThreshold: Float = 0.01f
+    visibilityThreshold: Float = 0.01f,
+    displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
     uiContext = uiContext,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
-    visibilityThreshold = visibilityThreshold
+    visibilityThreshold = visibilityThreshold,
+    displacement = displacement
 ), Interpolatable<Target> {
 
     class Target(
@@ -30,10 +34,12 @@ class ZIndex(
         val easing: Easing? = null,
     )
 
+    override fun calculateRenderValue(base: Float, displacement: Float): Float =
+        base - displacement
+
     override val modifier: Modifier
         get() = Modifier.composed {
-            val value by animatable.asState()
-            this.zIndex(value)
+            this.zIndex(renderValueFlow.collectAsState().value)
         }
 
     override suspend fun lerpTo(start: Target, end: Target, fraction: Float) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -1,7 +1,6 @@
 package com.bumble.appyx.transitionmodel
 
 import DefaultAnimationSpec
-import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
@@ -17,7 +16,7 @@ import com.bumble.appyx.interactions.core.ui.MotionController
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
-import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import com.bumble.appyx.interactions.core.ui.property.impl.GenericFloatProperty
 import com.bumble.appyx.interactions.core.ui.state.BaseMutableUiState
 import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
 import com.bumble.appyx.withPrevious
@@ -34,7 +33,7 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
     protected val defaultAnimationSpec: SpringSpec<Float> = DefaultAnimationSpec,
 ) : MotionController<InteractionTarget, ModelState> where MutableUiState : BaseMutableUiState<MutableUiState, TargetUiState> {
 
-    open val geometryMappings: List<Pair<(ModelState) -> Float, MotionProperty<Float, AnimationVector1D>>> =
+    open val geometryMappings: List<Pair<(ModelState) -> Float, GenericFloatProperty>> =
         emptyList()
 
     private val coroutineScope = uiContext.coroutineScope
@@ -241,14 +240,14 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
                 }
 
                 GeometryBehaviour.ANIMATE -> {
-                    if (geometry.value != targetValue) {
+                    if (geometry.internalValue != targetValue) {
                         geometry.animateTo(
                             targetValue, spring(
                                 stiffness = currentSpringSpec.stiffness,
                                 dampingRatio = currentSpringSpec.dampingRatio
                             )
                         ) {
-                            AppyxLogger.d(TAG, "Geometry animateTo (Segment) – ${geometry.value} -> $targetValue")
+                            AppyxLogger.d(TAG, "Geometry animateTo (Segment) – ${geometry.internalValue} -> $targetValue")
                         }
                     }
                 }

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import com.bumble.appyx.components.demos.cards.DatingCards
 import com.bumble.appyx.components.demos.promoter.PromoterExperiment
 import com.bumble.appyx.components.internal.testdrive.android.TestDriveExperiment
+import com.bumble.appyx.components.spotlight.ui.slider.SpotlightSlider
+import com.bumble.appyx.components.spotlight.ui.sliderrotation.SpotlightSliderRotation
 import com.bumble.appyx.interactions.sample.BackStackExperimentDebug
 import com.bumble.appyx.interactions.sample.SpotlightExperiment
 import com.bumble.appyx.interactions.sample.SpotlightExperimentDebug
@@ -63,12 +65,12 @@ class MainActivity : ComponentActivity() {
                         }
                         when (content) {
                             0 -> DatingCards()
-                            1 -> SpotlightExperiment()
-                            2 -> SpotlightExperimentDebug()
+                            1 -> SpotlightExperiment { SpotlightSlider(it) }
+                            2 -> SpotlightExperiment { SpotlightSliderRotation(it) }
                             3 -> BackStackExperimentDebug()
                             4 -> TestDriveExperiment()
                             5 -> PromoterExperiment()
-                            else -> SpotlightExperiment()
+                            else -> SpotlightExperiment { SpotlightSlider(it) }
                         }
                     }
                 }

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = appyx_dark
                 ) {
-                    var content by remember { mutableStateOf(4) }
+                    var content by remember { mutableStateOf(1) }
                     Column {
                         Row(
                             modifier = Modifier

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
@@ -28,9 +28,9 @@ import com.bumble.appyx.components.demos.promoter.PromoterExperiment
 import com.bumble.appyx.components.internal.testdrive.android.TestDriveExperiment
 import com.bumble.appyx.components.spotlight.ui.slider.SpotlightSlider
 import com.bumble.appyx.components.spotlight.ui.sliderrotation.SpotlightSliderRotation
+import com.bumble.appyx.components.spotlight.ui.sliderscale.SpotlightSliderScale
 import com.bumble.appyx.interactions.sample.BackStackExperimentDebug
 import com.bumble.appyx.interactions.sample.SpotlightExperiment
-import com.bumble.appyx.interactions.sample.SpotlightExperimentDebug
 import com.bumble.appyx.interactions.theme.AppyxTheme
 import com.bumble.appyx.interactions.theme.appyx_dark
 
@@ -66,8 +66,8 @@ class MainActivity : ComponentActivity() {
                         when (content) {
                             0 -> DatingCards()
                             1 -> SpotlightExperiment { SpotlightSlider(it) }
-                            2 -> SpotlightExperiment { SpotlightSliderRotation(it) }
-                            3 -> BackStackExperimentDebug()
+                            2 -> SpotlightExperiment { SpotlightSliderScale(it) }
+                            3 -> SpotlightExperiment { SpotlightSliderRotation(it) }
                             4 -> TestDriveExperiment()
                             5 -> PromoterExperiment()
                             else -> SpotlightExperiment { SpotlightSlider(it) }

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = appyx_dark
                 ) {
-                    var content by remember { mutableStateOf(1) }
+                    var content by remember { mutableStateOf(4) }
                     Column {
                         Row(
                             modifier = Modifier

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
@@ -26,7 +26,6 @@ import com.bumble.appyx.components.spotlight.operation.next
 import com.bumble.appyx.components.spotlight.operation.previous
 import com.bumble.appyx.components.spotlight.operation.updateElements
 import com.bumble.appyx.components.spotlight.ui.slider.SpotlightSlider
-import com.bumble.appyx.components.spotlight.ui.sliderrotation.SpotlightSliderRotation
 import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.helper.InteractionModelSetup

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
@@ -33,36 +33,37 @@ import com.bumble.appyx.interactions.sample.android.Children
 import com.bumble.appyx.interactions.sample.android.Element
 import com.bumble.appyx.interactions.theme.appyx_dark
 import com.bumble.appyx.transitionmodel.BaseMotionController
+import com.bumble.appyx.interactions.sample.InteractionTarget as Target
 
 @ExperimentalMaterialApi
 @Composable
 @Suppress("LongMethod", "MagicNumber")
 fun SpotlightExperiment(
     modifier: Modifier = Modifier,
-    motionController: (UiContext) -> BaseMotionController<InteractionTarget, SpotlightModel.State<InteractionTarget>, *, *>
+    motionController: (UiContext) -> BaseMotionController<Target, SpotlightModel.State<Target>, *, *>
 ) {
     val items = listOf(
-        InteractionTarget.Child1,
-        InteractionTarget.Child2,
-        InteractionTarget.Child3,
-        InteractionTarget.Child4,
-        InteractionTarget.Child5,
-        InteractionTarget.Child6,
-        InteractionTarget.Child7,
-        InteractionTarget.Child1,
-        InteractionTarget.Child2,
-        InteractionTarget.Child3,
-        InteractionTarget.Child4,
-        InteractionTarget.Child5,
-        InteractionTarget.Child6,
-        InteractionTarget.Child7,
-        InteractionTarget.Child1,
-        InteractionTarget.Child2,
-        InteractionTarget.Child3,
-        InteractionTarget.Child4,
-        InteractionTarget.Child5,
-        InteractionTarget.Child6,
-        InteractionTarget.Child7,
+        Target.Child1,
+        Target.Child2,
+        Target.Child3,
+        Target.Child4,
+        Target.Child5,
+        Target.Child6,
+        Target.Child7,
+        Target.Child1,
+        Target.Child2,
+        Target.Child3,
+        Target.Child4,
+        Target.Child5,
+        Target.Child6,
+        Target.Child7,
+        Target.Child1,
+        Target.Child2,
+        Target.Child3,
+        Target.Child4,
+        Target.Child5,
+        Target.Child6,
+        Target.Child7,
     )
     val spotlight = Spotlight(
         model = SpotlightModel(

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
@@ -26,16 +26,21 @@ import com.bumble.appyx.components.spotlight.operation.next
 import com.bumble.appyx.components.spotlight.operation.previous
 import com.bumble.appyx.components.spotlight.operation.updateElements
 import com.bumble.appyx.components.spotlight.ui.slider.SpotlightSlider
+import com.bumble.appyx.components.spotlight.ui.sliderrotation.SpotlightSliderRotation
 import com.bumble.appyx.interactions.AppyxLogger
+import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.helper.InteractionModelSetup
 import com.bumble.appyx.interactions.sample.android.Children
 import com.bumble.appyx.interactions.sample.android.Element
 import com.bumble.appyx.interactions.theme.appyx_dark
+import com.bumble.appyx.transitionmodel.BaseMotionController
 
 @ExperimentalMaterialApi
 @Composable
 @Suppress("LongMethod", "MagicNumber")
-fun SpotlightExperiment(modifier: Modifier = Modifier) {
+fun SpotlightExperiment(
+    motionController: (UiContext) -> BaseMotionController<InteractionTarget, SpotlightModel.State<InteractionTarget>, *, *>
+) {
     val items = listOf(
         InteractionTarget.Child1,
         InteractionTarget.Child2,
@@ -64,7 +69,7 @@ fun SpotlightExperiment(modifier: Modifier = Modifier) {
             items = items,
             savedStateMap = null
         ),
-        motionController = { SpotlightSlider(it) },
+        motionController = motionController,
         gestureFactory = { SpotlightSlider.Gestures(it) },
         animationSpec = spring(stiffness = Spring.StiffnessVeryLow / 4)
     )

--- a/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
+++ b/demos/appyx-interactions/android/src/main/kotlin/com/bumble/appyx/interactions/sample/SpotlightExperiment.kt
@@ -38,6 +38,7 @@ import com.bumble.appyx.transitionmodel.BaseMotionController
 @Composable
 @Suppress("LongMethod", "MagicNumber")
 fun SpotlightExperiment(
+    modifier: Modifier = Modifier,
     motionController: (UiContext) -> BaseMotionController<InteractionTarget, SpotlightModel.State<InteractionTarget>, *, *>
 ) {
     val items = listOf(
@@ -76,7 +77,7 @@ fun SpotlightExperiment(
     InteractionModelSetup(spotlight)
 
     Column(
-        Modifier
+        modifier
             .fillMaxWidth()
             .background(appyx_dark)
     ) {


### PR DESCRIPTION
Adds the ability to use displacement on any `MotionProperty`, not just `Position`.

I added scroll-based scale mutation to `SpotlightSlider` as a demonstration (could be extracted/parameterised as a next step so that it's not always enforced).


https://github.com/bumble-tech/appyx/assets/238198/8bba3870-cb34-48be-ba83-9ca6e57519a8

