### PR TITLE
Fix drag vs align

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#579](https://github.com/bumble-tech/appyx/pull/579) – Expose `AndroidLifecycle` in `PlatformLifecycleRegistry` for Android
 - [#584](https://github.com/bumble-tech/appyx/pull/584) – Fix applying offset twice in `AppyxComponent`
+- [#585](https://github.com/bumble-tech/appyx/pull/585) – Fix drag vs align
 
 ## 2.0.0-alpha04
 

--- a/appyx-components/experimental/cards/android/src/main/kotlin/com/bumble/appyx/components/experimental/cards/android/DatingCards.kt
+++ b/appyx-components/experimental/cards/android/src/main/kotlin/com/bumble/appyx/components/experimental/cards/android/DatingCards.kt
@@ -49,11 +49,10 @@ fun DatingCards(modifier: Modifier = Modifier) {
         appyxComponent = cards,
         gestureValidator = permissiveValidator,
     ) { elementUiModel ->
-        Box(
-            modifier = elementUiModel.modifier
-        ) {
-            ProfileCard(profile = elementUiModel.element.interactionTarget.profile)
-        }
+        ProfileCard(
+            profile = elementUiModel.element.interactionTarget.profile,
+            modifier = Modifier.fillMaxSize().then(elementUiModel.modifier)
+        )
     }
 }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -197,5 +197,5 @@ fun elementOffset(
         it.alignment.align(elementSize, containerSize, layoutDirection)
     } ?: IntOffset.Zero
 
-    return positionInsideOffset - positionOutsideOffset
+    return positionInsideOffset + positionOutsideOffset
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -190,16 +189,13 @@ fun elementOffset(
     val positionOutside = motionPropertyRenderValue<PositionOutside.Value, PositionOutside>()
     val layoutDirection = LocalLayoutDirection.current
 
-    val positionInsideOffset by derivedStateOf {
-        positionInside?.let {
-            it.alignment.align(elementSize, containerSize, layoutDirection)
-        } ?: IntOffset.Zero
-    }
-    val positionOutsideOffset by derivedStateOf {
-        positionOutside?.let {
-            it.alignment.align(elementSize, containerSize, layoutDirection)
-        } ?: IntOffset.Zero
-    }
+    val positionInsideOffset = positionInside?.let {
+        it.alignment.align(elementSize, containerSize, layoutDirection)
+    } ?: IntOffset.Zero
+
+    val positionOutsideOffset = positionOutside?.let {
+        it.alignment.align(elementSize, containerSize, layoutDirection)
+    } ?: IntOffset.Zero
 
     return positionInsideOffset - positionOutsideOffset
 }

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/DraggableChildren.kt
@@ -20,10 +20,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -229,6 +229,6 @@ class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
             } ?: IntOffset.Zero
         }
 
-        return positionInsideOffset - positionOutsideOffset
+        return positionInsideOffset + positionOutsideOffset
     }
 }

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -218,16 +217,13 @@ class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
         val positionOutside = motionPropertyRenderValue<PositionOutside.Value, PositionOutside>()
         val layoutDirection = LocalLayoutDirection.current
 
-        val positionInsideOffset by derivedStateOf {
-            positionInside?.let {
-                it.alignment.align(elementSize, containerSize, layoutDirection)
-            } ?: IntOffset.Zero
-        }
-        val positionOutsideOffset by derivedStateOf {
-            positionOutside?.let {
-                it.alignment.align(elementSize, containerSize, layoutDirection)
-            } ?: IntOffset.Zero
-        }
+        val positionInsideOffset = positionInside?.let {
+            it.alignment.align(elementSize, containerSize, layoutDirection)
+        } ?: IntOffset.Zero
+
+        val positionOutsideOffset = positionOutside?.let {
+            it.alignment.align(elementSize, containerSize, layoutDirection)
+        } ?: IntOffset.Zero
 
         return positionInsideOffset + positionOutsideOffset
     }

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/AppyxComponent.kt
@@ -2,13 +2,12 @@ package com.bumble.appyx.navigation.composable
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -25,7 +24,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
@@ -35,9 +36,14 @@ import com.bumble.appyx.interactions.core.model.BaseAppyxComponent
 import com.bumble.appyx.interactions.core.model.removedElements
 import com.bumble.appyx.interactions.core.modifiers.onPointerEvent
 import com.bumble.appyx.interactions.core.ui.LocalBoxScope
+import com.bumble.appyx.interactions.core.ui.LocalMotionProperties
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.UiContext
 import com.bumble.appyx.interactions.core.ui.output.ElementUiModel
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside.Value
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionOutside
+import com.bumble.appyx.interactions.core.ui.property.motionPropertyRenderValue
 import com.bumble.appyx.navigation.integration.LocalScreenSize
 import com.bumble.appyx.navigation.node.ParentNode
 import kotlin.math.roundToInt
@@ -52,27 +58,29 @@ fun <InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Ap
     clipToBounds: Boolean = false,
     gestureValidator: GestureValidator = GestureValidator.defaultValidator,
     gestureExtraTouchArea: Dp = defaultExtraTouch,
