### PR TITLE
Settle after gesture release

### DIFF
--- a/appyx-components/experimental/puzzle15/android/src/main/kotlin/com/bumble/appyx/components/experimental/puzzle15/android/Puzzle15.kt
+++ b/appyx-components/experimental/puzzle15/android/src/main/kotlin/com/bumble/appyx/components/experimental/puzzle15/android/Puzzle15.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import com.bumble.appyx.components.experimental.puzzle15.ui.Puzzle15Ui
-import com.bumble.appyx.interactions.sample.colors
 import com.bumble.appyx.interactions.theme.appyx_dark
 import kotlin.math.roundToInt
 
@@ -16,7 +15,6 @@ fun Puzzle15() {
     Puzzle15Ui(
         screenWidthPx = (LocalConfiguration.current.screenWidthDp * LocalDensity.current.density).roundToInt(),
         screenHeightPx = (LocalConfiguration.current.screenHeightDp * LocalDensity.current.density).roundToInt(),
-        colors = colors,
         modifier = Modifier.fillMaxSize().background(appyx_dark),
     )
 }

--- a/appyx-components/experimental/puzzle15/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/puzzle15/ui/Puzzle15MotionController.kt
+++ b/appyx-components/experimental/puzzle15/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/puzzle15/ui/Puzzle15MotionController.kt
@@ -50,34 +50,36 @@ class Puzzle15MotionController(
     ): MutableUiState =
         targetUiState.toMutableState(uiContext)
 
