### PR TITLE
Make motion controller public and expose scrollX value

### DIFF
--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -32,7 +32,7 @@ class SpotlightSlider<InteractionTarget : Any>(
 ) {
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
-    private val scrollX = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
+    val scrollX = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
     override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
@@ -26,7 +26,7 @@ class SpotlightSliderRotation<InteractionTarget : Any>(
 ) {
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
-    private val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
+    val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
     override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
@@ -24,7 +24,7 @@ class SpotlightSliderScale<InteractionTarget : Any>(
 ) {
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
-    private val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
+    val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
     override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX


### PR DESCRIPTION
## Description

Allow collecting motion controller from InteractionModel. 

This will allow us, for instance, to observe the scroll value in SpotlightSlider

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
