### PR TITLE
Rework visibility approach

### DIFF
--- a/appyx-components/stable/backstack/android/src/androidTest/kotlin/com/bumble/appyx/components/backstack/android/BackStackTest.kt
+++ b/appyx-components/stable/backstack/android/src/androidTest/kotlin/com/bumble/appyx/components/backstack/android/BackStackTest.kt
@@ -56,8 +56,8 @@ class BackStackTest(private val testParam: TestParam) {
         backStack.push(interactionTarget = InteractionTarget.Child4)
         backStack.pop(animationSpec = tweenTwoSec)
 
-        // all operations finished. advanced time > 2000 (last operation animation spec)
-        composeTestRule.mainClock.advanceTimeBy(2100)
+        // all operations finished
+        composeTestRule.waitForIdle()
 
         Assert.assertEquals(3, backStack.elements.value.all.size)
     }

--- a/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/slider/BackStackSlider.kt
+++ b/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/slider/BackStackSlider.kt
@@ -33,7 +33,7 @@ class BackStackSlider<InteractionTarget : Any>(
             stashed.mapIndexed { index, element ->
                 MatchedTargetUiState(
                     element,
-                    visible.toOutsideLeft(index + 1, -width)
+                    visible.toOutsideLeft(index + 1, width)
                 )
             } +
             destroyed.mapIndexed { index, element ->

--- a/appyx-components/stable/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/android/SpotlightTest.kt
+++ b/appyx-components/stable/spotlight/android/src/androidTest/kotlin/com/bumble/appyx/components/spotlight/android/SpotlightTest.kt
@@ -56,6 +56,8 @@ class SpotlightTest(private val testParam: TestParam) {
             spotlight.waitUntilAnimationEnded(composeTestRule)
         }
 
+        composeTestRule.waitForIdle()
+
         checkInteractionTargetsOnScreen(setOf(InteractionTarget.Child5, InteractionTarget.Child4))
     }
 
@@ -72,6 +74,8 @@ class SpotlightTest(private val testParam: TestParam) {
             spotlight.last(mode = testParam.operationMode)
             spotlight.waitUntilAnimationEnded(composeTestRule)
         }
+
+        composeTestRule.waitForIdle()
 
         checkInteractionTargetsOnScreen(setOf(InteractionTarget.Child5))
     }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -88,7 +88,7 @@ fun <InteractionTarget : Any, ModelState : Any> DraggableChildren(
         ) {
             elementUiModels.value.forEach { elementUiModel ->
                 key(elementUiModel.element.id) {
-                    elementUiModel.animationContainer()
+                    elementUiModel.persistedContainer()
                     val isVisible by elementUiModel.visibleState.collectAsState()
                     if (isVisible) {
                         element.invoke(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -88,7 +88,7 @@ fun <InteractionTarget : Any, ModelState : Any> DraggableChildren(
         ) {
             elementUiModels.value.forEach { elementUiModel ->
                 key(elementUiModel.element.id) {
-                    elementUiModel.persistedContainer()
+                    elementUiModel.persistentContainer()
                     val isVisible by elementUiModel.visibleState.collectAsState()
                     if (isVisible) {
                         element.invoke(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/output/ElementUiModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/output/ElementUiModel.kt
@@ -9,7 +9,14 @@ import kotlinx.coroutines.flow.StateFlow
 data class ElementUiModel<InteractionTarget>(
     val element: Element<InteractionTarget>,
     val visibleState: StateFlow<Boolean>,
-    val animationContainer: @Composable () -> Unit,
+    /**
+     * The purpose of this container is to be present in composition as long as corresponding
+     * Element exists. With its help we calculate visibility of the element and animate MotionProperties
+     * even if the element is invisible. This help to break circular dependency when element is
+     * not present in the composition and therefore we can't update MotionProperties, and because
+     * MotionProperties are not updated element can never enter composition even when it should.
+     */
+    val persistedContainer: @Composable () -> Unit,
     val modifier: Modifier,
     val progress: Flow<Float>
 )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/output/ElementUiModel.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/output/ElementUiModel.kt
@@ -16,7 +16,7 @@ data class ElementUiModel<InteractionTarget>(
      * not present in the composition and therefore we can't update MotionProperties, and because
      * MotionProperties are not updated element can never enter composition even when it should.
      */
-    val persistedContainer: @Composable () -> Unit,
+    val persistentContainer: @Composable () -> Unit,
     val modifier: Modifier,
     val progress: Flow<Float>
 )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -11,6 +11,7 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import com.bumble.appyx.mapState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -32,12 +33,13 @@ class Alpha(
         val easing: Easing? = null,
     ) : MotionProperty.Target
 
+    override val isVisibleFlow: StateFlow<Boolean> =
+        renderValueFlow.mapState(uiContext.coroutineScope) {
+            it > 0f
+        }
+
     override fun calculateRenderValue(base: Float, displacement: Float): Float =
         base - displacement
-
-    override val visibilityMapper: ((Float) -> Boolean) = { alpha ->
-        alpha > 0.0f
-    }
 
     override val modifier: Modifier
         get() = Modifier.composed {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ColorOverlay.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ColorOverlay.kt
@@ -37,8 +37,6 @@ class ColorOverlay(
     override fun calculateRenderValue(base: Float, displacement: Float): Float =
         base - displacement
 
-    override val visibilityMapper: ((Float) -> Boolean) = { true }
-
     override val modifier: Modifier
         get() = Modifier.composed {
             val alpha = renderValueFlow.collectAsState().value

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Position.kt
@@ -10,12 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
-import com.bumble.appyx.interactions.core.ui.toPx
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -39,60 +37,6 @@ class Position(
 
     override fun calculateRenderValue(base: DpOffset, displacement: DpOffset): DpOffset =
         base - displacement
-
-    override val visibilityMapper: (DpOffset) -> Boolean = { displacedValue ->
-        val bounds = uiContext.transitionBounds
-        val clipToBounds = uiContext.clipToBounds
-
-        val itemOffsetRangeX = calculateItemOffsetRangeX(displacedValue, bounds)
-        val itemOffsetRangeY = calculateItemOffsetRangeY(displacedValue, bounds)
-
-        val visibleOffsetRangeX = calculateVisibleOffsetRangeX(bounds, clipToBounds)
-        val visibleOffsetRangeY = calculateVisibleOffsetRangeY(bounds, clipToBounds)
-
-        val isVisible = itemOffsetRangeX.hasIntersection(visibleOffsetRangeX)
-            && itemOffsetRangeY.hasIntersection(visibleOffsetRangeY)
-        isVisible
-    }
-
-    private fun calculateItemOffsetRangeX(
-        displacedValue: DpOffset,
-        bounds: TransitionBounds
-    ): ClosedRange<Int> {
-        val displacedValueXPx = displacedValue.x.toPx(bounds.density)
-        return (displacedValueXPx..(displacedValueXPx + bounds.widthPx))
-    }
-
-    private fun calculateItemOffsetRangeY(
-        displacedValue: DpOffset,
-        bounds: TransitionBounds
-    ): ClosedRange<Int> {
-        val displacedValueYPx = displacedValue.y.toPx(bounds.density)
-        return (displacedValueYPx..(displacedValueYPx + bounds.heightPx))
-    }
-
-    private fun calculateVisibleOffsetRangeX(bounds: TransitionBounds, clipToBounds: Boolean) =
-        if (clipToBounds) {
-            (0)..(bounds.widthPx)
-        } else {
-            (-bounds.containerOffsetXPx)..(bounds.screenWidthPx - bounds.containerOffsetXPx)
-        }
-
-    private fun calculateVisibleOffsetRangeY(bounds: TransitionBounds, clipToBounds: Boolean) =
-        if (clipToBounds) {
-            (0)..(bounds.heightPx)
-        } else {
-            (-bounds.containerOffsetYPx)..(bounds.screenHeightPx - bounds.containerOffsetYPx)
-        }
-
-
-    // If one range ends where another starts we consider them as non-intersected
-    private fun <T : Comparable<T>> ClosedRange<T>.hasIntersection(another: ClosedRange<T>): Boolean =
-        when {
-            isEmpty() || another.isEmpty() -> false
-            endInclusive <= another.start || start >= another.endInclusive -> false
-            else -> true
-        }
 
     override val modifier: Modifier
         get() = Modifier.composed {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -37,10 +37,6 @@ class Scale(
     override fun calculateRenderValue(base: Float, displacement: Float): Float =
         base - displacement
 
-    override val visibilityMapper: ((Float) -> Boolean) = { scale ->
-        scale > 0.0f
-    }
-
     override val modifier: Modifier
         get() = Modifier.composed {
             this.scale(renderValueFlow.collectAsState().value)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Shadow.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Shadow.kt
@@ -36,8 +36,6 @@ class Shadow(
     override fun calculateRenderValue(base: Float, displacement: Float): Float =
         base - displacement
 
-    override val visibilityMapper: ((Float) -> Boolean) = { true }
-
     override val modifier: Modifier
         get() = Modifier.composed {
             this.shadow(elevation = renderValueFlow.collectAsState().value.dp, clip = false)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
@@ -1,32 +1,83 @@
 package com.bumble.appyx.interactions.core.ui.state
 
 import androidx.compose.animation.core.SpringSpec
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onPlaced
 import com.bumble.appyx.combineState
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 
 abstract class BaseMutableUiState<MutableUiState, TargetUiState>(
     val uiContext: UiContext,
     val motionProperties: List<MotionProperty<*, *>>
 ) {
+
+    private val containerRect = Rect(
+        offset = Offset.Zero,
+        size = Size(
+            width = uiContext.transitionBounds.widthPx.toFloat(),
+            height = uiContext.transitionBounds.heightPx.toFloat()
+        )
+    )
+
     abstract val modifier: Modifier
+
+    private val _isBoundsVisible = MutableStateFlow(false)
+    private val visibilitySources: Iterable<StateFlow<Boolean>> =
+        motionProperties.mapNotNull { it.isVisibleFlow } + _isBoundsVisible
+
+    val isVisible: StateFlow<Boolean>
+        get() = combineState(
+            visibilitySources,
+            uiContext.coroutineScope
+        ) { booleanArray ->
+            booleanArray.all { it }
+        }
+
+    /**
+     * This modifier duplicates original modifier, and will be placed on the dummy compose view
+     * to calculate bounds relative to parent and eventually update bounds visibility relative
+     * to parent's bounds. Because it's responsible only for calculating element's bounds it ensures
+     * that it's invisible by setting alpha as 0f. Additionally, it makes sure that it occupies all
+     * available space by applying fillMaxSize().
+     */
+    val visibilityModifier: Modifier
+        get() = modifier
+            .fillMaxSize()
+            .graphicsLayer {
+                // Making sure that this modifier is invisible
+                alpha = 0f
+            }
+            .onPlaced { coordinates ->
+                if (uiContext.clipToBounds) {
+                    val boundsInParent = coordinates.boundsInParent()
+                    val overlaps = boundsInParent.overlaps(containerRect)
+                    _isBoundsVisible.update { overlaps }
+                } else {
+                    // if element is invisible boundsInRoot will have width == 0 or height == 0 or both
+                    val boundsInRoot = coordinates.boundsInRoot()
+                    _isBoundsVisible.update {
+                        (boundsInRoot.width > 0f && boundsInRoot.height > 0f)
+                    }
+                }
+            }
 
     val isAnimating: Flow<Boolean>
         get() = combine(motionProperties.map { it.isAnimating }) { booleanArray ->
             booleanArray.any { it }
-        }
-
-    val isVisible: StateFlow<Boolean>
-        get() = combineState(
-            motionProperties.map { it.isVisibleFlow },
-            uiContext.coroutineScope
-        ) { booleanArray ->
-            booleanArray.all { it }
         }
 
     abstract suspend fun snapTo(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
@@ -55,12 +55,13 @@ abstract class BaseMutableUiState<MutableUiState, TargetUiState>(
      * available space by applying fillMaxSize().
      */
     val visibilityModifier: Modifier
-        get() = modifier
-            .fillMaxSize()
+        get() = Modifier
             .graphicsLayer {
                 // Making sure that this modifier is invisible
                 alpha = 0f
             }
+            .then(modifier)
+            .fillMaxSize()
             .onPlaced { coordinates ->
                 if (uiContext.clipToBounds) {
                     val boundsInParent = coordinates.boundsInParent()

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -74,7 +74,7 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
     ) {
         elementUiModels.value.forEach { elementUiModel ->
             key(elementUiModel.element.id) {
-                elementUiModel.animationContainer()
+                elementUiModel.persistedContainer()
                 val isVisible by elementUiModel.visibleState.collectAsState()
                 if (isVisible) {
                     element.invoke(elementUiModel)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -74,7 +74,7 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
     ) {
         elementUiModels.value.forEach { elementUiModel ->
             key(elementUiModel.element.id) {
-                elementUiModel.persistedContainer()
+                elementUiModel.persistentContainer()
                 val isVisible by elementUiModel.visibleState.collectAsState()
                 if (isVisible) {
                     element.invoke(elementUiModel)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -92,7 +92,7 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
             ElementUiModel(
                 element = t1.element,
                 visibleState = mutableUiState.isVisible,
-                persistedContainer = @Composable {
+                persistentContainer = @Composable {
                     Box(modifier = mutableUiState.visibilityModifier)
                     observeElementAnimationChanges(mutableUiState, t1)
                     manageAnimations(mutableUiState, t1, update)
@@ -201,7 +201,7 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
             ElementUiModel(
                 element = t1.element,
                 visibleState = mutableUiState.isVisible,
-                persistedContainer = @Composable {
+                persistentContainer = @Composable {
                     Box(modifier = mutableUiState.visibilityModifier)
                     interpolateUiState(segmentProgress, mutableUiState, t0, t1, initialProgress)
                 },

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/transitionmodel/BaseMotionController.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.transitionmodel
 import DefaultAnimationSpec
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -91,7 +92,8 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
             ElementUiModel(
                 element = t1.element,
                 visibleState = mutableUiState.isVisible,
-                animationContainer = @Composable {
+                persistedContainer = @Composable {
+                    Box(modifier = mutableUiState.visibilityModifier)
                     observeElementAnimationChanges(mutableUiState, t1)
                     manageAnimations(mutableUiState, t1, update)
                 },
@@ -199,7 +201,8 @@ abstract class BaseMotionController<InteractionTarget : Any, ModelState, Mutable
             ElementUiModel(
                 element = t1.element,
                 visibleState = mutableUiState.isVisible,
-                animationContainer = @Composable {
+                persistedContainer = @Composable {
+                    Box(modifier = mutableUiState.visibilityModifier)
                     interpolateUiState(segmentProgress, mutableUiState, t0, t1, initialProgress)
                 },
                 modifier = mutableUiState.modifier,

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
@@ -112,7 +112,7 @@ class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
         visibleFrames.value
             .forEach { uiModel ->
                 key(uiModel.element.id) {
-                    uiModel.animationContainer()
+                    uiModel.persistedContainer()
                     val isVisible by uiModel.visibleState.collectAsState()
                     if (isVisible) {
                         Child(

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/Children.kt
@@ -112,7 +112,7 @@ class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
         visibleFrames.value
             .forEach { uiModel ->
                 key(uiModel.element.id) {
-                    uiModel.persistedContainer()
+                    uiModel.persistentContainer()
                     val isVisible by uiModel.visibleState.collectAsState()
                     if (isVisible) {
                         Child(

--- a/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/backstack/BackStackNode.kt
+++ b/demos/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/node/backstack/BackStackNode.kt
@@ -102,6 +102,7 @@ class BackStackNode(
                 .background(appyx_dark)
         ) {
             Children(
+                clipToBounds = true,
                 interactionModel = backStack,
                 modifier = Modifier
                     .weight(0.9f)


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/464

**Old approach:**
Every `MotionProperty` is exposing `isVisibleFlow`, and `BaseMutableUiState` visibility was a combined value from all these flows. The problem with that approach is that each `MotionProperty` doesn't have enough information to calculate its visibility correctly. For instance, `Position` can resolve its visibility correctly but if `Scale` or `Rotation` is present they will not be considered.

**New approach**
In the new approach, I duplicate the modifier which will be used for transitions, and add `onPlaced` modifier which will help to understand where the element bounds relative to the parent (if clipToBounds == true) or root (if clipToBounds == false). The only factor that is not considered is alpha. For that reason I'm allowing `MotionProperties` to override `isVisibleFlow` if they influence visibility and its not related to position.
 

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
