### PR TITLE
Check uiContext instead of bounds when updaing uiContext

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.Element
-import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 import com.bumble.appyx.interactions.core.model.backpresshandlerstrategies.BackPressHandlerStrategy
 import com.bumble.appyx.interactions.core.model.backpresshandlerstrategies.DontHandleBackPress
 import com.bumble.appyx.interactions.core.model.progress.AnimatedProgressController
@@ -27,6 +26,7 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.context.UiContextAware
 import com.bumble.appyx.interactions.core.ui.context.zeroSizeTransitionBounds
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
+import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -73,14 +73,7 @@ open class BaseInteractionModel<InteractionTarget : Any, ModelState : Any>(
 
     private var animationChangesJob: Job? = null
     private var animationFinishedJob: Job? = null
-
-    private var transitionBounds: TransitionBounds = zeroSizeTransitionBounds
-        set(value) {
-            if (value != field) {
-                AppyxLogger.d("InteractionModel", "TransitionBounds changed: $value")
-                field = value
-            }
-        }
+    private var uiContext: UiContext? = null
 
     private var _isAnimating = MutableStateFlow(false)
     val isAnimating: StateFlow<Boolean> = _isAnimating
@@ -170,12 +163,12 @@ open class BaseInteractionModel<InteractionTarget : Any, ModelState : Any>(
     }
 
     override fun updateContext(uiContext: UiContext) {
-        if (this.transitionBounds != uiContext.transitionBounds) {
-            this.transitionBounds = uiContext.transitionBounds
+        if (this.uiContext != uiContext) {
+            AppyxLogger.d("InteractionModel", "new uiContext supplied: $uiContext")
             _motionController = motionController(uiContext).also {
                 onMotionControllerReady(it)
             }
-            _gestureFactory = gestureFactory(transitionBounds)
+            _gestureFactory = gestureFactory(uiContext.transitionBounds)
         }
     }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseInteractionModel.kt
@@ -164,6 +164,7 @@ open class BaseInteractionModel<InteractionTarget : Any, ModelState : Any>(
 
     override fun updateContext(uiContext: UiContext) {
         if (this.uiContext != uiContext) {
+            this.uiContext = uiContext
             AppyxLogger.d("InteractionModel", "new uiContext supplied: $uiContext")
             _motionController = motionController(uiContext).also {
                 onMotionControllerReady(it)


### PR DESCRIPTION
## Description

MotionController does not respond to model changes in some cases. It happens if new uiContext is supplied with new coroutines scope while having the same transition bounds.

Steps to reproduce:

1. ParentNode has Spotlight with SpotlightFader
2. ChildrenNode have Spotlight with SpotlightSlider
3. In ParentNode activate any Spotlight's index and then activate back the current index
4. Child Node with SpotlightSlider stops reacting to scroll

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
