### PR TITLE
Fixed artifact publishing after updating to AGP 8.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,6 @@ jobs:
           mergeDetektSarif
           :plugins:buildPlugins
           --continue
-      - name: Check publication setup
-        run: >
-          ./gradlew
-          publishAllPublicationsToOSSRHRepository
-          publishAllPublicationsToSonatypeSnapshotRepository
-          --dry-run
-          --no-parallel
       - name: Deploy snapshot
         if: env.MAIN_BRANCH == 'true' && github.repository == 'bumble-tech/appyx'
         env:
@@ -71,6 +64,29 @@ jobs:
           path: |
             **/build/reports/
             !**/build/reports/dependency-analysis/
+
+  publication-verification:
+    name: Publication verification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
+      - name: Check publication setup
+        run: >
+          ./gradlew
+          publishAllPublicationsToOSSRHRepository
+          publishAllPublicationsToSonatypeSnapshotRepository
+          --dry-run
+          --no-parallel
+      - name: Publish locally
+        run: ./gradlew publishToMavenLocal -Psigning.required=false --no-parallel --continue
 
   instrumentation-tests:
     name: Instrumentation tests

--- a/plugins/publish-plugin/src/main/kotlin/AndroidAppyxPublishPlugin.kt
+++ b/plugins/publish-plugin/src/main/kotlin/AndroidAppyxPublishPlugin.kt
@@ -12,7 +12,11 @@ internal class AndroidAppyxPublishPlugin : ProjectPlugin() {
             publishing {
                 singleVariant(getComponentName()) {
                     withSourcesJar()
-                    withJavadocJar()
+                    /**
+                     * Currently not working with Multiplatform plugin and AGP 8+
+                     * https://github.com/bumble-tech/appyx/issues/582
+                     */
+                    // withJavadocJar()
                 }
             }
         }

--- a/plugins/publish-plugin/src/main/kotlin/ProjectPlugin.kt
+++ b/plugins/publish-plugin/src/main/kotlin/ProjectPlugin.kt
@@ -75,7 +75,7 @@ internal abstract class ProjectPlugin : Plugin<Project> {
     }
 
     private fun SigningExtension.configureSigning() {
-        isRequired = true
+        isRequired = project.findProperty("signing.required")?.toString()?.toBooleanStrict() ?: true
 
         sign(project.extensions.getByType(PublishingExtension::class.java).publications)
 


### PR DESCRIPTION
## Description
Fixed artifact publishing after updating to AGP 8.x.

This was fixed by disabling android-library (non-multiplatform) javadoc publishing. See #582 for details.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