-    block: @Composable (ChildrenTransitionScope<InteractionTarget, ModelState>.() -> Unit)? = null,
+    block: @Composable ChildrenTransitionScope<InteractionTarget, ModelState>.() -> Unit = {
+        children { child, elementUiModel ->
+            child(elementUiModel.modifier)
+        }
+    }
 ) {
     val density = LocalDensity.current
     val screenWidthPx = (LocalScreenSize.current.widthDp * density.density).value.roundToInt()
     val screenHeightPx = (LocalScreenSize.current.heightDp * density.density).value.roundToInt()
     val coroutineScope = rememberCoroutineScope()
+    var containerSize by remember { mutableStateOf(IntSize.Zero) }
     var uiContext by remember { mutableStateOf<UiContext?>(null) }
-    val childrenBlock = block ?: {
-        children { child, _ ->
-            child()
-        }
-    }
 
     LaunchedEffect(uiContext) {
         uiContext?.let { appyxComponent.updateContext(it) }
     }
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .then(if (clipToBounds) Modifier.clipToBounds() else Modifier)
             .onPlaced {
+                containerSize = it.size
                 uiContext = UiContext(
                     coroutineScope = coroutineScope,
                     transitionBounds = TransitionBounds(
@@ -90,18 +98,17 @@ fun <InteractionTarget : Any, ModelState : Any> ParentNode<InteractionTarget>.Ap
                     appyxComponent.onRelease()
                 }
             }
-            .fillMaxSize()
     ) {
         CompositionLocalProvider(LocalBoxScope provides this) {
-            childrenBlock(
-                ChildrenTransitionScope(appyxComponent, gestureExtraTouchArea, gestureValidator)
+            block(
+                ChildrenTransitionScope(containerSize, appyxComponent, gestureExtraTouchArea, gestureValidator)
             )
         }
     }
-
 }
 
 class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
+    private val containerSize: IntSize,
     private val appyxComponent: BaseAppyxComponent<InteractionTarget, NavState>,
     private val gestureExtraTouchArea: Dp,
     private val gestureValidator: GestureValidator
@@ -132,66 +139,95 @@ class ChildrenTransitionScope<InteractionTarget : Any, NavState : Any>(
 
         uiModels
             .forEach { elementUiModel ->
+                val id = elementUiModel.element.id
+
                 key(elementUiModel.element.id) {
-                    var transformedBoundingBox by remember(elementUiModel.element.id) {
-                        mutableStateOf(Rect.Zero)
-                    }
-                    var offsetCenter by remember(elementUiModel.element.id) { mutableStateOf(Offset.Zero) }
-                    var size by remember(elementUiModel.element.id) { mutableStateOf(IntSize.Zero) }
+                    var transformedBoundingBox by remember(id) { mutableStateOf(Rect.Zero) }
+                    var elementSize by remember(id) { mutableStateOf(IntSize.Zero) }
+                    var offsetCenter by remember(id) { mutableStateOf(Offset.Zero) }
                     val isVisible by elementUiModel.visibleState.collectAsState()
+
                     elementUiModel.persistentContainer()
+
                     if (isVisible) {
-                        Box(
-                            modifier = Modifier
-                                .offset { offsetCenter.round() }
-                                .width(with(density) { size.width.toDp() })
-                                .height(with(density) { size.height.toDp() })
-                                .offset { offsetCenter.round() }
-                                .pointerInput(appyxComponent) {
-                                    detectDragGesturesOrCancellation(
-                                        onDragStart = { position ->
-                                            appyxComponent.onStartDrag(position)
-                                        },
-                                        onDrag = { change, dragAmount ->
-                                            if (gestureValidator.isGestureValid(
-                                                    change.position,
-                                                    transformedBoundingBox.translate(-offsetCenter)
-                                                )
-                                            ) {
-                                                change.consume()
-                                                appyxComponent.onDrag(dragAmount, density)
-                                                true
-                                            } else {
-                                                appyxComponent.onDragEnd()
-                                                false
-                                            }
-                                        },
-                                        onDragEnd = {
-                                            appyxComponent.onDragEnd()
-                                        },
-                                    )
-                                }
-                        )
-                        Child(
-                            elementUiModel = elementUiModel.copy(
-                                modifier = Modifier
-                                    .then(elementUiModel.modifier)
-                                    .onPlaced {
-                                        size = it.size
-                                        val localCenter = Offset(
-                                            it.size.width.toFloat(),
-                                            it.size.height.toFloat()
-                                        ) / 2f
-                                        transformedBoundingBox =
-                                            it.boundsInParent().inflate(gestureExtraTouchAreaPx)
-                                        offsetCenter = transformedBoundingBox.center - localCenter
-                                    }
-                            ),
-                            saveableStateHolder = saveableStateHolder,
-                            decorator = block
-                        )
+                        CompositionLocalProvider(
+                            LocalMotionProperties provides elementUiModel.motionProperties
+                        ) {
+                            val elementOffset = offsetCenter.round() - elementOffset(elementSize, containerSize)
+
+                            Child(
+                                elementUiModel = elementUiModel.copy(
+                                    modifier = Modifier
+                                        .offset { elementOffset }
+                                        .pointerInput(appyxComponent) {
+                                            detectDragGesturesOrCancellation(
+                                                onDragStart = { position ->
+                                                    appyxComponent.onStartDrag(position)
+                                                },
+                                                onDrag = { change, dragAmount ->
+                                                    if (gestureValidator.isGestureValid(
+                                                            change.position,
+                                                            transformedBoundingBox.translate(-offsetCenter)
+                                                        )
+                                                    ) {
+                                                        change.consume()
+                                                        appyxComponent.onDrag(dragAmount, density)
+                                                        true
+                                                    } else {
+                                                        appyxComponent.onDragEnd()
+                                                        false
+                                                    }
+                                                },
+                                                onDragEnd = {
+                                                    appyxComponent.onDragEnd()
+                                                },
+                                            )
+                                        }
+                                        .offset { -elementOffset }
+                                        .then(elementUiModel.modifier)
+                                        .onPlaced {
+                                            elementSize = it.size
+                                            val localCenter = Offset(
+                                                it.size.width.toFloat(),
+                                                it.size.height.toFloat()
+                                            ) / 2f
+                                            transformedBoundingBox =
+                                                it
+                                                    .boundsInParent()
+                                                    .inflate(gestureExtraTouchAreaPx)
+                                            offsetCenter = transformedBoundingBox.center - localCenter
+                                        }
+                                ),
+                                saveableStateHolder = saveableStateHolder,
+                                decorator = block
+                            )
+                        }
                     }
                 }
             }
+    }
+
+    @Composable
+    private fun elementOffset(
+        elementSize: IntSize,
+        containerSize: IntSize
+    ): IntOffset {
+
+        val positionInside = motionPropertyRenderValue<Value, PositionInside>()
+        val positionOutside = motionPropertyRenderValue<PositionOutside.Value, PositionOutside>()
+        val layoutDirection = LocalLayoutDirection.current
+
+        val positionInsideOffset by derivedStateOf {
+            positionInside?.let {
+                it.alignment.align(elementSize, containerSize, layoutDirection)
+            } ?: IntOffset.Zero
+        }
+        val positionOutsideOffset by derivedStateOf {
+            positionOutside?.let {
+                it.alignment.align(elementSize, containerSize, layoutDirection)
+            } ?: IntOffset.Zero
+        }
+
+        return positionInsideOffset - positionOutsideOffset
     }
 }

