### PR TITLE
Rename integrationPoint property 

### DIFF
--- a/appyx-navigation/src/androidTest/kotlin/com/bumble/appyx/navigation/AppyxTestScenario.kt
+++ b/appyx-navigation/src/androidTest/kotlin/com/bumble/appyx/navigation/AppyxTestScenario.kt
@@ -25,7 +25,7 @@ class AppyxTestScenario<T : Node>(
         AppyxTestActivity.composableView = { activity ->
             decorator {
                 NodeHost(
-                    integrationPoint = activity.appyxIntegrationPoint,
+                    integrationPoint = activity.appyxV2IntegrationPoint,
                     factory = { buildContext ->
                         node = nodeFactory.create(buildContext)
                         awaitNode.countDown()

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/ActivityIntegrationPoint.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/ActivityIntegrationPoint.kt
@@ -61,7 +61,7 @@ open class ActivityIntegrationPoint(
                 "Activity ${activity::class.qualifiedName} does not implement IntegrationPointProvider"
             )
 
-            return integrationPointProvider.appyxIntegrationPoint
+            return integrationPointProvider.appyxV2IntegrationPoint
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/IntegrationPointProvider.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/IntegrationPointProvider.kt
@@ -2,5 +2,5 @@ package com.bumble.appyx.navigation.integrationpoint
 
 interface IntegrationPointProvider {
 
-    val appyxIntegrationPoint: IntegrationPoint
+    val appyxV2IntegrationPoint: IntegrationPoint
 }

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/NodeActivity.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/NodeActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
  * See [NodeComponentActivity] for building upon [ComponentActivity].
  *
  * Also offers base functionality to satisfy dependencies of Android-related functionality
- * down the tree via [appyxIntegrationPoint]:
+ * down the tree via [appyxV2IntegrationPoint]:
  * - [ActivityStarter]
  * - [PermissionRequester]
  *
@@ -19,7 +19,7 @@ import androidx.appcompat.app.AppCompatActivity
  */
 open class NodeActivity : AppCompatActivity(), IntegrationPointProvider {
 
-    override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
+    override lateinit var appyxV2IntegrationPoint: ActivityIntegrationPoint
         protected set
 
     protected open fun createIntegrationPoint(savedInstanceState: Bundle?) =
@@ -30,12 +30,12 @@ open class NodeActivity : AppCompatActivity(), IntegrationPointProvider {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        appyxIntegrationPoint = createIntegrationPoint(savedInstanceState)
+        appyxV2IntegrationPoint = createIntegrationPoint(savedInstanceState)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        appyxIntegrationPoint.onActivityResult(requestCode, resultCode, data)
+        appyxV2IntegrationPoint.onActivityResult(requestCode, resultCode, data)
     }
 
     override fun onRequestPermissionsResult(
@@ -44,12 +44,12 @@ open class NodeActivity : AppCompatActivity(), IntegrationPointProvider {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        appyxIntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        appyxV2IntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        appyxIntegrationPoint.onSaveInstanceState(outState)
+        appyxV2IntegrationPoint.onSaveInstanceState(outState)
     }
 
 }

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/NodeComponentActivity.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/integrationpoint/NodeComponentActivity.kt
@@ -10,7 +10,7 @@ import androidx.activity.ComponentActivity
  * See [NodeActivity] for building upon [AppCompatActivity]
  *
  * Also offers base functionality to satisfy dependencies of Android-related functionality
- * down the tree via [appyxIntegrationPoint]:
+ * down the tree via [appyxV2IntegrationPoint]:
  * - [ActivityStarter]
  * - [PermissionRequester]
  *
@@ -19,7 +19,7 @@ import androidx.activity.ComponentActivity
  */
 open class NodeComponentActivity : ComponentActivity(), IntegrationPointProvider {
 
-    override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
+    override lateinit var appyxV2IntegrationPoint: ActivityIntegrationPoint
         protected set
 
     protected open fun createIntegrationPoint(savedInstanceState: Bundle?) =
@@ -30,13 +30,13 @@ open class NodeComponentActivity : ComponentActivity(), IntegrationPointProvider
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        appyxIntegrationPoint = createIntegrationPoint(savedInstanceState)
+        appyxV2IntegrationPoint = createIntegrationPoint(savedInstanceState)
     }
 
     @Suppress("OVERRIDE_DEPRECATION")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        appyxIntegrationPoint.onActivityResult(requestCode, resultCode, data)
+        appyxV2IntegrationPoint.onActivityResult(requestCode, resultCode, data)
     }
 
     @Suppress("OVERRIDE_DEPRECATION")
@@ -46,11 +46,11 @@ open class NodeComponentActivity : ComponentActivity(), IntegrationPointProvider
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        appyxIntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        appyxV2IntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        appyxIntegrationPoint.onSaveInstanceState(outState)
+        appyxV2IntegrationPoint.onSaveInstanceState(outState)
     }
 }

--- a/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/MainActivity.kt
+++ b/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : NodeActivity() {
                 // A surface container using the 'background' color from the theme
                 Surface(color = MaterialTheme.colorScheme.background) {
                     Column {
-                        NodeHost(integrationPoint = appyxIntegrationPoint) {
+                        NodeHost(integrationPoint = appyxV2IntegrationPoint) {
                             ContainerNode(
                                 buildContext = it,
                             )

--- a/demos/navigation-compose/src/androidTest/kotlin/com/bumble/appyx/sample/navigtion/compose/ComposeNavigationRootTest.kt
+++ b/demos/navigation-compose/src/androidTest/kotlin/com/bumble/appyx/sample/navigtion/compose/ComposeNavigationRootTest.kt
@@ -19,7 +19,7 @@ class ComposeNavigationRootTest {
             // 'integrationPoint' must be provided to ensure it can be accessed from within the
             // Jetpack compose navigation graph.
             CompositionLocalProvider(
-                LocalIntegrationPoint provides appyxTestActivity.appyxIntegrationPoint,
+                LocalIntegrationPoint provides appyxTestActivity.appyxV2IntegrationPoint,
             ) {
                 ComposeNavigationRoot()
             }

--- a/utils/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/utils/interop/ribs/AppyxRibsInteropActivity.kt
+++ b/utils/interop-ribs/src/androidTest/kotlin/com/bumble/appyx/utils/interop/ribs/AppyxRibsInteropActivity.kt
@@ -14,7 +14,7 @@ class AppyxRibsInteropActivity : InteropActivity() {
 
     override fun createRib(savedInstanceState: Bundle?): Rib =
         RibsNodeBuilder()
-            .build(BuildContext.root(savedInstanceState), appyxIntegrationPoint)
+            .build(BuildContext.root(savedInstanceState), appyxV2IntegrationPoint)
             .also { ribsNode = it }
 
 }

--- a/utils/interop-ribs/src/main/kotlin/com/bumble/appyx/utils/interop/ribs/InteropActivity.kt
+++ b/utils/interop-ribs/src/main/kotlin/com/bumble/appyx/utils/interop/ribs/InteropActivity.kt
@@ -8,7 +8,7 @@ import com.bumble.appyx.navigation.integrationpoint.IntegrationPointProvider
 
 abstract class InteropActivity : RibActivity(), IntegrationPointProvider {
 
-    override lateinit var appyxIntegrationPoint: ActivityIntegrationPoint
+    override lateinit var appyxV2IntegrationPoint: ActivityIntegrationPoint
 
     protected open fun createAppyxIntegrationPoint(savedInstanceState: Bundle?) =
         ActivityIntegrationPoint(
@@ -19,13 +19,13 @@ abstract class InteropActivity : RibActivity(), IntegrationPointProvider {
     override fun onCreate(savedInstanceState: Bundle?) {
         // super.onCreate() creates RIB with AppyxNode inside. It's important to have
         // appyxIntegrationPoint ready before we create a root node
-        appyxIntegrationPoint = createAppyxIntegrationPoint(savedInstanceState)
+        appyxV2IntegrationPoint = createAppyxIntegrationPoint(savedInstanceState)
         super.onCreate(savedInstanceState)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        appyxIntegrationPoint.onActivityResult(requestCode, resultCode, data)
+        appyxV2IntegrationPoint.onActivityResult(requestCode, resultCode, data)
     }
 
     override fun onRequestPermissionsResult(
@@ -34,12 +34,12 @@ abstract class InteropActivity : RibActivity(), IntegrationPointProvider {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        appyxIntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        appyxV2IntegrationPoint.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        appyxIntegrationPoint.onSaveInstanceState(outState)
+        appyxV2IntegrationPoint.onSaveInstanceState(outState)
     }
 
 }

--- a/utils/testing-ui/src/main/kotlin/com/bumble/appyx/utils/testing/ui/rules/AppyxActivityTestRule.kt
+++ b/utils/testing-ui/src/main/kotlin/com/bumble/appyx/utils/testing/ui/rules/AppyxActivityTestRule.kt
@@ -8,7 +8,6 @@ import androidx.test.rule.ActivityTestRule
 import com.bumble.appyx.navigation.integration.NodeFactory
 import com.bumble.appyx.navigation.integration.NodeHost
 import com.bumble.appyx.navigation.node.Node
-import com.bumble.appyx.utils.testing.ui.rules.AppyxTestActivity
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -45,7 +44,7 @@ open class AppyxActivityTestRule<T : Node>(
     override fun beforeActivityLaunched() {
         AppyxTestActivity.composableView = { activity ->
             decorator {
-                NodeHost(integrationPoint = activity.appyxIntegrationPoint, factory = { buildContext ->
+                NodeHost(integrationPoint = activity.appyxV2IntegrationPoint, factory = { buildContext ->
                     node = nodeFactory.create(buildContext)
                     node
                 })


### PR DESCRIPTION
## Description

Rename integrationPoint property  in IntegrationPointProvider.kt to avoid clash with 1.x

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
