### PR TITLE
Renamings

### DIFF
--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/TestDriveExperiment.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/TestDriveExperiment.kt
@@ -145,11 +145,11 @@ fun <InteractionTarget : Any> TestDriveUi(
             screenHeightPx = screenHeightPx,
             colors = colors,
             interactionModel = testDrive,
-        ) { frameModel ->
+        ) { elementUiModel ->
             Box(
                 modifier = Modifier.size(60.dp)
-                    .then(frameModel.modifier)
-                    .pointerInput(frameModel.element.id) {
+                    .then(elementUiModel.modifier)
+                    .pointerInput(elementUiModel.element.id) {
                         detectDragGestures(
                             onDrag = { change, dragAmount ->
                                 change.consume()

--- a/appyx-components/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/SpotlightTest.kt
+++ b/appyx-components/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/SpotlightTest.kt
@@ -35,7 +35,7 @@ class SpotlightTest(private val testParam: TestParam) {
         fun data() = arrayOf(
             TestParam(operationMode = Operation.Mode.IMMEDIATE),
             TestParam(operationMode = Operation.Mode.KEYFRAME),
-            TestParam(operationMode = Operation.Mode.GEOMETRY)
+            TestParam(operationMode = Operation.Mode.IMPOSED)
         )
     }
 

--- a/appyx-components/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/SpotlightViewpointTest.kt
+++ b/appyx-components/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/SpotlightViewpointTest.kt
@@ -20,7 +20,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestName
 
-class SpotlightGeometryTest {
+class SpotlightViewpointTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
@@ -29,7 +29,7 @@ class SpotlightGeometryTest {
     var nameRule = TestName()
 
     @Test
-    fun when_keyframe_operation_then_scroll_using_geometry() {
+    fun when_keyframe_operation_then_scroll_using_viewpoint() {
         val spotlight = composeTestRule.createSpotlight(
             items = listOf(Child1, Child2, Child3)
         )
@@ -49,7 +49,7 @@ class SpotlightGeometryTest {
     }
 
     @Test
-    fun when_update__operation_then_scroll_using_geometry() {
+    fun when_update__operation_then_scroll_using_viewpoint() {
         val spotlight = composeTestRule.createSpotlight(
             items = listOf(Child1, Child2, Child3)
         )
@@ -88,7 +88,7 @@ class SpotlightGeometryTest {
                 moveBy(Offset(-200f, 0f), 500L)
             }
             .performTouchInput {
-                composeTestRule.snapshot("${this@SpotlightGeometryTest.javaClass.simpleName}_${nameRule.methodName}")
+                composeTestRule.snapshot("${this@SpotlightViewpointTest.javaClass.simpleName}_${nameRule.methodName}")
                 up()
             }
     }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Activate.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Activate.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 @Parcelize
 class Activate<InteractionTarget : Any>(
     private val index: Float,
-    override val mode: Operation.Mode = Operation.Mode.GEOMETRY
+    override val mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
@@ -29,7 +29,7 @@ class Activate<InteractionTarget : Any>(
 fun <InteractionTarget : Any> Spotlight<InteractionTarget>.activate(
     index: Float,
     animationSpec: AnimationSpec<Float> = defaultAnimationSpec,
-    mode: Operation.Mode = Operation.Mode.GEOMETRY
+    mode: Operation.Mode = Operation.Mode.IMPOSED
 ) {
     operation(Activate(index, mode), animationSpec)
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/First.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/First.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class First<InteractionTarget : Any>(
-    override val mode: Operation.Mode = Operation.Mode.GEOMETRY
+    override val mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
@@ -27,7 +27,7 @@ class First<InteractionTarget : Any>(
 
 fun <InteractionTarget : Any> Spotlight<InteractionTarget>.first(
     animationSpec: AnimationSpec<Float> = defaultAnimationSpec,
-    mode: Operation.Mode = Operation.Mode.GEOMETRY
+    mode: Operation.Mode = Operation.Mode.IMPOSED
 ) {
     operation(First(mode), animationSpec)
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Last.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Last.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class Last<InteractionTarget : Any>(
-    override val mode: Operation.Mode = Operation.Mode.GEOMETRY
+    override val mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
@@ -27,7 +27,7 @@ class Last<InteractionTarget : Any>(
 
 fun <InteractionTarget : Any> Spotlight<InteractionTarget>.last(
     animationSpec: AnimationSpec<Float> = defaultAnimationSpec,
-    mode: Operation.Mode = Operation.Mode.GEOMETRY
+    mode: Operation.Mode = Operation.Mode.IMPOSED
 ) {
     operation(Last(mode), animationSpec)
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Next.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Next.kt
@@ -9,7 +9,7 @@ import com.bumble.appyx.components.spotlight.SpotlightModel
 
 @Parcelize
 class Next<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.GEOMETRY
+    override val mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
@@ -26,7 +26,7 @@ class Next<InteractionTarget>(
 
 fun <InteractionTarget : Any> Spotlight<InteractionTarget>.next(
     animationSpec: AnimationSpec<Float> = defaultAnimationSpec,
-    mode: Operation.Mode = Operation.Mode.GEOMETRY
+    mode: Operation.Mode = Operation.Mode.IMPOSED
 ) {
     operation(Next(mode), animationSpec)
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Previous.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Previous.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class Previous<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.GEOMETRY
+    override val mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =
@@ -27,7 +27,7 @@ class Previous<InteractionTarget>(
 
 fun <InteractionTarget : Any> Spotlight<InteractionTarget>.previous(
     animationSpec: AnimationSpec<Float> = defaultAnimationSpec,
-    mode: Operation.Mode = Operation.Mode.GEOMETRY
+    mode: Operation.Mode = Operation.Mode.IMPOSED
 ) {
     operation(Previous(mode), animationSpec)
 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -33,7 +33,7 @@ class SpotlightSlider<InteractionTarget : Any>(
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
     private val scrollX = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
-    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
+    override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX
         )

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
@@ -27,7 +27,7 @@ class SpotlightSliderRotation<InteractionTarget : Any>(
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
     private val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
-    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
+    override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX
         )

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
@@ -25,7 +25,7 @@ class SpotlightSliderScale<InteractionTarget : Any>(
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
     private val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
-    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
+    override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX
         )

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
@@ -28,7 +28,7 @@ class SpotlightStack3D<InteractionTarget : Any>(
     private val height: Dp = uiContext.transitionBounds.heightDp
 
     private val scrollX = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f))
-    override val geometryMappings: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
+    override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX
         )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/BaseTransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/BaseTransitionModel.kt
@@ -104,8 +104,8 @@ abstract class BaseTransitionModel<InteractionTarget, ModelState : Parcelable>(
                 enforcedMode = IMMEDIATE
                 createUpdate(operation)
             }
-            GEOMETRY -> {
-                updateGeometry(operation)
+            IMPOSED -> {
+                impose(operation)
             }
             KEYFRAME -> {
                 createSegment(operation)
@@ -126,7 +126,7 @@ abstract class BaseTransitionModel<InteractionTarget, ModelState : Parcelable>(
         }
     }
 
-    private fun updateGeometry(operation: Operation<ModelState>): Boolean {
+    private fun impose(operation: Operation<ModelState>): Boolean {
         return when (val currentState = state.value) {
             is Keyframes -> {
                 with(currentState) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/Operation.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/Operation.kt
@@ -9,22 +9,28 @@ interface Operation<ModelState> : Parcelable {
 
     enum class Mode {
         /**
-         * Operation should be executed without a queue, and should trigger
+         * The operation should be executed without a queue, and should trigger
          * animation mode.
          */
         IMMEDIATE,
 
         /**
-         * Operation should be executed without a queue just as IMMEDIATE,
-         * but shouldn't trigger animation mode. It's intended for state changes
-         * that should affect geometry only.
-         */
-        GEOMETRY,
-
-        /**
          * Operation should be enqueued and treated as a keyframe.
          */
-        KEYFRAME
+        KEYFRAME,
+
+        /**
+         * The operation should be executed without a queue just the same as IMMEDIATE, but with a
+         * special condition: when the model is already in KEYFRAME mode,
+         * the operation result should be imposed on all existing keyframe states, rather than
+         * switching to IMMEDIATE mode.
+         * If the model is already in IMMEDIATE mode, executing an IMPOSED operation isn't
+         * different from another IMMEDIATE one.
+         *
+         * A typical use-case is a state change that should only affect the viewpoint,
+         * allowing it to happen always independently of any other element-related state change.
+         */
+        IMPOSED,
     }
 
     val mode: Mode

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -74,12 +74,12 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                 )
             }
     ) {
-        frames.value.forEach { frameModel ->
-            key(frameModel.element.id) {
-                frameModel.animationContainer()
-                val isVisible by frameModel.visibleState.collectAsState()
+        frames.value.forEach { elementUiModel ->
+            key(elementUiModel.element.id) {
+                elementUiModel.animationContainer()
+                val isVisible by elementUiModel.visibleState.collectAsState()
                 if (isVisible) {
-                    element.invoke(frameModel)
+                    element.invoke(elementUiModel)
                 }
             }
         }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -263,8 +263,8 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         val fromValue = fieldOfState(segment.fromState)
         val targetValue = fieldOfState(segment.targetState)
 
-        // If the viewpoint value was updated via a GEOMETRY operation mode, then it was applied both to the
-        // start and end values (see [BaseTransitionModel.updateGeometry()], and they should be the same.
+        // If the viewpoint value was updated via a IMPOSED operation mode, then it was applied both to the
+        // start and end values (see [BaseTransitionModel.impose()], and they should be the same.
         // This means that even though we have a Segment, the interpolation is working on some other part of
         // the ModelState, not the viewpoint, and we should still consider the viewpoint value as a separate concern,
         // that we need to animate.

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -108,8 +108,8 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         update: Update<ModelState>
     ) {
         LaunchedEffect(update, this) {
-            // make sure to use scope created by Launched effect as this scope should be cancelled
-            // when associated FrameModel cease to exist
+            // Make sure to use the scope created by LaunchedEffect as this scope should be cancelled
+            // when the associated ElementUiModel ceases to exist
             launch {
                 if (update.animate) {
                     mutableUiState.animateTo(
@@ -130,8 +130,8 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         matchedTargetUiState: MatchedTargetUiState<InteractionTarget, TargetUiState>
     ) {
         LaunchedEffect(this) {
-            // make sure to use scope created by Launched effect as this scope should be cancelled
-            // when associated FrameModel cease to exist
+            // Make sure to use the scope created by LaunchedEffect as this scope should be cancelled
+            // when the associated ElementUiModel ceases to exist
             launch {
                 mutableUiState.isAnimating
                     .distinctUntilChanged()

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -33,16 +33,16 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
     protected val defaultAnimationSpec: SpringSpec<Float> = DefaultAnimationSpec,
 ) : MotionController<InteractionTarget, ModelState> where MutableUiState : BaseMutableUiState<MutableUiState, TargetUiState> {
 
-    open val geometryMappings: List<Pair<(ModelState) -> Float, GenericFloatProperty>> =
+    open val viewpointDimensions: List<Pair<(ModelState) -> Float, GenericFloatProperty>> =
         emptyList()
 
     private val coroutineScope = uiContext.coroutineScope
     private val mutableUiStateCache: MutableMap<String, MutableUiState> = mutableMapOf()
     private val animations: MutableMap<String, Boolean> = mutableMapOf()
-    private val geometryModeAnimatingState: StateFlow<Boolean>
-        get() = if (geometryMappings.isNotEmpty()) {
+    private val viewpointIsAnimating: StateFlow<Boolean>
+        get() = if (viewpointDimensions.isNotEmpty()) {
             combineState(
-                geometryMappings.map { it.second.isAnimating },
+                viewpointDimensions.map { it.second.isAnimating },
                 uiContext.coroutineScope
             ) { values ->
                 values.any { it }
@@ -50,13 +50,13 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         } else {
             MutableStateFlow(false)
         }
-    private val updateModeAnimatingState = MutableStateFlow(false)
+    private val updateIsAnimating = MutableStateFlow(false)
     private val isAnimatingState: StateFlow<Boolean>
-        get() = updateModeAnimatingState.combineState(
-            geometryModeAnimatingState,
+        get() = updateIsAnimating.combineState(
+            viewpointIsAnimating,
             uiContext.coroutineScope
-        ) { isGeometryAnimating, isUpdateAnimating ->
-            isGeometryAnimating || isUpdateAnimating
+        ) { b1, b2 ->
+            b1 || b2
         }
 
     protected var currentSpringSpec: SpringSpec<Float> = defaultAnimationSpec
@@ -80,7 +80,7 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         val matchedTargetUiStates = update.currentTargetState.toUiTargets()
 
         coroutineScope.launch {
-            updateGeometry(update)
+            updateViewpoint(update)
         }
 
         // TODO: use a map instead of find
@@ -142,13 +142,13 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
                         if (current && !previous) {
                             // animation started
                             animations[matchedTargetUiState.element.id] = true
-                            updateModeAnimatingState.update { true }
+                            updateIsAnimating.update { true }
                             AppyxLogger.d(TAG, "animation for element ${matchedTargetUiState.element.id} is started")
                         } else {
                             // animation finished
                             _finishedAnimations.emit(matchedTargetUiState.element)
                             animations[matchedTargetUiState.element.id] = false
-                            updateModeAnimatingState.update { animations.any { it.value } }
+                            updateIsAnimating.update { animations.any { it.value } }
                             AppyxLogger.d(TAG, "animation for element ${matchedTargetUiState.element.id} is finished")
                         }
                     }
@@ -156,17 +156,17 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         }
     }
 
-    private suspend fun updateGeometry(update: Update<ModelState>) {
-        geometryMappings.forEach { (fieldOfState, geometry) ->
+    private suspend fun updateViewpoint(update: Update<ModelState>) {
+        viewpointDimensions.forEach { (fieldOfState, viewpointDimension) ->
             val targetValue = fieldOfState(update.currentTargetState)
-            geometry.animateTo(
+            viewpointDimension.animateTo(
                 targetValue,
                 spring(
                     stiffness = currentSpringSpec.stiffness,
                     dampingRatio = currentSpringSpec.dampingRatio
                 )
             ) {
-                AppyxLogger.d(TAG, "Geometry animateTo (Update) – $targetValue")
+                AppyxLogger.d(TAG, "Viewpoint animateTo (Update) – $targetValue")
             }
         }
     }
@@ -182,7 +182,7 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
 
         coroutineScope.launch {
             segmentProgress.collect {
-                updateGeometry(segment, it)
+                updateViewpoint(segment, it)
             }
         }
 
@@ -222,32 +222,32 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         }
     }
 
-    private suspend fun updateGeometry(
+    private suspend fun updateViewpoint(
         segment: Segment<ModelState>,
         segmentProgress: Float
     ) {
-        geometryMappings.forEach { (fieldOfState, geometry) ->
-            val (behaviour, targetValue) = geometryTargetValue(
+        viewpointDimensions.forEach { (fieldOfState, viewpointDimension) ->
+            val (behaviour, targetValue) = viewpointTargetValue(
                 segment,
                 segmentProgress,
                 fieldOfState
             )
 
             when (behaviour) {
-                GeometryBehaviour.SNAP -> {
-                    geometry.snapTo(targetValue)
-                    AppyxLogger.d(TAG, "Geometry snapTo (Segment): $targetValue")
+                ViewpointBehaviour.SNAP -> {
+                    viewpointDimension.snapTo(targetValue)
+                    AppyxLogger.d(TAG, "Viewpoint snapTo (Segment): $targetValue")
                 }
 
-                GeometryBehaviour.ANIMATE -> {
-                    if (geometry.internalValue != targetValue) {
-                        geometry.animateTo(
+                ViewpointBehaviour.ANIMATE -> {
+                    if (viewpointDimension.internalValue != targetValue) {
+                        viewpointDimension.animateTo(
                             targetValue, spring(
                                 stiffness = currentSpringSpec.stiffness,
                                 dampingRatio = currentSpringSpec.dampingRatio
                             )
                         ) {
-                            AppyxLogger.d(TAG, "Geometry animateTo (Segment) – ${geometry.internalValue} -> $targetValue")
+                            AppyxLogger.d(TAG, "Viewpoint animateTo (Segment) – ${viewpointDimension.internalValue} -> $targetValue")
                         }
                     }
                 }
@@ -255,28 +255,28 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
         }
     }
 
-    private fun geometryTargetValue(
+    private fun viewpointTargetValue(
         segment: Segment<ModelState>,
         segmentProgress: Float,
         fieldOfState: (ModelState) -> Float
-    ): Pair<GeometryBehaviour, Float> {
+    ): Pair<ViewpointBehaviour, Float> {
         val fromValue = fieldOfState(segment.fromState)
         val targetValue = fieldOfState(segment.targetState)
 
-        // If the geometry value was inserted via a GEOMETRY operation mode, then it was applied both to the
+        // If the viewpoint value was updated via a GEOMETRY operation mode, then it was applied both to the
         // start and end values (see [BaseTransitionModel.updateGeometry()], and they should be the same.
         // This means that even though we have a Segment, the interpolation is working on some other part of
-        // the ModelState, not the geometry, and we should still consider the geometry value as a separate concern,
+        // the ModelState, not the viewpoint, and we should still consider the viewpoint value as a separate concern,
         // that we need to animate.
-        return if (fromValue == targetValue) GeometryBehaviour.ANIMATE to targetValue
-        // If the geometry value was added via a KEYFRAME operation mode, then the relevant value
+        return if (fromValue == targetValue) ViewpointBehaviour.ANIMATE to targetValue
+        // If the viewpoint target value was updated via a KEYFRAME operation mode, then the relevant value
         // will be different for the targetValue.
-        // This means that the Segment was specifically created to interpolate the geometry value (probably a gesture)
+        // This means that the Segment was specifically created to interpolate the viewpoint value (probably a gesture)
         // and that it's important to follow the interpolation by snapping.
-        else GeometryBehaviour.SNAP to lerpFloat(fromValue, targetValue, segmentProgress)
+        else ViewpointBehaviour.SNAP to lerpFloat(fromValue, targetValue, segmentProgress)
     }
 
-    private enum class GeometryBehaviour {
+    private enum class ViewpointBehaviour {
         SNAP, ANIMATE
     }
 

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
@@ -36,11 +36,11 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
     clipToBounds: Boolean = false,
     gestureSpec: GestureSpec = GestureSpec(),
     noinline block: @Composable ChildrenTransitionScope<InteractionTarget, ModelState>.() -> Unit = {
-        children { child, frameModel ->
+        children { child, elementUiModel ->
             child(
                 modifier = Modifier.gestureModifier(
                     interactionModel = interactionModel,
-                    key = frameModel.element,
+                    key = elementUiModel.element,
                     gestureSpec = gestureSpec
                 )
             )


### PR DESCRIPTION
Changed:

- Model layer mention of `Operation.Mode.GEOMETRY` -> `IMPOSED` (describes how it behaves, not what it's used for)
- UI mentions of `geometry` -> `viewpoint`
- Leftover mentions of old naming: `frameModel` -> `elementUiModel`