### PR TITLE
Spotlight stack3d center

### DIFF
--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
@@ -11,7 +11,6 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.GenericFloatProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
-import com.bumble.appyx.interactions.core.ui.property.impl.RotationX
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.interactions.core.ui.property.impl.ZIndex
 import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
@@ -23,7 +22,6 @@ class SpotlightStack3D<InteractionTarget : Any>(
 ) : BaseMotionController<InteractionTarget, State<InteractionTarget>, MutableUiState, TargetUiState>(
     uiContext = uiContext,
 ) {
-    private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
 
     private val scrollY = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f))
@@ -33,7 +31,6 @@ class SpotlightStack3D<InteractionTarget : Any>(
         )
 
     private val created: TargetUiState = TargetUiState(
-        rotationX = RotationX.Target(0f),
         position = Position.Target(DpOffset(0.dp, height)),
         scale = Scale.Target(2.5f),
         alpha = Alpha.Target(0f),
@@ -41,7 +38,6 @@ class SpotlightStack3D<InteractionTarget : Any>(
     )
 
     private val standard: TargetUiState = TargetUiState(
-        rotationX = RotationX.Target(0f),
         position = Position.Target(DpOffset.Zero),
         scale = Scale.Target(1f),
         alpha = Alpha.Target(1f),
@@ -49,7 +45,6 @@ class SpotlightStack3D<InteractionTarget : Any>(
     )
 
     private val destroyed: TargetUiState = TargetUiState(
-        rotationX = RotationX.Target(0f),
         position = Position.Target(DpOffset(0.dp, -height)),
         scale = Scale.Target(0.25f),
         alpha = Alpha.Target(0f),
@@ -81,7 +76,6 @@ class SpotlightStack3D<InteractionTarget : Any>(
         targetUiState.toMutableState(
             uiContext = uiContext,
             scrollX = scrollY.renderValueFlow.mapState(uiContext.coroutineScope) { it - targetUiState.positionInList },
-            itemWidth = width,
             itemHeight = height,
         )
 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/TargetUiState.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.StateFlow
 @MutableUiStateSpecs
 class TargetUiState(
     val positionInList: Int = 0,
-    val rotationX: RotationX.Target,
     val position: Position.Target,
     val scale: Scale.Target,
     val alpha: Alpha.Target,
@@ -30,7 +29,6 @@ class TargetUiState(
         positionInList: Int,
     ) : this(
         positionInList = positionInList,
-        rotationX = base.rotationX,
         position = base.position,
         scale = base.scale,
         alpha = base.alpha,
@@ -40,27 +38,18 @@ class TargetUiState(
     fun toMutableState(
         uiContext: UiContext,
         scrollX: StateFlow<Float>,
-        itemWidth: Dp,
         itemHeight: Dp,
         itemsInStack: Int = 3,
     ): MutableUiState {
         return MutableUiState(
             uiContext = uiContext,
-            rotationX = RotationX(
-                uiContext = uiContext,
-                target = rotationX,
-                displacement = scrollX.mapState(uiContext.coroutineScope) {
-                    2.5f * clamp(-it, 0f, 1f)
-                },
-                origin = TransformOrigin(0.075f, 0f),
-            ),
             position = Position(
                 uiContext = uiContext,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     val factor = 0.075f + smoothstep(0f, 1f, it)
                     DpOffset(
-                        x = (-0.125f * it * itemWidth.value).dp,
+                        x = 0.dp,
                         y = (-factor * it * itemHeight.value / (1f - 0.1f * it)).dp,
                     )
                 }


### PR DESCRIPTION
## Description

Instead of having spotlight elements appear from the left, let's make them appear in the center of the container.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
