### PR TITLE
Remove gesture settle config from draggable

### DIFF
--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
@@ -49,7 +49,7 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
     private val motionController: (UiContext) -> MotionController<InteractionTarget, ModelState>,
     private val gestureFactory: (TransitionBounds) -> GestureFactory<InteractionTarget, ModelState> = { GestureFactory.Noop() },
     final override val defaultAnimationSpec: AnimationSpec<Float> = DefaultAnimationSpec,
-    final override val gestureSettleConfig: GestureSettleConfig = GestureSettleConfig(
+    protected val gestureSettleConfig: GestureSettleConfig = GestureSettleConfig(
         completeGestureSpec = defaultAnimationSpec,
         revertGestureSpec = defaultAnimationSpec,
     ),
@@ -85,7 +85,6 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
         model = model,
         gestureFactory = { _gestureFactory },
         defaultAnimationSpec = defaultAnimationSpec,
-        gestureSettleConfig = gestureSettleConfig,
     )
 
     private val _uiModels: MutableStateFlow<List<ElementUiModel<InteractionTarget>>> =

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressController.kt
@@ -11,13 +11,11 @@ import com.bumble.appyx.interactions.core.model.transition.TransitionModel.Settl
 import com.bumble.appyx.interactions.core.model.transition.TransitionModel.SettleDirection.REVERT
 import com.bumble.appyx.interactions.core.ui.gesture.Gesture
 import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
-import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 
 internal class DragProgressController<InteractionTarget : Any, State>(
     private val model: TransitionModel<InteractionTarget, State>,
     private val gestureFactory: () -> GestureFactory<InteractionTarget, State>,
     override val defaultAnimationSpec: AnimationSpec<Float>,
-    override val gestureSettleConfig: GestureSettleConfig,
 ) : Draggable {
 
     // TODO get rid of this

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/progress/Draggable.kt
@@ -2,11 +2,8 @@ package com.bumble.appyx.interactions.core.model.progress
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
-import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 
 interface Draggable : HasDefaultAnimationSpec<Float> {
-
-    val gestureSettleConfig: GestureSettleConfig
 
     fun onStartDrag(position: Offset)
 

--- a/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressControllerTest.kt
+++ b/appyx-interactions/common/src/commonTest/kotlin/com/bumble/appyx/interactions/core/model/progress/DragProgressControllerTest.kt
@@ -6,7 +6,6 @@ import com.bumble.appyx.InteractionTarget.Child1
 import com.bumble.appyx.InteractionTarget.Child2
 import com.bumble.appyx.interactions.core.TestGestures
 import com.bumble.appyx.interactions.core.TestTransitionModel
-import com.bumble.appyx.interactions.core.ui.gesture.GestureSettleConfig
 import com.bumble.appyx.interactions.core.ui.helper.DefaultAnimationSpec
 import kotlin.test.Test
 import kotlin.test.asserter
@@ -24,7 +23,6 @@ class DragProgressControllerTest {
             model = TestTransitionModel(items),
             gestureFactory = { gestureFactory },
             defaultAnimationSpec = DefaultAnimationSpec,
-            gestureSettleConfig = GestureSettleConfig(),
         )
         try {
             dragProgressController.onDrag(Offset(-12f, 0f), Density(1f))


### PR DESCRIPTION
## Description

Not all `Draggable` things should have settling in general. The concept of revert/complete doesn't apply to e.g. free dragging, so it should be moved out of this interface.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
