### PR TITLE
Set bounds on all new motion controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
 
 ### Fixed
 
-- [#586](https://github.com/bumble-tech/appyx/issues/586) – Fix `AppyxComponent` wrongly applying width and height modifier to children composables
 - [#584](https://github.com/bumble-tech/appyx/pull/584) – Fix applying offset twice in `AppyxComponent`
 - [#585](https://github.com/bumble-tech/appyx/pull/585) – Fix drag vs align
 - [#571](https://github.com/bumble-tech/appyx/pull/571) – Avoid `MotionController` recreation
+- [#587](https://github.com/bumble-tech/appyx/pull/587) – Fix `DraggableChildren` and rename it to `AppyxComponent`
+- [#588](https://github.com/bumble-tech/appyx/pull/588) – Set bounds on all new motion controllers
 
 
 ## 2.0.0-alpha04

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
@@ -183,6 +183,7 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
     }
 
     private fun onMotionControllerReady(motionController: MotionController<InteractionTarget, ModelState>) {
+        motionController.updateBounds(transitionBounds)
         observeAnimationChanges(motionController)
         observeMotionController(motionController)
     }


### PR DESCRIPTION
## Description

**Observed bug**

Sample app scenario:

1. Moved `Promoter` to inside `Spotlight`, rather than `BackStack`
3. Embedded component works at first, but when moved off screen then re-added to composition, it looks visually broken

**Why this happens**

1. With `BackStack`, `Promoter` was popped and recreated the next time; however, with `Spotlight` it was kept alive
2. The embedded `AppyxComponent` receives `updateContext` when re-entering the composition
3. This leads to its `MotionController` being recreated (without any knowledge of `TransitionBounds`)
4. Since the component cached the last `TransitionBounds`, and the new one passed to it is exactly the same, the `if` check does not set it on the new `MotionController` instance:

    ```kotlin
    override fun updateBounds(transitionBounds: TransitionBounds) {
        if (transitionBounds != this.transitionBounds) {
            this.transitionBounds = transitionBounds
            _gestureFactory = gestureFactory(transitionBounds)
            _motionController?.updateBounds(transitionBounds)
        }
    }
    ```
    
    Which is fine that it's skipped, but we shouldn't rely on this being called either.

5. If the size of the bounds is used to calculate any `TargetUiState` values (as is the case with `Promoter`), those will be messed up.



**Fix introduced**

Always set bounds on the new `MotionController` instance.


## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
