### PR TITLE
Fix bug when updating elements with different size compared to the current set of elements

### DIFF
--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
@@ -31,15 +31,15 @@ class UpdateElements<InteractionTarget : Any>(
         val newSize = max(positions.size, items.size)
         val newPositions = ArrayList<Position<InteractionTarget>>(newSize)
         for (i in 0 until newSize) {
-            val elementForPosition =
+            val elementsForPosition =
                 mutableMapOf<Element<InteractionTarget>, SpotlightModel.State.ElementState>()
             if (i < positions.size) {
-                elementForPosition += positions[i].elements
+                elementsForPosition += positions[i].elements
             }
             if (i < items.size) {
-                elementForPosition += (items[i].asElement() to CREATED)
+                elementsForPosition += (items[i].asElement() to CREATED)
             }
-            newPositions.add(i, Position(elements = elementForPosition))
+            newPositions.add(i, Position(elements = elementsForPosition))
         }
         return baseLineState.copy(positions = newPositions)
     }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
@@ -6,11 +6,14 @@ import com.bumble.appyx.components.spotlight.SpotlightModel
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.CREATED
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.DESTROYED
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.STANDARD
+import com.bumble.appyx.components.spotlight.SpotlightModel.State.Position
 import com.bumble.appyx.interactions.Parcelize
 import com.bumble.appyx.interactions.RawValue
+import com.bumble.appyx.interactions.core.Element
 import com.bumble.appyx.interactions.core.asElement
 import com.bumble.appyx.interactions.core.model.transition.BaseOperation
 import com.bumble.appyx.interactions.core.model.transition.Operation
+import kotlin.math.max
 
 @Parcelize
 // TODO cleanup SpotlightModel.State.positions if a position doesn't contain more elements
