### PR TITLE
Check nullability before calling ParenNode's performUpNavigation method

### DIFF
--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/Node.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/Node.kt
@@ -183,14 +183,14 @@ open class Node @VisibleForTesting internal constructor(
         require(parent != null || isRoot) {
             "Can't navigate up, neither parent nor integration point is presented"
         }
-        if ((parent as Node).performUpNavigation() != true) {
+        if (parent?.performUpNavigation() != true) {
             integrationPoint.handleUpNavigation()
         }
     }
 
     @CallSuper
-    protected open fun performUpNavigation(): Boolean =
-        handleUpNavigationByPlugins() || (parent as? Node)?.performUpNavigation() == true
+    open fun performUpNavigation(): Boolean =
+        handleUpNavigationByPlugins() || parent?.performUpNavigation() == true
 
     private fun handleUpNavigationByPlugins(): Boolean =
         plugins<UpNavigationHandler>().any { it.handleUpNavigation() }


### PR DESCRIPTION
## Description

Fix NPE when for RootNode when performUpNavigation is called

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
