### PR TITLE
Align customisation implementation with 1.x implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Pending changes
 
-–
+### Fixed
+
+- [#575](https://github.com/bumble-tech/appyx/pull/575) - Make customisations lazy to improve performance
 
 ## 2.0.0-alpha03
 

--- a/utils/customisations/src/commonMain/kotlin/com/bumble/appyx/utils/customisations/MutableNodeCustomisationDirectory.kt
+++ b/utils/customisations/src/commonMain/kotlin/com/bumble/appyx/utils/customisations/MutableNodeCustomisationDirectory.kt
@@ -3,8 +3,19 @@ package com.bumble.appyx.utils.customisations
 import kotlin.reflect.KClass
 
 interface MutableNodeCustomisationDirectory : NodeCustomisationDirectory {
+    fun <T : Any> putSubDirectory(key: KClass<T>, valueProvider: () -> NodeCustomisationDirectory)
 
-    fun <T : Any> putSubDirectory(key: KClass<T>, value: NodeCustomisationDirectory)
+    fun <T : NodeCustomisation> put(key: KClass<T>, valueProvider: () -> T)
+}
 
-    fun <T : NodeCustomisation> put(key: KClass<T>, value: T)
+inline fun <reified T : Any> MutableNodeCustomisationDirectory.putSubDirectory(
+    noinline valueProvider: () -> NodeCustomisationDirectory
+) {
+    putSubDirectory(T::class, valueProvider)
+}
+
+inline fun <reified T : NodeCustomisation> MutableNodeCustomisationDirectory.put(
+    noinline valueProvider: () -> T
+) {
+    put(T::class, valueProvider)
 }

--- a/utils/customisations/src/jsMain/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImpl.kt
+++ b/utils/customisations/src/jsMain/kotlin/com/bumble/appyx/utils/customisations/NodeCustomisationDirectoryImpl.kt
@@ -6,7 +6,7 @@ actual open class NodeCustomisationDirectoryImpl actual constructor(
     override val parent: NodeCustomisationDirectory?
 ) : MutableNodeCustomisationDirectory {
 
-    override fun <T : NodeCustomisation> put(key: KClass<T>, value: T) {
+    override fun <T : NodeCustomisation> put(key: KClass<T>, valueProvider: () -> T) {
         // NO-OP
     }
 
@@ -16,7 +16,7 @@ actual open class NodeCustomisationDirectoryImpl actual constructor(
     override fun <T : NodeCustomisation> getRecursively(key: KClass<T>): T? =
         null
 
-    override fun <T : Any> putSubDirectory(key: KClass<T>, value: NodeCustomisationDirectory) {
+    override fun <T : Any> putSubDirectory(key: KClass<T>, valueProvider: () -> NodeCustomisationDirectory) {
         // NO-OP
     }
 


### PR DESCRIPTION
## Description

- Make customisations lazy, just like in 1.x to improve performance and possible help with ANRs
- Add utility functions

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
