### PR TITLE
Remove zIndex modifier from samples

### DIFF
--- a/compose_mpp_sample.py
+++ b/compose_mpp_sample.py
@@ -19,6 +19,9 @@ def copy_files(source_directory, target_directory):
     shutil.copytree(source_directory, target_directory, copy_function=shutil.copy2)
 
 
+def is_running_on_ci():
+    os.environ.get('GITHUB_ACTIONS') == 'false'
+
 def generate_html(width, height, target_directory, html_file_name, classname):
     """Generate HTML code"""
     return "<div class=\"{classname}\">" \
@@ -56,5 +59,6 @@ def define_env(env):
         site_target_directory = os.path.join(env.variables.config.site_dir, target_directory)
         if not os.path.exists(site_target_directory):
             copy_files(project_output_directory, site_target_directory)
-        html_target_directory = os.path.relpath(site_target_directory, env.variables.config.site_dir)
+        base_url = '/'
+        html_target_directory = urljoin(base_url, os.path.relpath(site_target_directory, env.variables.config.site_dir))
         return generate_html(width, height, html_target_directory, html_file_name, classname)

--- a/compose_mpp_sample.py
+++ b/compose_mpp_sample.py
@@ -19,9 +19,6 @@ def copy_files(source_directory, target_directory):
     shutil.copytree(source_directory, target_directory, copy_function=shutil.copy2)
 
 
-def is_running_on_ci():
-    os.environ.get('GITHUB_ACTIONS') == 'false'
-
 def generate_html(width, height, target_directory, html_file_name, classname):
     """Generate HTML code"""
     return "<div class=\"{classname}\">" \

--- a/demos/mkdocs/appyx-interactions/gestures/dragprediction/web/src/jsMain/kotlin/com/bumble/appyx/demos/dragprediction/DragPrediction.kt
+++ b/demos/mkdocs/appyx-interactions/gestures/dragprediction/web/src/jsMain/kotlin/com/bumble/appyx/demos/dragprediction/DragPrediction.kt
@@ -189,7 +189,6 @@ fun <InteractionTarget : Any> ModelUi(
         appyxComponent = testDrive,
         screenWidthPx = screenWidthPx,
         screenHeightPx = screenHeightPx,
-        modifier = modifier.zIndex(2f)
     ) { elementUiModel ->
         Box(
             modifier = Modifier.size(60.dp)

--- a/demos/mkdocs/appyx-interactions/gestures/incompletedrag/web/src/jsMain/kotlin/com/bumble/appyx/demos/incompletedrag/IncompleteDrag.kt
+++ b/demos/mkdocs/appyx-interactions/gestures/incompletedrag/web/src/jsMain/kotlin/com/bumble/appyx/demos/incompletedrag/IncompleteDrag.kt
@@ -144,7 +144,6 @@ fun <InteractionTarget : Any> ModelUi(
         appyxComponent = testDrive,
         screenWidthPx = screenWidthPx,
         screenHeightPx = screenHeightPx,
-        modifier = modifier.zIndex(2f)
     )
     { elementUiModel ->
         Box(

--- a/demos/mkdocs/appyx-interactions/interactions/sample1/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample1/Sample1.kt
+++ b/demos/mkdocs/appyx-interactions/interactions/sample1/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample1/Sample1.kt
@@ -142,7 +142,6 @@ fun <InteractionTarget : Any> ModelUi(
         appyxComponent = testDrive,
         screenWidthPx = screenWidthPx,
         screenHeightPx = screenHeightPx,
-        modifier = modifier.zIndex(2f)
     ) { elementUiModel ->
         Box(
             modifier = Modifier

--- a/demos/mkdocs/appyx-interactions/interactions/sample2/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample2/Sample2.kt
+++ b/demos/mkdocs/appyx-interactions/interactions/sample2/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample2/Sample2.kt
@@ -142,9 +142,7 @@ fun <InteractionTarget : Any> ModelUi(
         appyxComponent = testDrive,
         screenWidthPx = screenWidthPx,
         screenHeightPx = screenHeightPx,
-        modifier = modifier.zIndex(2f)
-    )
-    { elementUiModel ->
+    ) { elementUiModel ->
         Box(
             modifier = Modifier
                 .size(60.dp)

--- a/demos/mkdocs/appyx-interactions/interactions/sample3/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample3/Sample3.kt
+++ b/demos/mkdocs/appyx-interactions/interactions/sample3/web/src/jsMain/kotlin/com/bumble/appyx/demos/sample3/Sample3.kt
@@ -189,7 +189,6 @@ fun <InteractionTarget : Any> ModelUi(
         appyxComponent = testDrive,
         screenWidthPx = screenWidthPx,
         screenHeightPx = screenHeightPx,
-        modifier = modifier.zIndex(2f)
     ) { elementUiModel ->
         Box(
             modifier = Modifier.size(60.dp)
@@ -228,10 +227,14 @@ private fun Controls(
             Box(
                 modifier = Modifier
                     .background(color_primary, shape = RoundedCornerShape(4.dp))
-                    .clickable { testDrive.next(mode = IMMEDIATE, spring(
-                        stiffness = Spring.StiffnessVeryLow,
-                        dampingRatio = Spring.DampingRatioMediumBouncy
-                    )) }
+                    .clickable {
+                        testDrive.next(
+                            mode = IMMEDIATE, spring(
+                                stiffness = Spring.StiffnessVeryLow,
+                                dampingRatio = Spring.DampingRatioMediumBouncy
+                            )
+                        )
+                    }
                     .padding(horizontal = 18.dp, vertical = 9.dp)
             ) {
                 Text("Immediate")


### PR DESCRIPTION
## Description

Some samples had zIndex modifier blocking access to buttons and action them.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
