### PR TITLE
Fix mkdocs site url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: >
-          ./gradlew 
-          -Dorg.gradle.jvmargs=-Xmx8g 
-          $(grep -r "compile_task=" --include "*.md" . | awk -F'"' '{print $2}' | sort -u | tr '\n' ' ')
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
       - run: pip install mkdocs-macros-plugin
       - run: mkdocs build --strict

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - run: >
+          ./gradlew 
+          -Dorg.gradle.jvmargs=-Xmx8g 
+          $(grep -r "compile_task=" --include "*.md" . | awk -F'"' '{print $2}' | sort -u | tr '\n' ' ')
       - run: pip install mkdocs-material 
       - run: pip install mkdocs-macros-plugin
       - run: mkdocs build --strict

--- a/compose_mpp_sample.py
+++ b/compose_mpp_sample.py
@@ -56,5 +56,6 @@ def define_env(env):
         site_target_directory = os.path.join(env.variables.config.site_dir, target_directory)
         if not os.path.exists(site_target_directory):
             copy_files(project_output_directory, site_target_directory)
-        html_target_directory = os.path.join("/appyx", os.path.relpath(site_target_directory, env.variables.config.site_dir))
+        base_url = urlparse(env.variables.config.site_url).path
+        html_target_directory = urljoin(base_url, os.path.relpath(site_target_directory, env.variables.config.site_dir))
         return generate_html(width, height, html_target_directory, html_file_name, classname)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # General setup
 site_name: Appyx
-site_url: https://github.com/bumble-tech/appyx
+site_url: https://bumble-tech.github.io/appyx/
 site_author: Bumble
 site_description: Model-driven navigation for Jetpack Compose
 


### PR DESCRIPTION
## Description

The `site-url` in the `mkdocs.yml` file refers to the repository URL, rather than the GitHub Pages URL.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