@@ -23,14 +26,23 @@ class UpdateElements<InteractionTarget : Any>(
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
         true
 
-    override fun createFromState(baseLineState: SpotlightModel.State<InteractionTarget>): SpotlightModel.State<InteractionTarget> =
-        baseLineState.copy(
-            positions = baseLineState.positions.mapIndexed { index, position ->
-                position.copy(
-                    elements = position.elements + (items[index].asElement() to CREATED)
-                )
-            },
-        )
+    override fun createFromState(baseLineState: SpotlightModel.State<InteractionTarget>): SpotlightModel.State<InteractionTarget> {
+        val positions = baseLineState.positions
+        val newSize = max(positions.size, items.size)
+        val newPositions = ArrayList<Position<InteractionTarget>>(newSize)
+        for (i in 0 until newSize) {
+            val elementForPosition =
+                mutableMapOf<Element<InteractionTarget>, SpotlightModel.State.ElementState>()
+            if (i < positions.size) {
+                elementForPosition += positions[i].elements
+            }
+            if (i < items.size) {
+                elementForPosition += (items[i].asElement() to CREATED)
+            }
+            newPositions.add(i, Position(elements = elementForPosition))
+        }
+        return baseLineState.copy(positions = newPositions)
+    }
 
     override fun createTargetState(fromState: SpotlightModel.State<InteractionTarget>): SpotlightModel.State<InteractionTarget> =
         fromState.copy(

--- a/appyx-components/spotlight/common/src/commonTest/kotlin/com/bumble/appyx/components/spotlight/model/SpotlightModelTest.kt
+++ b/appyx-components/spotlight/common/src/commonTest/kotlin/com/bumble/appyx/components/spotlight/model/SpotlightModelTest.kt
@@ -1,14 +1,15 @@
-package com.bumble.appyx.components.spotlight.restore
+package com.bumble.appyx.components.spotlight.model
 
 import com.bumble.appyx.components.spotlight.InteractionTarget.Child1
 import com.bumble.appyx.components.spotlight.InteractionTarget.Child2
 import com.bumble.appyx.components.spotlight.SpotlightModel
 import com.bumble.appyx.components.spotlight.operation.Next
+import com.bumble.appyx.components.spotlight.operation.UpdateElements
 import com.bumble.appyx.interactions.core.state.MutableSavedStateMapImpl
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class SpotlightRestoreTest {
+class SpotlightModelTest {
 
     @Test
     fun GIVEN_spotlight_with_2_elements_WHEN_state_restored_THEN_all_elements_are_retained() {
@@ -31,6 +32,34 @@ class SpotlightRestoreTest {
         assertEquals(
             spotlight.output.value.currentTargetState,
             newSpotlight.output.value.currentTargetState
+        )
+    }
+
+    @Test
+    fun GIVEN_empty_spotlight_WHEN_updated_with_element_THEN_state_contains_element_and_sets_index() {
+        val spotlight = SpotlightModel(
+            items = listOf(),
+            savedStateMap = null
+        )
+
+        val newElements = listOf(Child1, Child2)
+        val newActiveIndex = 1f
+
+        spotlight.operation(
+            UpdateElements(
+                items = newElements,
+                initialActiveIndex = newActiveIndex
+            )
+        )
+
+        assertEquals(
+            expected = newElements,
+            actual = spotlight.elements.value.map { it.interactionTarget }.toList(),
+        )
+
+        assertEquals(
+            expected = newActiveIndex,
+            actual = spotlight.output.value.currentTargetState.activeIndex,
         )
     }
 }

--- a/appyx-components/spotlight/common/src/commonTest/kotlin/com/bumble/appyx/components/spotlight/model/SpotlightModelTest.kt
+++ b/appyx-components/spotlight/common/src/commonTest/kotlin/com/bumble/appyx/components/spotlight/model/SpotlightModelTest.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.components.spotlight.model
 
 import com.bumble.appyx.components.spotlight.InteractionTarget.Child1
 import com.bumble.appyx.components.spotlight.InteractionTarget.Child2
+import com.bumble.appyx.components.spotlight.InteractionTarget.Child3
 import com.bumble.appyx.components.spotlight.SpotlightModel
 import com.bumble.appyx.components.spotlight.operation.Next
 import com.bumble.appyx.components.spotlight.operation.UpdateElements
@@ -36,7 +37,7 @@ class SpotlightModelTest {
     }
 
     @Test
-    fun GIVEN_empty_spotlight_WHEN_updated_with_element_THEN_state_contains_element_and_sets_index() {
+    fun GIVEN_empty_spotlight_WHEN_updated_with_element_THEN_state_contains_elements() {
         val spotlight = SpotlightModel(
             items = listOf(),
             savedStateMap = null
@@ -56,10 +57,45 @@ class SpotlightModelTest {
             expected = newElements,
             actual = spotlight.elements.value.map { it.interactionTarget }.toList(),
         )
+    }
+
+    @Test
+    fun GIVEN_empty_spotlight_WHEN_updated_with_element_THEN_sets_provided_active_index() {
+        val spotlight = SpotlightModel(
+            items = listOf(),
+            savedStateMap = null
+        )
+
+        val newElements = listOf(Child1, Child2)
+        val newActiveIndex = 1f
+
+        spotlight.operation(
+            UpdateElements(
+                items = newElements,
+                initialActiveIndex = newActiveIndex
+            )
+        )
 
         assertEquals(
             expected = newActiveIndex,
             actual = spotlight.output.value.currentTargetState.activeIndex,
+        )
+    }
+
+    @Test
+    fun GIVEN_spotlight_WHEN_updated_with_elements_different_size_THEN_state_contains_element() {
+        val spotlight = SpotlightModel(
+            items = listOf(Child1),
+            savedStateMap = null
+        )
+
+        val newElements = listOf(Child2, Child3)
+
+        spotlight.operation(UpdateElements(items = newElements))
+
+        assertEquals(
+            expected = newElements,
+            actual = spotlight.elements.value.map { it.interactionTarget }.toList(),
         )
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/441

If the new elements' size was bigger than the current one it wasn't updating the elements properly.


https://github.com/bumble-tech/appyx/assets/5773436/4d19772f-4ba5-4751-aca6-dc59d0668417



## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
