### PR TITLE
2.x remove UI context from Motion Property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - [#562](https://github.com/bumble-tech/appyx/issues/562) – Implement custom alignment to remove screen size knowledge when offsetting element in MotionController
+- [#562](https://github.com/bumble-tech/appyx/pull/565) – Remove UiContext parameter from MotionProperty and provide BoxScope via composition local
 
 ---
 

--- a/appyx-components/experimental/modal/common/src/commonMain/kotlin/com/bumble/appyx/components/modal/ui/TargetUiState.kt
+++ b/appyx-components/experimental/modal/common/src/commonMain/kotlin/com/bumble/appyx/components/modal/ui/TargetUiState.kt
@@ -18,8 +18,8 @@ class TargetUiState(
     ): MutableUiState =
         MutableUiState(
             uiContext = uiContext,
-            height = Height(uiContext, height),
-            position = PositionOutside(uiContext, position),
-            corner = RoundedCorners(uiContext, corner),
+            height = Height(uiContext.coroutineScope, height),
+            position = PositionOutside(uiContext.coroutineScope, position),
+            corner = RoundedCorners(uiContext.coroutineScope, corner),
         )
 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/fader/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/fader/TargetUiState.kt
@@ -17,6 +17,6 @@ class TargetUiState(
     ): MutableUiState =
         MutableUiState(
             uiContext = uiContext,
-            alpha = Alpha(uiContext, alpha),
+            alpha = Alpha(uiContext.coroutineScope, alpha),
         )
 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/SpotlightSlider.kt
@@ -31,7 +31,7 @@ class SpotlightSlider<InteractionTarget : Any>(
     uiContext = uiContext
 ) {
     private val scrollX = GenericFloatProperty(
-        uiContext,
+        uiContext.coroutineScope,
         GenericFloatProperty.Target(0f)
     ) // TODO sync this with the model's initial value rather than assuming 0
     override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/slider/TargetUiState.kt
@@ -45,7 +45,7 @@ class TargetUiState(
         MutableUiState(
             uiContext = uiContext,
             position = PositionOutside(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     PositionOutside.Value(
@@ -53,7 +53,7 @@ class TargetUiState(
                     )
                 },
             ),
-            scale = Scale(uiContext, scale),
-            alpha = Alpha(uiContext, alpha),
+            scale = Scale(uiContext.coroutineScope, scale),
+            alpha = Alpha(uiContext.coroutineScope, alpha),
         )
 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/SpotlightSliderRotation.kt
@@ -23,7 +23,7 @@ class SpotlightSliderRotation<InteractionTarget : Any>(
     uiContext = uiContext
 ) {
     private val scrollX = GenericFloatProperty(
-        uiContext,
+        uiContext.coroutineScope,
         Target(0f)
     ) // TODO sync this with the model's initial value rather than assuming 0
     override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderrotation/TargetUiState.kt
@@ -54,7 +54,7 @@ class TargetUiState(
         return MutableUiState(
             uiContext = uiContext,
             position = PositionOutside(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     PositionOutside.Value(
@@ -65,17 +65,17 @@ class TargetUiState(
                     )
                 },
             ),
-            scale = Scale(uiContext, scale,
+            scale = Scale(uiContext.coroutineScope, scale,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { scroll ->
                     scaleUpTo(cutOffCenter(positionInList.toFloat(), scroll, 0.15f), -0.1f, 1f)
                 }
             ),
-            rotationY = RotationY(uiContext, rotationY,
+            rotationY = RotationY(uiContext.coroutineScope, rotationY,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { scroll ->
                     scaleUpTo(cutOffCenterSigned(positionInList.toFloat(), scroll, 0.15f), 15f, 1f)
                 }
             ),
-            alpha = Alpha(uiContext, alpha),
+            alpha = Alpha(uiContext.coroutineScope, alpha),
         )
     }
 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/SpotlightSliderScale.kt
@@ -21,9 +21,7 @@ class SpotlightSliderScale<InteractionTarget : Any>(
 ) : BaseMotionController<InteractionTarget, State<InteractionTarget>, MutableUiState, TargetUiState>(
     uiContext = uiContext
 ) {
-    private val width: Dp = uiContext.transitionBounds.widthDp
-    private val height: Dp = uiContext.transitionBounds.heightDp
-    private val scrollX = GenericFloatProperty(uiContext, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
+    private val scrollX = GenericFloatProperty(uiContext.coroutineScope, Target(0f)) // TODO sync this with the model's initial value rather than assuming 0
     override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollX

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/sliderscale/TargetUiState.kt
@@ -46,7 +46,7 @@ class TargetUiState(
         return MutableUiState(
             uiContext = uiContext,
             position = PositionOutside(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     PositionOutside.Value(
@@ -57,7 +57,7 @@ class TargetUiState(
                     )
                 },
             ),
-            scale = Scale(uiContext, scale,
+            scale = Scale(uiContext.coroutineScope, scale,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     (abs(positionInList - it) - 0.15f).coerceIn(0f, 0.25f)
                 }

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/SpotlightStack3D.kt
@@ -23,7 +23,7 @@ class SpotlightStack3D<InteractionTarget : Any>(
 ) {
     private val height: Dp = uiContext.transitionBounds.heightDp
 
-    private val scrollY = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f))
+    private val scrollY = GenericFloatProperty(uiContext.coroutineScope, GenericFloatProperty.Target(0f))
     override val viewpointDimensions: List<Pair<(State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: State<InteractionTarget> -> state.activeIndex } to scrollY

--- a/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/TargetUiState.kt
+++ b/appyx-components/stable/spotlight/common/src/commonMain/kotlin/com/bumble/appyx/components/spotlight/ui/stack3d/TargetUiState.kt
@@ -42,7 +42,7 @@ class TargetUiState(
         return MutableUiState(
             uiContext = uiContext,
             position = PositionOutside(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     val factor = 0.075f + smoothstep(0f, 1f, it)
@@ -55,19 +55,19 @@ class TargetUiState(
                 }
             ),
             scale = Scale(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = scale,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { -0.1f * it },
             ),
             alpha = Alpha(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = alpha,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     clamp(it, 0f, 1f) + clamp(-it - itemsInStack, 0f, 1f)
                 },
             ),
             zIndex = ZIndex(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = zIndex,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { -it }
             ),

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/CompositionLocals.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/CompositionLocals.kt
@@ -1,6 +1,10 @@
 package com.bumble.appyx.interactions.core.ui
 
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.compositionLocalOf
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 
 val LocalMotionProperties = compositionLocalOf<List<MotionProperty<*, *>>?> { null }
+
+val LocalBoxScope = compositionLocalOf<BoxScope?> { null }
+

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/context/UiContext.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/context/UiContext.kt
@@ -1,6 +1,5 @@
 package com.bumble.appyx.interactions.core.ui.context
 
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Immutable
 import kotlinx.coroutines.CoroutineScope
 
@@ -8,6 +7,5 @@ import kotlinx.coroutines.CoroutineScope
 data class UiContext(
     val coroutineScope: CoroutineScope,
     val transitionBounds: TransitionBounds,
-    val boxScope: BoxScope,
     val clipToBounds: Boolean
 )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/MotionProperty.kt
@@ -13,8 +13,8 @@ import androidx.compose.animation.core.SpringSpec
 import androidx.compose.animation.core.spring
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.interactions.SystemClock
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.utils.multiplatform.AppyxLogger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.update
  * even when snapping. This is used to seamlessly switch to animation with a natural initial velocity
  * rather than zero.
  *
- * @param uiContext
+ * @param coroutineScope
  * @param animatable The backing [Animatable] to animate internal values with.
  * @param easing The [Easing] function to apply when setting interpolated values.
  * See [easingTransform].
@@ -37,7 +37,7 @@ import kotlinx.coroutines.flow.update
  * that are backed by the internal [Animatable].
  */
 abstract class MotionProperty<T, V : AnimationVector>(
-    protected val uiContext: UiContext,
+    protected val coroutineScope: CoroutineScope,
     private val animatable: Animatable<T, V>,
     val easing: Easing? = null,
     private val visibilityThreshold: T? = null,
@@ -81,7 +81,7 @@ abstract class MotionProperty<T, V : AnimationVector>(
         ) { displacement, value ->
             calculateRenderValue(value, displacement)
         }.stateIn(
-            scope = uiContext.coroutineScope,
+            scope = coroutineScope,
             started = SharingStarted.Eagerly,
             initialValue = internalValueFlow.value
         )

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Alpha.kt
@@ -7,21 +7,21 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.mapState
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class Alpha(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 0.01f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,
@@ -34,7 +34,7 @@ class Alpha(
     ) : MotionProperty.Target
 
     override val isVisibleFlow: StateFlow<Boolean> =
-        renderValueFlow.mapState(uiContext.coroutineScope) {
+        renderValueFlow.mapState(coroutineScope) {
             it > 0f
         }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AngularPosition.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/AngularPosition.kt
@@ -10,11 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.AngularPosition.Value
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.math.PI
@@ -22,12 +22,12 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 class AngularPosition(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     val target: Target,
     displacement: StateFlow<Value> = MutableStateFlow(Value.Zero),
     visibilityThreshold: Value = Value(0.1f, 0.1f)
 ) : MotionProperty<Value, AnimationVector2D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Value.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/BackgroundColor.kt
@@ -9,21 +9,21 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.BackgroundColor.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import androidx.compose.ui.graphics.lerp as lerpColor
 
 class BackgroundColor(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     displacement: StateFlow<Color> = MutableStateFlow(Color.Unspecified),
     visibilityThreshold: Color = Color(1, 1, 1, 1),
 ) : MotionProperty<Color, AnimationVector4D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Color.VectorConverter(target.value.colorSpace)),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ColorOverlay.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ColorOverlay.kt
@@ -8,21 +8,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class ColorOverlay(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     val color: Color = Color.Black,
     visibilityThreshold: Float = 0.01f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/GenericFloatProperty.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/GenericFloatProperty.kt
@@ -7,16 +7,17 @@ import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.jvm.JvmInline
 
 class GenericFloatProperty(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value),
     displacement = displacement
 ), Interpolatable<GenericFloatProperty> {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Height.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Height.kt
@@ -8,20 +8,20 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class Height(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     visibilityThreshold: Float = 0.01f,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
@@ -10,22 +10,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.RotationX.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class RotationX(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
@@ -10,22 +10,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.RotationY.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class RotationY(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -10,22 +10,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.RotationZ.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class RotationZ(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RoundedCorners.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RoundedCorners.kt
@@ -10,23 +10,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.context.UiContext
-import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.math.lerpInt
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.RoundedCorners.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class RoundedCorners(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Int = 1,
     displacement: StateFlow<Int> = MutableStateFlow(0),
 ) : MotionProperty<Int, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Int.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Scale.kt
@@ -9,22 +9,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.Scale.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class Scale(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     visibilityThreshold: Float = 0.01f,
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Shadow.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Shadow.kt
@@ -8,20 +8,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class Shadow(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 0.01f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Width.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/Width.kt
@@ -8,20 +8,20 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class Width(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     visibilityThreshold: Float = 0.01f,
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/ZIndex.kt
@@ -8,21 +8,21 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.zIndex
-import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.ZIndex.Target
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class ZIndex(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     target: Target,
     visibilityThreshold: Float = 0.01f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
 ) : MotionProperty<Float, AnimationVector1D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Float.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionInside.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionInside.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector4D
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.TwoWayConverter
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -12,7 +11,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.LocalBoxScope
 import com.bumble.appyx.interactions.core.ui.math.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
@@ -20,17 +19,18 @@ import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.position.BiasAlignment.InsideAlignment
 import com.bumble.appyx.interactions.core.ui.property.impl.position.BiasAlignment.InsideAlignment.Companion.TopStart
 import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside.Value
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.math.roundToInt
 
 class PositionInside(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     val target: Target,
     displacement: StateFlow<Value> = MutableStateFlow(Value.Zero),
     visibilityThreshold: Value = Value(InsideAlignment(0.01f, 0.01f), DpOffset(1.dp, 1.dp)),
 ) : MotionProperty<Value, AnimationVector4D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Value.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,
@@ -113,8 +113,7 @@ class PositionInside(
     override val modifier: Modifier
         get() = Modifier.composed {
             val value = renderValueFlow.collectAsState()
-            val boxScope: BoxScope = uiContext.boxScope
-
+            val boxScope = requireNotNull(LocalBoxScope.current)
             with(boxScope) {
                 this@composed
                     .offset {

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionOutside.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionOutside.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector4D
 import androidx.compose.animation.core.Easing
 import androidx.compose.animation.core.TwoWayConverter
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
@@ -12,24 +11,25 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.LocalBoxScope
 import com.bumble.appyx.interactions.core.ui.math.lerpDpOffset
 import com.bumble.appyx.interactions.core.ui.math.lerpFloat
 import com.bumble.appyx.interactions.core.ui.property.Interpolatable
 import com.bumble.appyx.interactions.core.ui.property.MotionProperty
 import com.bumble.appyx.interactions.core.ui.property.impl.position.BiasAlignment.OutsideAlignment
 import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionOutside.Value
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.math.roundToInt
 
 class PositionOutside(
-    uiContext: UiContext,
+    coroutineScope: CoroutineScope,
     val target: Target,
     displacement: StateFlow<Value> = MutableStateFlow(Value.Zero),
     visibilityThreshold: Value = Value(OutsideAlignment(0.01f, 0.01f), DpOffset(1.dp, 1.dp)),
 ) : MotionProperty<Value, AnimationVector4D>(
-    uiContext = uiContext,
+    coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Value.VectorConverter),
     easing = target.easing,
     visibilityThreshold = visibilityThreshold,
@@ -112,7 +112,7 @@ class PositionOutside(
     override val modifier: Modifier
         get() = Modifier.composed {
             val value = renderValueFlow.collectAsState()
-            val boxScope: BoxScope = uiContext.boxScope
+            val boxScope = requireNotNull(LocalBoxScope.current)
 
             with(boxScope) {
                 this@composed

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/sample/Children.kt
@@ -2,7 +2,6 @@ package com.bumble.appyx.interactions.sample
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -31,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
 import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
+import com.bumble.appyx.interactions.core.ui.LocalBoxScope
 import com.bumble.appyx.interactions.core.ui.LocalMotionProperties
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
@@ -55,7 +55,6 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
     val elementUiModels by appyxComponent.uiModels.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     var uiContext by remember { mutableStateOf<UiContext?>(null) }
-    var boxScope: BoxScope? = null
 
     LaunchedEffect(uiContext) {
         uiContext?.let { appyxComponent.updateContext(it) }
@@ -74,7 +73,6 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                         screenWidthPx = screenWidthPx,
                         screenHeightPx = screenHeightPx
                     ),
-                    boxScope = boxScope!!,
                     clipToBounds = clipToBounds
                 )
             }
@@ -84,21 +82,22 @@ fun <InteractionTarget : Any, ModelState : Any> Children(
                 }
             }
     ) {
-        boxScope = this
-        elementUiModels
-            .forEach { elementUiModel ->
-                key(elementUiModel.element.id) {
-                    elementUiModel.persistentContainer()
-                    val isVisible by elementUiModel.visibleState.collectAsState()
-                    if (isVisible) {
-                        CompositionLocalProvider(
-                            LocalMotionProperties provides elementUiModel.motionProperties
-                        ) {
-                            childWrapper.invoke(elementUiModel)
+        CompositionLocalProvider(LocalBoxScope provides this) {
+            elementUiModels
+                .forEach { elementUiModel ->
+                    key(elementUiModel.element.id) {
+                        elementUiModel.persistentContainer()
+                        val isVisible by elementUiModel.visibleState.collectAsState()
+                        if (isVisible) {
+                            CompositionLocalProvider(
+                                LocalMotionProperties provides elementUiModel.motionProperties
+                            ) {
+                                childWrapper.invoke(elementUiModel)
+                            }
                         }
                     }
                 }
-            }
+        }
     }
 }
 

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -1,12 +1,12 @@
 package com.bumble.appyx.navigation.composable
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -34,6 +34,7 @@ import com.bumble.appyx.interactions.core.gesture.detectDragGesturesOrCancellati
 import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
 import com.bumble.appyx.interactions.core.model.removedElements
 import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
+import com.bumble.appyx.interactions.core.ui.LocalBoxScope
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
@@ -58,7 +59,6 @@ fun <InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Ap
     val screenHeightPx = (LocalScreenSize.current.heightDp * density.density).value.roundToInt()
     val coroutineScope = rememberCoroutineScope()
     var uiContext by remember { mutableStateOf<UiContext?>(null) }
-    var boxScope: BoxScope? = null
     val childrenBlock = block ?: {
         children { child, _ ->
             child()
@@ -82,7 +82,6 @@ fun <InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Ap
                         screenWidthPx = screenWidthPx,
                         screenHeightPx = screenHeightPx
                     ),
-                    boxScope = boxScope!!,
                     clipToBounds = clipToBounds
                 )
             }
@@ -93,10 +92,11 @@ fun <InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Ap
             }
             .fillMaxSize()
     ) {
-        boxScope = this
-        childrenBlock(
-            ChildrenTransitionScope(appyxComponent, gestureExtraTouchArea, gestureValidator)
-        )
+        CompositionLocalProvider(LocalBoxScope provides this) {
+            childrenBlock(
+                ChildrenTransitionScope(appyxComponent, gestureExtraTouchArea, gestureValidator)
+            )
+        }
     }
 
 }

--- a/demos/appyx-interactions/desktop/src/desktopMain/kotlin/com/bumble/appyx/interactions/widgets/ui/TargetUiState.kt
+++ b/demos/appyx-interactions/desktop/src/desktopMain/kotlin/com/bumble/appyx/interactions/widgets/ui/TargetUiState.kt
@@ -47,7 +47,7 @@ class TargetUiState(
         return MutableUiState(
             uiContext = uiContext,
             rotationX = RotationX(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = rotationX,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     2.5f * clamp(-it, 0f, 1f)
@@ -55,7 +55,7 @@ class TargetUiState(
                 origin = TransformOrigin(0.075f, 0f),
             ),
             position = PositionOutside(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = position,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     val factor = 0.075f + smoothstep(0f, 1f, it)
@@ -68,19 +68,19 @@ class TargetUiState(
                 }
             ),
             scale = Scale(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = scale,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { -0.1f * it },
             ),
             alpha = Alpha(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = alpha,
                 displacement = scrollX.mapState(uiContext.coroutineScope) {
                     clamp(it, 0f, 1f) + clamp(-it - itemsInStack, 0f, 1f)
                 },
             ),
             zIndex = ZIndex(
-                uiContext = uiContext,
+                coroutineScope = uiContext.coroutineScope,
                 target = zIndex,
                 displacement = scrollX.mapState(uiContext.coroutineScope) { -it }
             ),

--- a/demos/appyx-interactions/desktop/src/desktopMain/kotlin/com/bumble/appyx/interactions/widgets/ui/WidgetsStack3D.kt
+++ b/demos/appyx-interactions/desktop/src/desktopMain/kotlin/com/bumble/appyx/interactions/widgets/ui/WidgetsStack3D.kt
@@ -22,7 +22,7 @@ class WidgetsStack3D<InteractionTarget : Any>(
     private val width: Dp = uiContext.transitionBounds.widthDp
     private val height: Dp = uiContext.transitionBounds.heightDp
 
-    private val scrollY = GenericFloatProperty(uiContext, GenericFloatProperty.Target(0f))
+    private val scrollY = GenericFloatProperty(uiContext.coroutineScope, GenericFloatProperty.Target(0f))
     override val viewpointDimensions: List<Pair<(SpotlightModel.State<InteractionTarget>) -> Float, GenericFloatProperty>> =
         listOf(
             { state: SpotlightModel.State<InteractionTarget> -> state.activeIndex } to scrollY

--- a/ksp/mutable-ui-processor/src/commonMain/kotlin/com/bumble/appyx/interactions/ksp/MutableUiStateProcessor.kt
+++ b/ksp/mutable-ui-processor/src/commonMain/kotlin/com/bumble/appyx/interactions/ksp/MutableUiStateProcessor.kt
@@ -270,7 +270,7 @@ class MutableUiStateProcessor(
             indent()
             addStatement("$PARAM_UI_CONTEXT = $PARAM_UI_CONTEXT,")
             params.forEach {
-                addStatement("${it.name} = ${it.type}($PARAM_UI_CONTEXT, ${it.name}),")
+                addStatement("${it.name} = ${it.type}($PARAM_UI_CONTEXT.$PARAM_COROUTINE_SCOPE, ${it.name}),")
             }
             unindent()
             add(")")
@@ -297,6 +297,7 @@ class MutableUiStateProcessor(
 
         const val PARAM_UI_CONTEXT = "uiContext"
         const val PARAM_MOTION_PROPERTIES = "motionProperties"
+        const val PARAM_COROUTINE_SCOPE = "coroutineScope"
         const val PARAM_SCOPE = "scope"
         const val PARAM_TARGET = "target"
         const val PARAM_SPRING_SPEC = "springSpec"


### PR DESCRIPTION
## Description

Remove UiContext parameter from MotionProperty and provide BoxScope via composition local

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