--- a/demos/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/node/spotlight/SpotlightNode.kt
+++ b/demos/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/node/spotlight/SpotlightNode.kt
@@ -3,6 +3,7 @@ package com.bumble.appyx.navigation.node.spotlight
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,7 +15,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -65,16 +69,21 @@ class SpotlightNode(
     override fun resolve(interactionTarget: InteractionTarget, buildContext: BuildContext): Node =
         when (interactionTarget) {
             is InteractionTarget.Child -> node(buildContext) { modifier ->
-                val backgroundColor = remember { colors.shuffled().random() }
+                val backgroundColorIdx = rememberSaveable { colors.shuffled().indices.random() }
+                val backgroundColor = colors[backgroundColorIdx]
+                var clicked by rememberSaveable { mutableStateOf(false) }
+
                 Box(
                     modifier = modifier
                         .fillMaxSize()
                         .clip(RoundedCornerShape(5))
                         .background(backgroundColor)
+                        .clickable { clicked = true }
                         .padding(24.dp)
+
                 ) {
                     Text(
-                        text = interactionTarget.index.toString(),
+                        text = "${interactionTarget.index} – Clicked: $clicked",
                         fontSize = 21.sp,
                         color = Color.Black,
                         fontWeight = FontWeight.Bold


### PR DESCRIPTION
## Description

Related to #539 

**Issue that arose in that PR's context**

- `boundsInParent()` gives an offset relative to 0,0 in parent – this offset is what we use to setup the gesture detection area
- `.align()`, if present in the `elementUiModel` modifiers will also affect the gesture detection area's alignment though, and we can't turn it off, because:
- `.align()` can only be set once in compose (or more precisely, the first one takes priority, any subsequent invocations are ignored), which means we couldn't do the same trick as with offset (+offset, gesture, -offset) to temporarily disable alignment
- but without turning it off temporarily the effect is that `boundsInParent()` offset is always relative to 0,0 whereas it should be relative to the alignment point, resulting in a wrong target area being calculated


**Approach that was implemented instead:**

- A `Box` was extracted from `Child` to apply the gesture detection on – this way it can remain unaffected by alignment change


**The problem with the approach**

- If `Child` has any gesture-related code (e.g. click), pointer input handling can't properly reach the `Box` by bubbling up, since it's not a parent to `Child` but a sibling in the hierarchy
- Dragging the `AppyxComponent` would break in this case and no longer do anything


**New solution**

- Revert back to using a single composable
- Detecting if `PositionInside`/`PositionOutside` `MotionProperty` are present
- Fetch their the alignment-related offset (relative to 0,0) and account for it in the offset calculation for the gesture

**Result**

- Click + Drag works properly
- Drag detection area is calculated properly


...

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
