### PR TITLE
Gesture improvements

### DIFF
--- a/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/NewRoot.kt
+++ b/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/NewRoot.kt
@@ -17,7 +17,7 @@ import com.bumble.appyx.components.backstack.BackStackModel
 @Parcelize
 data class NewRoot<InteractionTarget>(
     private val interactionTarget: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<BackStackModel.State<InteractionTarget>>() {
     override fun isApplicable(state: BackStackModel.State<InteractionTarget>): Boolean =
         true

--- a/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Pop.kt
+++ b/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Pop.kt
@@ -14,7 +14,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
  */
 @Parcelize
 class Pop<InteractionTarget : Any>(
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<State<InteractionTarget>>() {
     override fun isApplicable(state: State<InteractionTarget>): Boolean =
         state.stashed.isNotEmpty()

--- a/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Push.kt
+++ b/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Push.kt
@@ -17,7 +17,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 @Parcelize
 data class Push<InteractionTarget : Any>(
     private val interactionTarget: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<BackStackModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: BackStackModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Replace.kt
+++ b/appyx-components/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/operation/Replace.kt
@@ -18,7 +18,7 @@ import com.bumble.appyx.components.backstack.BackStackModel.State
 @Parcelize
 data class Replace<InteractionTarget : Any>(
     private val interactionTarget: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<State<InteractionTarget>>() {
     override fun isApplicable(state: State<InteractionTarget>): Boolean =
         interactionTarget != state.active.interactionTarget

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/operation/VoteLike.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/operation/VoteLike.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.components.demos.cards.CardsModel.State.Card.VisibleCard
 
 @Parcelize
 class VoteLike<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ): TopCardOperation<InteractionTarget>() {
 
     override fun createTargetState(fromState: CardsModel.State<InteractionTarget>): CardsModel.State<InteractionTarget> {

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/operation/VotePass.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/operation/VotePass.kt
@@ -7,7 +7,7 @@ import com.bumble.appyx.components.demos.cards.CardsModel.State.Card.InvisibleCa
 
 @Parcelize
 class VotePass<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : TopCardOperation<InteractionTarget>() {
 
     override fun createTargetState(fromState: CardsModel.State<InteractionTarget>): CardsModel.State<InteractionTarget> {

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
@@ -118,6 +118,7 @@ class CardsMotionController<InteractionTarget : Any>(
         }
 
         override fun createGesture(
+            state: CardsModel.State<InteractionTarget>,
             delta: Offset,
             density: Density
         ): Gesture<InteractionTarget, CardsModel.State<InteractionTarget>> {

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
@@ -11,7 +11,6 @@ import com.bumble.appyx.components.demos.cards.CardsModel.State.Card.InvisibleCa
 import com.bumble.appyx.components.demos.cards.operation.VoteLike
 import com.bumble.appyx.components.demos.cards.operation.VotePass
 import com.bumble.appyx.interactions.AppyxLogger
-import com.bumble.appyx.interactions.core.model.transition.Operation
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.gesture.Drag
@@ -135,12 +134,12 @@ class CardsMotionController<InteractionTarget : Any>(
 
             return if (dragHorizontalDirection(delta) == Drag.HorizontalDirection.LEFT) {
                 Gesture(
-                    operation = VotePass(Operation.Mode.KEYFRAME),
+                    operation = VotePass(),
                     axis = Offset(-dragToProgressFactor * width, 0f)
                 )
             } else {
                 Gesture(
-                    operation = VoteLike(Operation.Mode.KEYFRAME),
+                    operation = VoteLike(),
                     axis = Offset(dragToProgressFactor * width, 0f)
                 )
             }

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
@@ -136,14 +136,12 @@ class CardsMotionController<InteractionTarget : Any>(
             return if (dragHorizontalDirection(delta) == Drag.HorizontalDirection.LEFT) {
                 Gesture(
                     operation = VotePass(Operation.Mode.KEYFRAME),
-                    dragToProgress = { offset -> offset.x / (dragToProgressFactor * width) * -1 },
-                    partial = { offset, progress -> offset.copy(x = progress * width * -1) }
+                    axis = Offset(-dragToProgressFactor * width, 0f)
                 )
             } else {
                 Gesture(
                     operation = VoteLike(Operation.Mode.KEYFRAME),
-                    dragToProgress = { offset -> offset.x / (dragToProgressFactor * width) },
-                    partial = { offset, progress -> offset.copy(x = progress * width) }
+                    axis = Offset(dragToProgressFactor * width, 0f)
                 )
             }
         }

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/cards/ui/CardsMotionController.kt
@@ -135,12 +135,12 @@ class CardsMotionController<InteractionTarget : Any>(
             return if (dragHorizontalDirection(delta) == Drag.HorizontalDirection.LEFT) {
                 Gesture(
                     operation = VotePass(),
-                    axis = Offset(-dragToProgressFactor * width, 0f)
+                    completeAt = Offset(-dragToProgressFactor * width, 0f)
                 )
             } else {
                 Gesture(
                     operation = VoteLike(),
-                    axis = Offset(dragToProgressFactor * width, 0f)
+                    completeAt = Offset(dragToProgressFactor * width, 0f)
                 )
             }
         }

--- a/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/promoter/operation/AddFirst.kt
+++ b/appyx-components/demos/common/src/commonMain/kotlin/com/bumble/appyx/components/demos/promoter/operation/AddFirst.kt
@@ -12,7 +12,7 @@ import com.bumble.appyx.components.demos.promoter.PromoterModel
 @Parcelize
 data class AddFirst<InteractionTarget>(
     private val element: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<PromoterModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: PromoterModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/internal/android/src/androidTest/kotlin/com/bumble/appyx/components/internal/testdrive/helper/TestDriveUtils.kt
+++ b/appyx-components/internal/android/src/androidTest/kotlin/com/bumble/appyx/components/internal/testdrive/helper/TestDriveUtils.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import com.bumble.appyx.components.internal.testdrive.TestDrive
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel
 import com.bumble.appyx.components.internal.testdrive.TestDriveUi
-import com.bumble.appyx.components.internal.testdrive.ui.simple.TestDriveMotionController
+import com.bumble.appyx.components.internal.testdrive.ui.simple.TestDriveSimpleMotionController
 import com.bumble.appyx.interactions.core.gesture.GestureValidator.Companion.permissiveValidator
 import com.bumble.appyx.interactions.core.ui.helper.InteractionModelSetup
 import com.bumble.appyx.interactions.sample.InteractionTarget
@@ -39,14 +39,14 @@ fun ComposeContentTestRule.createTestDrive(
         scope = CoroutineScope(Dispatchers.Unconfined),
         model = model,
         motionController = {
-            TestDriveMotionController(
+            TestDriveSimpleMotionController(
                 uiContext = it,
                 uiAnimationSpec = uiAnimationSpec
             )
         },
         progressAnimationSpec = animationSpec ?: spring(),
         gestureFactory = {
-            TestDriveMotionController.Gestures(
+            TestDriveSimpleMotionController.Gestures(
                 it
             )
         },

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/TestDriveExperiment.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/TestDriveExperiment.kt
@@ -27,8 +27,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumble.appyx.components.internal.testdrive.operation.next
-import com.bumble.appyx.components.internal.testdrive.ui.simple.TestDriveMotionController
-import com.bumble.appyx.components.internal.testdrive.ui.simple.TestDriveMotionController.Companion.toTargetUiState
+import com.bumble.appyx.components.internal.testdrive.ui.rotation.TestDriveRotationMotionController
+import com.bumble.appyx.components.internal.testdrive.ui.rotation.TestDriveRotationMotionController.Companion.toTargetUiState
+import com.bumble.appyx.components.internal.testdrive.ui.simple.TestDriveSimpleMotionController
 import com.bumble.appyx.interactions.core.DraggableChildren
 import com.bumble.appyx.interactions.core.gesture.GestureValidator
 import com.bumble.appyx.interactions.core.gesture.GestureValidator.Companion.defaultValidator
@@ -58,11 +59,10 @@ fun <InteractionTarget : Any> TestDriveExperiment(
         TestDrive(
             scope = coroutineScope,
             model = model,
-            progressAnimationSpec =
-            spring(stiffness = Spring.StiffnessLow),
+            progressAnimationSpec = spring(stiffness = Spring.StiffnessLow),
             animateSettle = true,
             motionController = {
-                TestDriveMotionController(
+                TestDriveRotationMotionController(
                     it,
                     uiAnimationSpec = spring(
                         stiffness = Spring.StiffnessLow,
@@ -71,7 +71,7 @@ fun <InteractionTarget : Any> TestDriveExperiment(
                     ),
                 )
             },
-            gestureFactory = { TestDriveMotionController.Gestures(it) }
+            gestureFactory = { TestDriveSimpleMotionController.Gestures(it) }
         )
     }
 

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/MoveTo.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/MoveTo.kt
@@ -14,14 +14,14 @@ data class MoveTo<InteractionTarget>(
 ) : BaseOperation<TestDriveModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: TestDriveModel.State<InteractionTarget>): Boolean =
-        state.elementState.next() == elementState
+        true
 
     override fun createFromState(baseLineState: TestDriveModel.State<InteractionTarget>): TestDriveModel.State<InteractionTarget> =
         baseLineState
 
     override fun createTargetState(fromState: TestDriveModel.State<InteractionTarget>): TestDriveModel.State<InteractionTarget> =
         fromState.copy(
-            elementState = fromState.elementState.next()
+            elementState = elementState
         )
 }
 

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/MoveTo.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/MoveTo.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 @Parcelize
 data class MoveTo<InteractionTarget>(
     private val elementState: TestDriveModel.State.ElementState,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<TestDriveModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: TestDriveModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/Next.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/operation/Next.kt
@@ -9,7 +9,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 data class Next<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<TestDriveModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: TestDriveModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/rotation/TestDriveRotationMotionController.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/rotation/TestDriveRotationMotionController.kt
@@ -2,7 +2,6 @@ package com.bumble.appyx.components.internal.testdrive.ui.rotation
 
 import DefaultAnimationSpec
 import androidx.compose.animation.core.SpringSpec
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel
@@ -10,12 +9,8 @@ import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.Eleme
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.ElementState.B
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.ElementState.C
 import com.bumble.appyx.components.internal.testdrive.TestDriveModel.State.ElementState.D
-import com.bumble.appyx.components.internal.testdrive.operation.MoveTo
 import com.bumble.appyx.interactions.AppyxLogger
-import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.gesture.Gesture
-import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
 import com.bumble.appyx.interactions.core.ui.property.impl.RotationZ
@@ -25,9 +20,8 @@ import com.bumble.appyx.transitionmodel.testdrive.ui.md_light_blue_500
 import com.bumble.appyx.transitionmodel.testdrive.ui.md_light_green_500
 import com.bumble.appyx.transitionmodel.testdrive.ui.md_red_500
 import com.bumble.appyx.transitionmodel.testdrive.ui.md_yellow_500
-import kotlin.math.abs
 
-class TestDriveMotionController<InteractionTarget : Any>(
+class TestDriveRotationMotionController<InteractionTarget : Any>(
     uiContext: UiContext,
     uiAnimationSpec: SpringSpec<Float> = DefaultAnimationSpec
 ) : BaseMotionController<InteractionTarget, TestDriveModel.State<InteractionTarget>, MutableUiState, TargetUiState>(
@@ -82,50 +76,5 @@ class TestDriveMotionController<InteractionTarget : Any>(
 
     override fun mutableUiStateFor(uiContext: UiContext, targetUiState: TargetUiState): MutableUiState =
         targetUiState.toMutableState(uiContext)
-
-    class Gestures<InteractionTarget>(
-        transitionBounds: TransitionBounds,
-    ) : GestureFactory<InteractionTarget, TestDriveModel.State<InteractionTarget>> {
-        private val width = offsetB.x - offsetA.x
-
-        private val height = offsetD.y - offsetA.y
-        override fun createGesture(
-            delta: androidx.compose.ui.geometry.Offset,
-            density: Density
-        ): Gesture<InteractionTarget, TestDriveModel.State<InteractionTarget>> {
-            val width = with(density) { width.toPx() }
-            val height = with(density) { height.toPx() }
-
-            return if (abs(delta.x) > abs(delta.y)) {
-                if (delta.x < 0) {
-                    Gesture(
-                        operation = MoveTo(D),
-                        dragToProgress = { offset -> (offset.x / width) * -1 },
-                        partial = { offset, progress -> offset.copy(x = progress * width * -1) }
-                    )
-                } else {
-                    Gesture(
-                        operation = MoveTo(B),
-                        dragToProgress = { offset -> (offset.x / width) },
-                        partial = { offset, partial -> offset.copy(x = partial * width) }
-                    )
-                }
-            } else {
-                if (delta.y < 0) {
-                    Gesture(
-                        operation = MoveTo(A),
-                        dragToProgress = { offset -> (offset.y / height) * -1 },
-                        partial = { offset, partial -> offset.copy(y = partial * height * -1) }
-                    )
-                } else {
-                    Gesture(
-                        operation = MoveTo(C),
-                        dragToProgress = { offset -> (offset.y / height) },
-                        partial = { offset, partial -> offset.copy(y = partial * height) }
-                    )
-                }
-            }
-        }
-    }
 }
 

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/simple/TestDriveMotionController.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/simple/TestDriveMotionController.kt
@@ -15,17 +15,17 @@ import com.bumble.appyx.components.internal.testdrive.operation.MoveTo
 import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.E
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.N
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.NE
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.NW
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.S
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.SE
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.SW
-import com.bumble.appyx.interactions.core.ui.gesture.Drag.CompassDirection.W
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.RIGHT
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.UP
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.UPRIGHT
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.UPLEFT
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.DOWN
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.DOWNRIGHT
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.DOWNLEFT
+import com.bumble.appyx.interactions.core.ui.gesture.Drag.Direction8.LEFT
 import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
-import com.bumble.appyx.interactions.core.ui.gesture.dragCompassDirection
+import com.bumble.appyx.interactions.core.ui.gesture.dragDirection8
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
 import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
@@ -101,30 +101,30 @@ class TestDriveMotionController<InteractionTarget : Any>(
             val width = with(density) { widthDp.toPx() }
             val height = with(density) { heightDp.toPx() }
 
-            val direction = dragCompassDirection(delta)
+            val direction = dragDirection8(delta)
             return when (state.elementState) {
                 A -> when (direction) {
-                    E -> Gesture(MoveTo(B), Offset(width, 0f))
-                    SE -> Gesture(MoveTo(C), Offset(width, height))
-                    S -> Gesture(MoveTo(D), Offset(0f, height))
+                    RIGHT -> Gesture(MoveTo(B), Offset(width, 0f))
+                    DOWNRIGHT -> Gesture(MoveTo(C), Offset(width, height))
+                    DOWN -> Gesture(MoveTo(D), Offset(0f, height))
                     else -> Gesture.Noop()
                 }
                 B -> when (direction) {
-                    S -> Gesture(MoveTo(C), Offset(0f, height))
-                    SW -> Gesture(MoveTo(D), Offset(-width, height))
-                    W -> Gesture(MoveTo(A), Offset(-width, 0f))
+                    DOWN -> Gesture(MoveTo(C), Offset(0f, height))
+                    DOWNLEFT -> Gesture(MoveTo(D), Offset(-width, height))
+                    LEFT -> Gesture(MoveTo(A), Offset(-width, 0f))
                     else -> Gesture.Noop()
                 }
                 C -> when (direction) {
-                    W -> Gesture(MoveTo(D), Offset(-width, 0f))
-                    NW -> Gesture(MoveTo(A), Offset(-width, -height))
-                    N -> Gesture(MoveTo(B), Offset(0f, -height))
+                    LEFT -> Gesture(MoveTo(D), Offset(-width, 0f))
+                    UPLEFT -> Gesture(MoveTo(A), Offset(-width, -height))
+                    UP -> Gesture(MoveTo(B), Offset(0f, -height))
                     else -> Gesture.Noop()
                 }
                 D -> when (direction) {
-                    N -> Gesture(MoveTo(A), Offset(0f, -height))
-                    NE -> Gesture(MoveTo(B), Offset(width, -height))
-                    E -> Gesture(MoveTo(C), Offset(width, 0f))
+                    UP -> Gesture(MoveTo(A), Offset(0f, -height))
+                    UPRIGHT -> Gesture(MoveTo(B), Offset(width, -height))
+                    RIGHT -> Gesture(MoveTo(C), Offset(width, 0f))
                     else -> Gesture.Noop()
                 }
             }

--- a/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/simple/TestDriveSimpleMotionController.kt
+++ b/appyx-components/internal/common/src/commonMain/kotlin/com/bumble/appyx/components/internal/testdrive/ui/simple/TestDriveSimpleMotionController.kt
@@ -35,7 +35,7 @@ import com.bumble.appyx.transitionmodel.testdrive.ui.md_light_green_500
 import com.bumble.appyx.transitionmodel.testdrive.ui.md_red_500
 import com.bumble.appyx.transitionmodel.testdrive.ui.md_yellow_500
 
-class TestDriveMotionController<InteractionTarget : Any>(
+class TestDriveSimpleMotionController<InteractionTarget : Any>(
     uiContext: UiContext,
     uiAnimationSpec: SpringSpec<Float> = DefaultAnimationSpec
 ) : BaseMotionController<InteractionTarget, TestDriveModel.State<InteractionTarget>, MutableUiState, TargetUiState>(

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Activate.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Activate.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 @Parcelize
 class Activate<InteractionTarget : Any>(
     private val index: Float,
-    override val mode: Operation.Mode = Operation.Mode.IMPOSED
+    override var mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/First.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/First.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class First<InteractionTarget : Any>(
-    override val mode: Operation.Mode = Operation.Mode.IMPOSED
+    override var mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Last.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Last.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class Last<InteractionTarget : Any>(
-    override val mode: Operation.Mode = Operation.Mode.IMPOSED
+    override var mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Next.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Next.kt
@@ -9,7 +9,7 @@ import com.bumble.appyx.components.spotlight.SpotlightModel
 
 @Parcelize
 class Next<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.IMPOSED
+    override var mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Previous.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/Previous.kt
@@ -10,7 +10,7 @@ import com.bumble.appyx.interactions.core.model.transition.Operation
 
 @Parcelize
 class Previous<InteractionTarget>(
-    override val mode: Operation.Mode = Operation.Mode.IMPOSED
+    override var mode: Operation.Mode = Operation.Mode.IMPOSED
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/operation/UpdateElements.kt
@@ -20,7 +20,7 @@ import kotlin.math.max
 class UpdateElements<InteractionTarget : Any>(
     private val items: @RawValue List<InteractionTarget>,
     private val initialActiveIndex: Float? = null,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<SpotlightModel.State<InteractionTarget>>() {
 
     override fun isApplicable(state: SpotlightModel.State<InteractionTarget>): Boolean =

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -12,7 +12,6 @@ import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.D
 import com.bumble.appyx.components.spotlight.SpotlightModel.State.ElementState.STANDARD
 import com.bumble.appyx.components.spotlight.operation.Next
 import com.bumble.appyx.components.spotlight.operation.Previous
-import com.bumble.appyx.interactions.core.model.transition.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.gesture.Drag
@@ -104,12 +103,12 @@ class SpotlightSlider<InteractionTarget : Any>(
             Orientation.Horizontal -> {
                 when (dragHorizontalDirection(delta)) {
                     Drag.HorizontalDirection.LEFT -> Gesture(
-                        operation = if (reverseOrientation) Previous(KEYFRAME) else Next(KEYFRAME),
+                        operation = if (reverseOrientation) Previous() else Next(),
                         axis = Offset(-width, 0f)
                     )
 
                     else -> Gesture(
-                        operation = if (reverseOrientation) Next(KEYFRAME) else Previous(KEYFRAME),
+                        operation = if (reverseOrientation) Next() else Previous(),
                         axis = Offset(width, 0f)
                     )
                 }
@@ -118,13 +117,13 @@ class SpotlightSlider<InteractionTarget : Any>(
             Orientation.Vertical -> {
                 when (dragVerticalDirection(delta)) {
                     Drag.VerticalDirection.UP -> Gesture(
-                        operation = if (reverseOrientation) Previous(KEYFRAME) else Next(KEYFRAME),
+                        operation = if (reverseOrientation) Previous() else Next(),
                         axis = Offset(-height, 0f)
                     )
 
                     else ->
                         Gesture(
-                            operation = if (reverseOrientation) Next(KEYFRAME) else Previous(KEYFRAME),
+                            operation = if (reverseOrientation) Next() else Previous(),
                             axis = Offset(height, 0f)
                         )
                 }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -104,12 +104,12 @@ class SpotlightSlider<InteractionTarget : Any>(
                 when (dragHorizontalDirection(delta)) {
                     Drag.HorizontalDirection.LEFT -> Gesture(
                         operation = if (reverseOrientation) Previous() else Next(),
-                        axis = Offset(-width, 0f)
+                        completeAt = Offset(-width, 0f)
                     )
 
                     else -> Gesture(
                         operation = if (reverseOrientation) Next() else Previous(),
-                        axis = Offset(width, 0f)
+                        completeAt = Offset(width, 0f)
                     )
                 }
             }
@@ -118,13 +118,13 @@ class SpotlightSlider<InteractionTarget : Any>(
                 when (dragVerticalDirection(delta)) {
                     Drag.VerticalDirection.UP -> Gesture(
                         operation = if (reverseOrientation) Previous() else Next(),
-                        axis = Offset(0f, -height)
+                        completeAt = Offset(0f, -height)
                     )
 
                     else ->
                         Gesture(
                             operation = if (reverseOrientation) Next() else Previous(),
-                            axis = Offset(0f, height)
+                            completeAt = Offset(0f, height)
                         )
                 }
             }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -118,13 +118,13 @@ class SpotlightSlider<InteractionTarget : Any>(
                 when (dragVerticalDirection(delta)) {
                     Drag.VerticalDirection.UP -> Gesture(
                         operation = if (reverseOrientation) Previous() else Next(),
-                        axis = Offset(-height, 0f)
+                        axis = Offset(0f, -height)
                     )
 
                     else ->
                         Gesture(
                             operation = if (reverseOrientation) Next() else Previous(),
-                            axis = Offset(height, 0f)
+                            axis = Offset(0f, height)
                         )
                 }
             }

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -97,6 +97,7 @@ class SpotlightSlider<InteractionTarget : Any>(
         private val height = transitionBounds.heightPx
 
         override fun createGesture(
+            state: State<InteractionTarget>,
             delta: Offset,
             density: Density
         ): Gesture<InteractionTarget, State<InteractionTarget>> = when (orientation) {

--- a/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -93,8 +93,8 @@ class SpotlightSlider<InteractionTarget : Any>(
         private val orientation: Orientation = Orientation.Horizontal,
         private val reverseOrientation: Boolean = false,
     ) : GestureFactory<InteractionTarget, State<InteractionTarget>> {
-        private val width = transitionBounds.widthPx
-        private val height = transitionBounds.heightPx
+        private val width = transitionBounds.widthPx.toFloat()
+        private val height = transitionBounds.heightPx.toFloat()
 
         override fun createGesture(
             state: State<InteractionTarget>,
@@ -105,14 +105,12 @@ class SpotlightSlider<InteractionTarget : Any>(
                 when (dragHorizontalDirection(delta)) {
                     Drag.HorizontalDirection.LEFT -> Gesture(
                         operation = if (reverseOrientation) Previous(KEYFRAME) else Next(KEYFRAME),
-                        dragToProgress = { offset -> (offset.x / width) * -1 },
-                        partial = { offset, progress -> offset.copy(x = progress * width * -1) }
+                        axis = Offset(-width, 0f)
                     )
 
                     else -> Gesture(
                         operation = if (reverseOrientation) Next(KEYFRAME) else Previous(KEYFRAME),
-                        dragToProgress = { offset -> (offset.x / width) },
-                        partial = { offset, partial -> offset.copy(x = partial * width) }
+                        axis = Offset(width, 0f)
                     )
                 }
             }
@@ -121,15 +119,13 @@ class SpotlightSlider<InteractionTarget : Any>(
                 when (dragVerticalDirection(delta)) {
                     Drag.VerticalDirection.UP -> Gesture(
                         operation = if (reverseOrientation) Previous(KEYFRAME) else Next(KEYFRAME),
-                        dragToProgress = { offset -> (offset.y / height) * -1 },
-                        partial = { offset, partial -> offset.copy(y = partial * height * -1) }
+                        axis = Offset(-height, 0f)
                     )
 
                     else ->
                         Gesture(
                             operation = if (reverseOrientation) Next(KEYFRAME) else Previous(KEYFRAME),
-                            dragToProgress = { offset -> (offset.y / height) },
-                            partial = { offset, partial -> offset.copy(y = partial * height) }
+                            axis = Offset(height, 0f)
                         )
                 }
             }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -35,10 +35,13 @@ class DragProgressController<InteractionTarget : Any, State>(
     }
 
     override fun onDrag(dragAmount: Offset, density: Density) {
-        gestureFactory().createGesture(dragAmount, density)
         if (_gestureFactory == null) {
             _gestureFactory = { dragAmount ->
-                gestureFactory().createGesture(dragAmount, density)
+                gestureFactory().createGesture(
+                    state = model.output.value.currentTargetState,
+                    delta = dragAmount,
+                    density = density
+                )
             }
         }
         consumeDrag(dragAmount)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -73,7 +73,8 @@ class DragProgressController<InteractionTarget : Any, State>(
         if (gesture!!.startProgress == null) {
             // TODO internally this will always apply it to the end of a Keyframes queue,
             //  which is not necessarily what we want:
-            if (model.operation(operation)) {
+            if (model.canApply(operation)) {
+                model.operation(operation)
                 gesture!!.startProgress = currentProgress
                 AppyxLogger.d(TAG, "Gesture operation applied: $operation")
             } else {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -104,7 +104,9 @@ class DragProgressController<InteractionTarget : Any, State>(
                 // TODO without recursion
                 val remainder =
                     consumePartial(COMPLETE, dragAmount, totalTarget, deltaProgress, startProgress + 1)
-                consumeDrag(remainder)
+                if (remainder.getDistanceSquared() > 0) {
+                    consumeDrag(remainder)
+                }
             }
 
             // Case: we went back to or beyond the start,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.Density
 import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 import com.bumble.appyx.interactions.core.model.transition.Keyframes
+import com.bumble.appyx.interactions.core.model.transition.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel.SettleDirection.COMPLETE
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel.SettleDirection.REVERT
@@ -62,6 +63,7 @@ class DragProgressController<InteractionTarget : Any, State>(
 
         requireNotNull(gesture)
         val operation = gesture!!.operation
+        operation.mode = KEYFRAME
         val deltaProgress = gesture!!.dragToProgress(dragAmount)
         require(!deltaProgress.isNaN()) { "deltaProgress is NaN! – dragAmount: $dragAmount, gesture: $gesture, operation: $operation" }
         val currentProgress = if (currentState is Keyframes<*>) currentState.progress else 0f

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -55,7 +55,9 @@ class DragProgressController<InteractionTarget : Any, State>(
     private fun consumeDrag(dragAmount: Offset) {
         val currentState = model.output.value
         require(dragAmount.isValid()) { "dragAmount is NaN" }
-        require(dragAmount.getDistance() > 0f) { "dragAmount distance is 0" }
+        if (dragAmount.getDistanceSquared() == 0f) {
+            return
+        }
         requireNotNull(_gestureFactory) { "This should have been set already in this class" }
         if (gesture == null) {
             gesture = _gestureFactory!!.invoke(dragAmount)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/Operation.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/Operation.kt
@@ -33,7 +33,7 @@ interface Operation<ModelState> : Parcelable {
         IMPOSED,
     }
 
-    val mode: Mode
+    var mode: Mode
 
     fun isApplicable(state: ModelState): Boolean
 
@@ -41,8 +41,7 @@ interface Operation<ModelState> : Parcelable {
     @Parcelize
     class Noop<ModelState> : Operation<ModelState> {
 
-        override val mode: Mode
-            get() = Mode.IMMEDIATE
+        override var mode: Mode = Mode.IMMEDIATE
 
         override fun isApplicable(state: ModelState): Boolean =
             false

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/TransitionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/transition/TransitionModel.kt
@@ -32,6 +32,9 @@ interface TransitionModel<InteractionTarget, ModelState> : SavesInstanceState {
         overrideMode: Operation.Mode? = null
     ): Boolean
 
+    fun canApply(operation: Operation<ModelState>): Boolean =
+        operation.isApplicable(output.value.currentTargetState)
+
     fun setProgress(progress: Float)
 
     fun onSettled(direction: SettleDirection, animate: Boolean = false)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
@@ -2,26 +2,24 @@ package com.bumble.appyx.interactions.core.ui.gesture
 
 import androidx.compose.ui.geometry.Offset
 import com.bumble.appyx.interactions.core.ui.math.angleDegrees
-import kotlin.math.PI
 import kotlin.math.abs
-import kotlin.math.atan
 
 interface Drag {
 
-    enum class Direction {
-        LEFT, RIGHT, UP, DOWN
+    enum class VerticalDirection {
+        UP, DOWN
     }
 
     enum class HorizontalDirection {
         LEFT, RIGHT
     }
 
-    enum class VerticalDirection {
-        UP, DOWN
+    enum class Direction4 {
+        UP, DOWN, LEFT, RIGHT
     }
 
-    enum class CompassDirection {
-        N, NE, E, SE, S, SW, W, NW
+    enum class Direction8 {
+        UP, UPRIGHT, RIGHT, DOWNRIGHT, DOWN, DOWNLEFT, LEFT, UPLEFT
     }
 
     enum class ClockDirection(val digit: Int) {
@@ -50,16 +48,6 @@ fun dragAngleDegrees(delta: Offset): Double  =
     angleDegrees(delta)
 
 /**
- * The dominant direction of the drag (LEFT, RIGHT, UP, DOWN)
- */
-fun dragDirection(delta: Offset) =
-    if (abs(delta.x) > abs(delta.y)) {
-        if (delta.x < 0) Drag.Direction.LEFT else Drag.Direction.RIGHT
-    } else {
-        if (delta.y < 0) Drag.Direction.UP else Drag.Direction.DOWN
-    }
-
-/**
  * The horizontal aspect of the drag (LEFT or RIGHT), regardless of the dominant direction
  */
 fun dragHorizontalDirection(delta: Offset): Drag.HorizontalDirection =
@@ -72,20 +60,30 @@ fun dragVerticalDirection(delta: Offset): Drag.VerticalDirection =
     if (delta.y < 0) Drag.VerticalDirection.UP else Drag.VerticalDirection.DOWN
 
 /**
- * The drag direction interpreted on the compass
+ * The dominant direction of the drag of 4 possible directions
  */
-fun dragCompassDirection(delta: Offset): Drag.CompassDirection {
+fun dragDirection4(delta: Offset) =
+    if (abs(delta.x) > abs(delta.y)) {
+        if (delta.x < 0) Drag.Direction4.LEFT else Drag.Direction4.RIGHT
+    } else {
+        if (delta.y < 0) Drag.Direction4.UP else Drag.Direction4.DOWN
+    }
+
+/**
+ * The dominant direction of the drag of 8 possible directions
+ */
+fun dragDirection8(delta: Offset): Drag.Direction8 {
     val angle = dragAngleDegrees(delta)
     return when {
-        (0.0..22.5).contains(angle) -> Drag.CompassDirection.N
-        (22.5..67.5).contains(angle) -> Drag.CompassDirection.NE
-        (67.5..112.5).contains(angle) -> Drag.CompassDirection.E
-        (112.5..157.5).contains(angle) -> Drag.CompassDirection.SE
-        (157.5..202.5).contains(angle) -> Drag.CompassDirection.S
-        (202.5..247.5).contains(angle) -> Drag.CompassDirection.SW
-        (247.5..292.5).contains(angle) -> Drag.CompassDirection.W
-        (292.5..337.5).contains(angle) -> Drag.CompassDirection.NW
-        else -> Drag.CompassDirection.N
+        (0.0..22.5).contains(angle) -> Drag.Direction8.UP
+        (22.5..67.5).contains(angle) -> Drag.Direction8.UPRIGHT
+        (67.5..112.5).contains(angle) -> Drag.Direction8.RIGHT
+        (112.5..157.5).contains(angle) -> Drag.Direction8.DOWNRIGHT
+        (157.5..202.5).contains(angle) -> Drag.Direction8.DOWN
+        (202.5..247.5).contains(angle) -> Drag.Direction8.DOWNLEFT
+        (247.5..292.5).contains(angle) -> Drag.Direction8.LEFT
+        (292.5..337.5).contains(angle) -> Drag.Direction8.UPLEFT
+        else -> Drag.Direction8.UP
     }
 }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
@@ -44,7 +44,7 @@ interface Drag {
  * - 12 o'clock = 0 degrees
  * - 3 o'clock = 90 degrees
  */
-fun dragAngleDegrees(delta: Offset): Double  =
+fun dragAngleDegrees(delta: Offset): Float  =
     angleDegrees(delta)
 
 /**

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Drag.kt
@@ -1,6 +1,7 @@
 package com.bumble.appyx.interactions.core.ui.gesture
 
 import androidx.compose.ui.geometry.Offset
+import com.bumble.appyx.interactions.core.ui.math.angleDegrees
 import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.atan
@@ -45,31 +46,8 @@ interface Drag {
  * - 12 o'clock = 0 degrees
  * - 3 o'clock = 90 degrees
  */
-fun dragAngleDegrees(delta: Offset): Double  {
-    val (x, y) = delta
-    val deg = when {
-        x == 0f -> when {
-            y > 0 -> 90.0
-            y < 0 -> 270.0
-            else -> 0.0
-        }
-        y == 0f -> when {
-            x > 0 -> 0.0
-            x < 0 -> 180.0
-            else -> 0.0
-        }
-        else -> {
-            val deg = atan(y / x) * 180.0 / PI
-            when {
-                x < 0 -> 180 + deg
-                y < 0 -> 360 + deg
-                else -> deg
-            }
-        }
-    }
-
-    return (deg + 90) % 360
-}
+fun dragAngleDegrees(delta: Offset): Double  =
+    angleDegrees(delta)
 
 /**
  * The dominant direction of the drag (LEFT, RIGHT, UP, DOWN)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
@@ -18,10 +18,8 @@ open class Gesture<InteractionTarget, ModelState> internal constructor(
         operation = operation,
         dragToProgress = { offset -> proportionOf(offset, completeAt) },
         partial = { offset, remainder ->
-            val p = proportionOf(offset, completeAt)
-            val remp = remainder / p
-            val ret = offset * remp
-            ret
+            val totalProgress = proportionOf(offset, completeAt)
+            offset * (remainder / totalProgress)
         }
     )
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
@@ -19,9 +19,8 @@ open class Gesture<InteractionTarget, ModelState>(
         dragToProgress = { offset -> proportionOf(offset, axis) },
         partial = { offset, remainder ->
             val p = proportionOf(offset, axis)
-            val aligned = axis * p
-            val spent = aligned * (1 - remainder)
-            val ret = offset - spent
+            val remp = remainder / p
+            val ret = offset * remp
             ret
         }
     )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import com.bumble.appyx.interactions.core.model.transition.Operation
 import com.bumble.appyx.interactions.core.ui.math.proportionOf
 
-open class Gesture<InteractionTarget, ModelState>(
+open class Gesture<InteractionTarget, ModelState> internal constructor(
     val operation: Operation<ModelState>,
     val dragToProgress: (Offset) -> Float,
     val partial: (Offset, Float) -> Offset

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
@@ -13,12 +13,12 @@ open class Gesture<InteractionTarget, ModelState> internal constructor(
 
     constructor(
         operation: Operation<ModelState>,
-        axis: Offset,
+        completeAt: Offset,
     ) : this(
         operation = operation,
-        dragToProgress = { offset -> proportionOf(offset, axis) },
+        dragToProgress = { offset -> proportionOf(offset, completeAt) },
         partial = { offset, remainder ->
-            val p = proportionOf(offset, axis)
+            val p = proportionOf(offset, completeAt)
             val remp = remainder / p
             val ret = offset * remp
             ret

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/Gesture.kt
@@ -2,6 +2,7 @@ package com.bumble.appyx.interactions.core.ui.gesture
 
 import androidx.compose.ui.geometry.Offset
 import com.bumble.appyx.interactions.core.model.transition.Operation
+import com.bumble.appyx.interactions.core.ui.math.proportionOf
 
 open class Gesture<InteractionTarget, ModelState>(
     val operation: Operation<ModelState>,
@@ -9,6 +10,21 @@ open class Gesture<InteractionTarget, ModelState>(
     val partial: (Offset, Float) -> Offset
 ) {
     var startProgress: Float? = null
+
+    constructor(
+        operation: Operation<ModelState>,
+        axis: Offset,
+    ) : this(
+        operation = operation,
+        dragToProgress = { offset -> proportionOf(offset, axis) },
+        partial = { offset, remainder ->
+            val p = proportionOf(offset, axis)
+            val aligned = axis * p
+            val spent = aligned * (1 - remainder)
+            val ret = offset - spent
+            ret
+        }
+    )
 
     class Noop<InteractionTarget, ModelState> : Gesture<InteractionTarget, ModelState>(
         operation = Operation.Noop(),

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/GestureFactory.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/gesture/GestureFactory.kt
@@ -3,14 +3,22 @@ package com.bumble.appyx.interactions.core.ui.gesture
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 
-interface GestureFactory<InteractionTarget, State> {
+interface GestureFactory<InteractionTarget, ModelState> {
 
     fun onStartDrag(position: Offset) {}
 
-    fun createGesture(delta: Offset, density: Density): Gesture<InteractionTarget, State>
+    fun createGesture(
+        state: ModelState,
+        delta: Offset,
+        density: Density
+    ): Gesture<InteractionTarget, ModelState>
 
-    class Noop<InteractionTarget, State> : GestureFactory<InteractionTarget, State> {
-        override fun createGesture(delta: Offset, density: Density): Gesture<InteractionTarget, State> =
+    class Noop<InteractionTarget, ModelState> : GestureFactory<InteractionTarget, ModelState> {
+        override fun createGesture(
+            state: ModelState,
+            delta: Offset,
+            density: Density
+        ): Gesture<InteractionTarget, ModelState> =
             Gesture.Noop()
     }
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/Vector.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/Vector.kt
@@ -11,7 +11,7 @@ import kotlin.math.cos
  * - 12 o'clock = 0 degrees
  * - 3 o'clock = 90 degrees
  */
-fun angleDegrees(vector: Offset): Double  {
+fun angleDegrees(vector: Offset): Float  {
     val (x, y) = vector
     val deg = when {
         x == 0f -> when {
@@ -34,7 +34,7 @@ fun angleDegrees(vector: Offset): Double  {
         }
     }
 
-    return (deg + 90) % 360
+    return (deg.toFloat() + 90) % 360
 }
 
 fun scalarComponentOf(v1: Offset, v2: Offset): Float {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/Vector.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/math/Vector.kt
@@ -1,0 +1,51 @@
+package com.bumble.appyx.interactions.core.ui.math
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.PI
+import kotlin.math.atan
+import kotlin.math.cos
+
+/**
+ * The angle of the vector such that:
+ *
+ * - 12 o'clock = 0 degrees
+ * - 3 o'clock = 90 degrees
+ */
+fun angleDegrees(vector: Offset): Double  {
+    val (x, y) = vector
+    val deg = when {
+        x == 0f -> when {
+            y > 0 -> 90.0
+            y < 0 -> 270.0
+            else -> 0.0
+        }
+        y == 0f -> when {
+            x > 0 -> 0.0
+            x < 0 -> 180.0
+            else -> 0.0
+        }
+        else -> {
+            val deg = atan(y / x) * 180.0 / PI
+            when {
+                x < 0 -> 180 + deg
+                y < 0 -> 360 + deg
+                else -> deg
+            }
+        }
+    }
+
+    return (deg + 90) % 360
+}
+
+fun scalarComponentOf(v1: Offset, v2: Offset): Float {
+    val theta = angleDegrees(v1) - angleDegrees(v2)
+    val l = v1.getDistance()
+
+    return (l * cos(theta / 180 * PI)).toFloat()
+}
+
+fun proportionOf(v1: Offset, v2: Offset): Float {
+    val s = scalarComponentOf(v1, v2)
+
+    return s / v2.getDistance()
+}

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/operation/AddUnique.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/operation/AddUnique.kt
@@ -11,7 +11,7 @@ import com.bumble.appyx.interactions.permanent.PermanentModel
 @Parcelize
 data class AddUnique<InteractionTarget : Any>(
     private val interactionTarget: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<PermanentModel.State<InteractionTarget>>() {
 
 

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
@@ -41,11 +41,14 @@ class TestTransitionModel<InteractionTarget : Any>(
 class TestGestures<InteractionTarget : Any>(
     private val target: InteractionTarget,
 ) : GestureFactory<InteractionTarget, State<InteractionTarget>> {
-    override fun createGesture(delta: Offset, density: Density): Gesture<InteractionTarget, State<InteractionTarget>> =
+    override fun createGesture(
+        state: State<InteractionTarget>,
+        delta: Offset,
+        density: Density
+    ): Gesture<InteractionTarget, State<InteractionTarget>> =
         Gesture(
             operation = TestOperation(target),
-            dragToProgress = { _ -> 0f },
-            partial = { offset, _ -> offset }
+            axis = Offset(100f, 100f)
         )
 }
 

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
@@ -48,7 +48,7 @@ class TestGestures<InteractionTarget : Any>(
     ): Gesture<InteractionTarget, State<InteractionTarget>> =
         Gesture(
             operation = TestOperation(target),
-            axis = Offset(100f, 100f)
+            completeAt = Offset(100f, 100f)
         )
 }
 

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/TestTransitionModel.kt
@@ -55,7 +55,7 @@ class TestGestures<InteractionTarget : Any>(
 @Parcelize
 class TestOperation<InteractionTarget : Any>(
     private val interactionTarget: @RawValue InteractionTarget,
-    override val mode: Operation.Mode = Operation.Mode.KEYFRAME
+    override var mode: Operation.Mode = Operation.Mode.KEYFRAME
 ) : BaseOperation<State<InteractionTarget>>() {
     override fun createFromState(baseLineState: State<InteractionTarget>): State<InteractionTarget> =
         baseLineState


### PR DESCRIPTION
## Description

- Pass the model state to gesture factory
- Adds a much easier API for drag->progress calculation along an axis
- `TestDriveExperiment` uses the new apis, and now allows for diagonal gestures too
- Removes necessity to always define gesture operations as `KEYFRAME`, it's now added automatically
- Some fixes for possible bugs