-    class Gestures(private val bounds: TransitionBounds) :
-        GestureFactory<Tile, Puzzle15Model.State> {
+    class Gestures(
+        bounds: TransitionBounds,
+    ) : GestureFactory<Tile, Puzzle15Model.State> {
+
+        private val cellSize: Float = bounds.widthPx / 4f
 
         override fun createGesture(
             state: Puzzle15Model.State,
             delta: Offset,
             density: Density
         ): Gesture<Tile, Puzzle15Model.State> {
-            val distance = (bounds.widthPx / 4).toFloat()
             return when (dragDirection4(delta)) {
                 Drag.Direction4.UP -> Gesture(
                     operation = Swap(Swap.Direction.DOWN),
-                    completeAt = Offset(0f, -distance)
+                    completeAt = Offset(0f, -cellSize)
                 )
 
                 Drag.Direction4.LEFT -> Gesture(
                     operation = Swap(Swap.Direction.RIGHT),
-                    completeAt = Offset(-distance, 0f)
+                    completeAt = Offset(-cellSize, 0f)
                 )
 
                 Drag.Direction4.RIGHT -> Gesture(
                     operation = Swap(Swap.Direction.LEFT),
-                    completeAt = Offset(distance, 0f)
+                    completeAt = Offset(cellSize, 0f)
                 )
 
                 Drag.Direction4.DOWN -> Gesture(
                     operation = Swap(Swap.Direction.UP),
-                    completeAt = Offset(0f, distance)
+                    completeAt = Offset(0f, cellSize)
                 )
 
             }

--- a/appyx-components/experimental/puzzle15/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/puzzle15/ui/Puzzle15Ui.kt
+++ b/appyx-components/experimental/puzzle15/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/puzzle15/ui/Puzzle15Ui.kt
@@ -31,7 +31,6 @@ import com.bumble.appyx.components.experimental.puzzle15.operation.Swap.Directio
 import com.bumble.appyx.components.experimental.puzzle15.operation.Swap.Direction.LEFT
 import com.bumble.appyx.components.experimental.puzzle15.operation.Swap.Direction.RIGHT
 import com.bumble.appyx.components.experimental.puzzle15.operation.Swap.Direction.UP
-import com.bumble.appyx.interactions.AppyxLogger
 import com.bumble.appyx.interactions.core.ui.helper.AppyxComponentSetup
 import com.bumble.appyx.interactions.sample.Children
 
@@ -40,7 +39,6 @@ import com.bumble.appyx.interactions.sample.Children
 fun Puzzle15Ui(
     screenWidthPx: Int,
     screenHeightPx: Int,
-    colors: List<Color>,
     modifier: Modifier = Modifier,
 ) {
     println("Hello Puzzle15")
@@ -103,16 +101,18 @@ fun Puzzle15Ui(
                         Box(
                             modifier = Modifier.size(60.dp)
                                 .then(
-                                    elementUiModel.modifier
+                                    elementUiModel
+                                        .modifier
                                         .background(color = Color.White)
-                                ).pointerInput(elementUiModel.element.id) {
+                                )
+                                .pointerInput(elementUiModel.element.id) {
+                                    this.interceptOutOfBoundsChildEvents = true
                                     detectDragGestures(
                                         onDrag = { change, dragAmount ->
                                             change.consume()
                                             puzzle15.onDrag(dragAmount, this)
                                         },
                                         onDragEnd = {
-                                            AppyxLogger.d("drag", "end")
                                             puzzle15.onDragEnd()
                                         }
                                     )

--- a/appyx-components/experimental/puzzle15/web/src/jsMain/kotlin/com/bumble/appyx/experimental/puzzle15/web/main.js.kt
+++ b/appyx-components/experimental/puzzle15/web/src/jsMain/kotlin/com/bumble/appyx/experimental/puzzle15/web/main.js.kt
@@ -46,7 +46,6 @@ fun main() {
                 Puzzle15Ui(
                     screenWidthPx = size.width,
                     screenHeightPx = size.height,
-                    colors = colors,
                     modifier = Modifier
                         .fillMaxSize()
                         .background(Color.Black)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onPlaced
@@ -29,6 +30,7 @@ import com.bumble.appyx.interactions.core.gesture.GestureValidator
 import com.bumble.appyx.interactions.core.gesture.GestureValidator.Companion.defaultValidator
 import com.bumble.appyx.interactions.core.gesture.detectDragGesturesOrCancellation
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
+import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
@@ -81,6 +83,11 @@ fun <InteractionTarget : Any, ModelState : Any> DraggableAppyxComponent(
                     ),
                     clipToBounds = clipToBounds
                 )
+            }
+            .onPointerEvent {
+                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
+                    appyxComponent.onDragEnd()
+                }
             }
             .fillMaxSize()
     ) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -85,8 +85,8 @@ fun <InteractionTarget : Any, ModelState : Any> DraggableAppyxComponent(
                 )
             }
             .onPointerEvent {
-                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
-                    appyxComponent.onDragEnd()
+                if (it.type == PointerEventType.Release) {
+                    appyxComponent.onRelease()
                 }
             }
             .fillMaxSize()

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
@@ -260,7 +260,11 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
         }
     }
 
-    override fun isDragging(): Boolean = drag.isDragging()
+    fun onRelease() {
+        if (drag.isDragging()) {
+            onDragEnd()
+        }
+    }
 
     private fun settle(gestureSettleConfig: GestureSettleConfig) {
         if (isDebug) {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
@@ -260,6 +260,8 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
         }
     }
 
+    override fun isDragging(): Boolean = drag.isDragging()
+
     private fun settle(gestureSettleConfig: GestureSettleConfig) {
         if (isDebug) {
             debug?.settle()

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -13,7 +13,7 @@ import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
 import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 
-class DragProgressController<InteractionTarget : Any, State>(
+internal class DragProgressController<InteractionTarget : Any, State>(
     private val model: TransitionModel<InteractionTarget, State>,
     private val gestureFactory: () -> GestureFactory<InteractionTarget, State>,
     override val defaultAnimationSpec: AnimationSpec<Float>,
@@ -52,7 +52,7 @@ class DragProgressController<InteractionTarget : Any, State>(
         _gestureFactory = null
     }
 
-    override fun isDragging(): Boolean = _gestureFactory != null
+    fun isDragging(): Boolean = _gestureFactory != null
 
     private fun consumeDrag(dragAmount: Offset) {
         val currentState = model.output.value

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 import com.bumble.appyx.interactions.AppyxLogger
-import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 import com.bumble.appyx.interactions.core.model.transition.Keyframes
 import com.bumble.appyx.interactions.core.model.transition.Operation.Mode.KEYFRAME
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel
@@ -12,6 +11,7 @@ import com.bumble.appyx.interactions.core.model.transition.TransitionModel.Settl
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel.SettleDirection.REVERT
 import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
+import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 
 class DragProgressController<InteractionTarget : Any, State>(
     private val model: TransitionModel<InteractionTarget, State>,
@@ -51,6 +51,8 @@ class DragProgressController<InteractionTarget : Any, State>(
     override fun onDragEnd() {
         _gestureFactory = null
     }
+
+    override fun isDragging(): Boolean = _gestureFactory != null
 
     private fun consumeDrag(dragAmount: Offset) {
         val currentState = model.output.value

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
@@ -13,4 +13,6 @@ interface Draggable : HasDefaultAnimationSpec<Float> {
     fun onDrag(dragAmount: Offset, density: Density)
 
     fun onDragEnd()
+
+    fun isDragging(): Boolean
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
@@ -13,6 +13,4 @@ interface Draggable : HasDefaultAnimationSpec<Float> {
     fun onDrag(dragAmount: Offset, density: Density)
 
     fun onDragEnd()
-
-    fun isDragging(): Boolean
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/modifiers/OnPointerEventNode.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/modifiers/OnPointerEventNode.kt
@@ -1,0 +1,49 @@
+package com.bumble.appyx.interactions.core.modifiers
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.IntSize
+
+@OptIn(ExperimentalComposeUiApi::class)
+class OnPointerEventNode(var callback: (PointerEvent) -> Unit) :
+    PointerInputModifierNode, Modifier.Node() {
+    override fun onPointerEvent(
+        pointerEvent: PointerEvent,
+        pass: PointerEventPass,
+        bounds: IntSize
+    ) {
+        if (pass == PointerEventPass.Initial) {
+            callback(pointerEvent)
+        }
+    }
+
+    override fun sharePointerInputWithSiblings(): Boolean = false
+
+    override fun onCancelPointerInput() {
+        // Do nothing
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+data class PointerInputElement(
+    val callback: (PointerEvent) -> Unit
+) : ModifierNodeElement<OnPointerEventNode>() {
+    override fun create() = OnPointerEventNode(callback)
+    override fun update(node: OnPointerEventNode): OnPointerEventNode {
+        node.callback = callback
+        return node
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "onPointerEvent"
+        properties["callback"] = callback
+    }
+}
+
+fun Modifier.onPointerEvent(callback: (PointerEvent) -> Unit) =
+    this then PointerInputElement(callback)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
@@ -27,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
+import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
@@ -40,7 +42,7 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
     modifier: Modifier = Modifier,
     clipToBounds: Boolean = false,
     childContent: @Composable (ElementUiModel<InteractionTarget>) -> Unit = {},
-    childWrapper: @Composable (ElementUiModel<InteractionTarget>) -> Unit = { frameModel->
+    childWrapper: @Composable (ElementUiModel<InteractionTarget>) -> Unit = { frameModel ->
         ChildWrapper(frameModel) {
             childContent(frameModel)
         }
@@ -70,6 +72,11 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                     ),
                     clipToBounds = clipToBounds
                 )
+            }
+            .onPointerEvent {
+                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
+                    appyxComponent.onDragEnd()
+                }
             }
     ) {
         elementUiModels

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -74,8 +74,8 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                 )
             }
             .onPointerEvent {
-                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
-                    appyxComponent.onDragEnd()
+                if (it.type == PointerEventType.Release) {
+                    appyxComponent.onRelease()
                 }
             }
     ) {

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -15,13 +15,11 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
 import com.bumble.appyx.interactions.core.model.removedElements
-import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
@@ -70,11 +68,6 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
                     ),
                     clipToBounds = clipToBounds
                 )
-            }
-            .onPointerEvent {
-                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
-                    appyxComponent.onDragEnd()
-                }
             }
     ) {
         block(

--- a/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/src/main/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -15,11 +15,13 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
 import com.bumble.appyx.interactions.core.model.removedElements
+import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
@@ -43,7 +45,6 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
         }
     }
 ) {
-
     val density = LocalDensity.current
     val coroutineScope = rememberCoroutineScope()
     val screenWidthPx = (LocalConfiguration.current.screenWidthDp * density.density).roundToInt()
@@ -69,6 +70,11 @@ inline fun <reified InteractionTarget : Any, ModelState : Any> ParentNode<Intera
                     ),
                     clipToBounds = clipToBounds
                 )
+            }
+            .onPointerEvent {
+                if (it.type == PointerEventType.Release && appyxComponent.isDragging()) {
+                    appyxComponent.onDragEnd()
+                }
             }
     ) {
         block(


### PR DESCRIPTION
## Description

Jetpack Compose does not send the `Release` motion event type to the `Element` that is being dragged, which is why the `onDragEnd` event does not get triggered, and no settling occurs. As a workaround, the parent element needs to be made aware of when the `Release` event is triggered and allow the underlying motion controller to properly end the current drag and settle gesture.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
