### PR TITLE
Set explicit TopCenter alignment for BackStack3D

### DIFF
--- a/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/stack3d/BackStack3D.kt
+++ b/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/stack3d/BackStack3D.kt
@@ -16,6 +16,7 @@ import com.bumble.appyx.interactions.core.ui.gesture.GestureFactory
 import com.bumble.appyx.interactions.core.ui.gesture.dragVerticalDirection
 import com.bumble.appyx.interactions.core.ui.property.impl.Alpha
 import com.bumble.appyx.interactions.core.ui.property.impl.Position
+import com.bumble.appyx.interactions.core.ui.property.impl.Position.Alignment.TopCenter
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale
 import com.bumble.appyx.interactions.core.ui.property.impl.ZIndex
 import com.bumble.appyx.interactions.core.ui.state.MatchedTargetUiState
@@ -31,7 +32,7 @@ class BackStack3D<InteractionTarget : Any>(
 
     private val topMost: TargetUiState =
         TargetUiState(
-            position = Position.Target(DpOffset(0f.dp, (itemsInStack * 16).dp)),
+            position = Position.Target(TopCenter, DpOffset(0f.dp, (itemsInStack * 16).dp)),
             scale = Scale.Target(1f, origin = TransformOrigin(0.5f, 0.0f)),
             alpha = Alpha.Target(1f),
             zIndex = ZIndex.Target(itemsInStack.toFloat()),
@@ -39,7 +40,7 @@ class BackStack3D<InteractionTarget : Any>(
 
     private val incoming: TargetUiState =
         TargetUiState(
-            position = Position.Target(DpOffset(0f.dp, height)),
+            position = Position.Target(TopCenter, DpOffset(0f.dp, height)),
             scale = Scale.Target(1f, origin = TransformOrigin(0.5f, 0.0f)),
             alpha = Alpha.Target(0f),
             zIndex = ZIndex.Target(itemsInStack + 1f),
@@ -47,7 +48,7 @@ class BackStack3D<InteractionTarget : Any>(
 
     private fun stacked(stackIndex: Int): TargetUiState =
         TargetUiState(
-            position = Position.Target(DpOffset(0f.dp, (itemsInStack - stackIndex) * 16.dp)),
+            position = Position.Target(TopCenter, DpOffset(0f.dp, (itemsInStack - stackIndex) * 16.dp)),
             scale = Scale.Target(1f - stackIndex * 0.05f, origin = TransformOrigin(0.5f, 0.0f)),
             alpha = Alpha.Target(if (stackIndex < itemsInStack) 1f else 0f),
             zIndex = ZIndex.Target(-stackIndex.toFloat()),


### PR DESCRIPTION
## Description

`BackStack3D` was implicitly relying on a `Column` composable setting a `CenterHorizontally` alignment further up the composition, which made it look as intended only accidentally.

Since the merge of #539 , `Alignment` is either explicit, or `TopStart` as a default, which results in the sample not showing correct centering inside its own (internal) container and being slightly off to the left side:

<img width="195" alt="Screenshot 2023-07-27 at 22 26 47" src="https://github.com/bumble-tech/appyx/assets/238198/f685cbce-1c4c-4552-9ca4-44c3b52ce18d">

The fix is simply adding an explicit `TopCenter` alignment.

Changelog and documentation are unaffected since this is just a sample, not library code.
...

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
