### PR TITLE
Fix snapshot and mkdocs deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,6 +15,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - run: pip install mkdocs-material
       - run: pip install mkdocs-macros-plugin
       - run: pip install mkdocs-redirects

--- a/plugins/publish-plugin/src/main/kotlin/MultiplatformAppyxPublishPlugin.kt
+++ b/plugins/publish-plugin/src/main/kotlin/MultiplatformAppyxPublishPlugin.kt
@@ -1,23 +1,27 @@
 
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.kotlin.dsl.registering
 
 internal class MultiplatformAppyxPublishPlugin : ProjectPlugin() {
 
     override fun PublicationContainer.createPublications(project: Project) = Unit
 
     override fun PublishingExtension.configurePublications(project: Project) {
-        val javadocJar by project.tasks.registering(Jar::class) {
-            archiveClassifier.set("javadoc")
-        }
         publications.withType(MavenPublication::class.java).configureEach {
-            artifact(javadocJar.get())
+            val publication = this
+            val javadocJar = project.tasks.register("${publication.name}JavadocJar", Jar::class.java) {
+                group = JavaBasePlugin.DOCUMENTATION_GROUP
+                description = "Assembles ${publication.name} Kotlin docs into a Javadoc jar"
+                archiveClassifier.set("javadoc")
+
+                // https://github.com/gradle/gradle/issues/26091
+                archiveBaseName.set("${archiveBaseName.get()}-${publication.name}")
+            }
+            artifact(javadocJar)
             configurePublication(project)
         }
     }


### PR DESCRIPTION
## Description
Fixed post AGP 8.1.1 upgrade bugs.

This required:
- Ensure the documentation publishing task uses Java 17
- Fixed multiplatform javadoc publishing using the fix suggested here: https://github.com/gradle/gradle/issues/26091#issuecomment-1681343496

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
