### PR TITLE
Fix visibility resolution when item is less then a parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 
 ### Fixed
-
+- 
+- [#589](https://github.com/bumble-tech/appyx/pull/589) – Fix visibility resolution for elements that do not match parent's size
 - [#586](https://github.com/bumble-tech/appyx/issues/586) – Fix `AppyxComponent` wrongly applying width and height modifier to children composables
 - [#584](https://github.com/bumble-tech/appyx/pull/584) – Fix applying offset twice in `AppyxComponent`
 - [#585](https://github.com/bumble-tech/appyx/pull/585) – Fix drag vs align

--- a/appyx-components/experimental/promoter/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/promoter/ui/PromoterMotionController.kt
+++ b/appyx-components/experimental/promoter/common/src/commonMain/kotlin/com/bumble/appyx/components/experimental/promoter/ui/PromoterMotionController.kt
@@ -3,7 +3,6 @@
 package com.bumble.appyx.components.experimental.promoter.ui
 
 import androidx.compose.animation.core.SpringSpec
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.components.experimental.promoter.PromoterModel
@@ -71,7 +70,7 @@ class PromoterMotionController<InteractionTarget : Any>(
     private lateinit var destroyed: TargetUiState
 
     @Suppress("LongMethod")
-    fun createTargetUiStates(radius: Float) {
+    private fun createTargetUiStates(radius: Float) {
         created = TargetUiState(
             position = PositionInside.Target(alignment = Center),
             angularPosition = AngularPosition.Target(

--- a/appyx-interactions/android/build.gradle.kts
+++ b/appyx-interactions/android/build.gradle.kts
@@ -13,9 +13,10 @@ dependencies {
     api(project(":appyx-interactions:appyx-interactions"))
     api(libs.compose.ui.test.junit4)
     implementation(libs.androidx.test.core)
-
     implementation(composeBom)
+
     androidTestImplementation(composeBom)
+    androidTestImplementation(libs.compose.ui.test.junit4)
 
     debugRuntimeOnly(libs.compose.ui.test.manifest)
 }

--- a/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/MutableUiStateTest.kt
+++ b/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/MutableUiStateTest.kt
@@ -1,0 +1,195 @@
+package com.bumble.appyx.interactions.ui.state
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.bumble.appyx.interactions.core.ui.LocalBoxScope
+import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.property.impl.position.BiasAlignment
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MutableUiStateTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var testMutableUiState: TestMutableUiState
+    private lateinit var coroutineScope: CoroutineScope
+
+    private fun setupTestMutableUiState(
+        target: PositionInside.Target = PositionInside.Target(
+            alignment = BiasAlignment.InsideAlignment.TopStart
+        ),
+        clipToBounds: Boolean = false,
+        containerModifier: Modifier = Modifier
+            .fillMaxSize(),
+        childModifier: Modifier = Modifier,
+    ) {
+        composeTestRule.setContent {
+            BoxWithConstraints(
+                modifier = containerModifier
+            ) {
+                CompositionLocalProvider(LocalBoxScope provides this@BoxWithConstraints) {
+                    val density = LocalDensity.current
+                    val localConfiguration = LocalConfiguration.current
+                    coroutineScope = rememberCoroutineScope()
+                    val uiContext = remember { UiContext(coroutineScope, clipToBounds) }
+                    testMutableUiState = remember {
+                        TestMutableUiState(
+                            uiContext = uiContext,
+                            position = PositionInside(
+                                coroutineScope = coroutineScope,
+                                target = target,
+                            )
+                        ).apply {
+                            updateBounds(
+                                TransitionBounds(
+                                    density = density,
+                                    widthPx = this@BoxWithConstraints.constraints.maxWidth,
+                                    heightPx = this@BoxWithConstraints.constraints.maxHeight,
+                                    screenWidthPx = (localConfiguration.screenWidthDp * density.density).roundToInt(),
+                                    screenHeightPx = (localConfiguration.screenHeightDp * density.density).roundToInt(),
+                                )
+                            )
+                        }
+                    }
+                    Box(
+                        modifier = childModifier
+                            .then(testMutableUiState.visibilityModifier)
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun GIVEN_visible_state_WHEN_moved_outside_of_screen_THEN_visibility_is_false() = runTest {
+        // child is in the top-left corner with the size of 60dp
+        val childSize = 60.dp
+        setupTestMutableUiState(
+            childModifier = Modifier
+                .requiredSize(childSize)
+                .background(color = Color.Red)
+        )
+
+        // moving the child to the top-right corner + offset its size -> pushes it off screen
+        testMutableUiState.snapTo(
+            target = TestTargetUiState(
+                position = PositionInside.Target(
+                    alignment = BiasAlignment.InsideAlignment.TopEnd,
+                    offset = DpOffset(x = childSize, y = 0.dp)
+                )
+            )
+        )
+
+        // assert it's invisible
+        composeTestRule.waitForIdle()
+        assertFalse(testMutableUiState.isVisible.value)
+    }
+
+    @Test
+    fun GIVEN_visible_state_WHEN_not_moved_outside_of_screen_THEN_visibility_is_true() = runTest {
+        val childSize = 60.dp
+
+        setupTestMutableUiState(
+            childModifier = Modifier
+                .requiredSize(childSize)
+                .background(color = Color.Red)
+        )
+
+        val offset = childSize - 1.dp
+        // moving the child to the top-right corner + offset less than its size -> make it just visible
+        testMutableUiState.snapTo(
+            target = TestTargetUiState(
+                position = PositionInside.Target(
+                    alignment = BiasAlignment.InsideAlignment.TopEnd,
+                    offset = DpOffset(x = offset, y = 0.dp)
+                )
+            )
+        )
+
+        // assert it's visible
+        composeTestRule.waitForIdle()
+        assertTrue(testMutableUiState.isVisible.value)
+    }
+
+    @Test
+    fun GIVEN_visible_state_and_clipToBounds_WHEN_moved_outside_of_parent_THEN_visibility_is_false() = runTest {
+        // child is in the top-left corner with the size of 60dp
+        val childSize = 60.dp
+        val parentSize = 120.dp
+        setupTestMutableUiState(
+            clipToBounds = true,
+            containerModifier = Modifier
+                .requiredSize(parentSize),
+            childModifier = Modifier
+                .requiredSize(childSize)
+                .background(color = Color.Red)
+        )
+
+        // moving the child with offset that equals parent's size -> pushes it off parent's bounds
+        testMutableUiState.snapTo(
+            target = TestTargetUiState(
+                position = PositionInside.Target(
+                    offset = DpOffset(x = parentSize, y = 0.dp)
+                )
+            )
+        )
+
+        // assert it's invisible
+        composeTestRule.waitForIdle()
+        assertFalse(testMutableUiState.isVisible.value)
+    }
+
+    @Test
+    fun GIVEN_visible_state_and_clipToBounds_WHEN_not_moved_outside_of_parent_THEN_visibility_is_true() = runTest {
+        // child is in the top-left corner with the size of 60dp
+        val childSize = 60.dp
+        val parentSize = 120.dp
+        setupTestMutableUiState(
+            clipToBounds = true,
+            containerModifier = Modifier
+                .requiredSize(parentSize),
+            childModifier = Modifier
+                .requiredSize(childSize)
+                .background(color = Color.Red)
+        )
+
+        // moving the child with offset that less parent's size -> just visible is parent's bounds
+        val offset = parentSize - 1.dp
+        testMutableUiState.snapTo(
+            target = TestTargetUiState(
+                position = PositionInside.Target(
+                    offset = DpOffset(x = offset, y = 0.dp)
+                )
+            )
+        )
+
+        // assert it's visible
+        composeTestRule.waitForIdle()
+        assertTrue(testMutableUiState.isVisible.value)
+    }
+
+}

--- a/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/TestMutableUiState.kt
+++ b/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/TestMutableUiState.kt
@@ -1,0 +1,53 @@
+package com.bumble.appyx.interactions.ui.state
+
+import androidx.compose.animation.core.SpringSpec
+import androidx.compose.animation.core.spring
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.interactions.core.ui.context.UiContext
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside
+import com.bumble.appyx.interactions.core.ui.state.BaseMutableUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+
+class TestMutableUiState(
+    uiContext: UiContext,
+    val position: PositionInside,
+) : BaseMutableUiState<TestTargetUiState>(
+    uiContext = uiContext,
+    motionProperties = listOf(position),
+) {
+    override val combinedMotionPropertyModifier: Modifier = Modifier
+        .then(position.modifier)
+
+    override suspend fun animateTo(
+        scope: CoroutineScope,
+        target: TestTargetUiState,
+        springSpec: SpringSpec<Float>,
+    ) {
+        listOf(
+            scope.async {
+                position.animateTo(
+                    target.position.value,
+                    spring(springSpec.dampingRatio, springSpec.stiffness),
+                )
+            },
+        ).awaitAll()
+    }
+
+    override suspend fun snapTo(target: TestTargetUiState) {
+        position.snapTo(target.position.value)
+    }
+
+    override fun lerpTo(
+        scope: CoroutineScope,
+        start: TestTargetUiState,
+        end: TestTargetUiState,
+        fraction: Float,
+    ) {
+        scope.launch {
+            position.lerpTo(start.position, end.position, fraction)
+        }
+    }
+}

--- a/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/TestTargetUiState.kt
+++ b/appyx-interactions/android/src/androidTest/kotlin/com/bumble/appyx/interactions/ui/state/TestTargetUiState.kt
@@ -1,0 +1,5 @@
+package com.bumble.appyx.interactions.ui.state
+
+import com.bumble.appyx.interactions.core.ui.property.impl.position.PositionInside
+
+class TestTargetUiState(val position: PositionInside.Target)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
@@ -45,24 +45,23 @@ abstract class BaseMutableUiState<TargetUiState>(
         )
     )
 
-    private val sizeChangedModifier: Modifier = Modifier
-        .onSizeChanged { size ->
-            _size.update { size }
-        }
-
-    protected abstract val combinedMotionPropertyModifier: Modifier
-
     val modifier
         get() = combinedMotionPropertyModifier
             .then(sizeChangedModifier)
+
+    protected abstract val combinedMotionPropertyModifier: Modifier
+
+    private val sizeChangedModifier: Modifier = Modifier
+        .onSizeChanged { size ->
+            this.size.update { size }
+        }
 
     private val _isBoundsVisible = MutableStateFlow(false)
     private val visibilitySources: Iterable<StateFlow<Boolean>> =
         motionProperties.mapNotNull { it.isVisibleFlow } + _isBoundsVisible
 
-    protected val _size = MutableStateFlow(IntSize.Zero)
+    protected val size = MutableStateFlow(IntSize.Zero)
 
-    @Suppress("unused")
     val isVisible: StateFlow<Boolean> = combineState(
         visibilitySources,
         uiContext.coroutineScope
@@ -76,7 +75,6 @@ abstract class BaseMutableUiState<TargetUiState>(
      * bounds visibility relative to parent's bounds. Because it's responsible only for calculating
      * element's bounds it ensures that it's invisible by setting alpha as 0f.
      */
-    @Suppress("unused")
     val visibilityModifier: Modifier
         get() = Modifier
             .graphicsLayer {
@@ -85,7 +83,7 @@ abstract class BaseMutableUiState<TargetUiState>(
             }
             .then(combinedMotionPropertyModifier)
             .composed {
-                val size by _size.collectAsState()
+                val size by size.collectAsState()
                 if (size != IntSize.Zero) {
                     val localDensity = LocalDensity.current.density
                     requiredSize(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/state/BaseMutableUiState.kt
@@ -2,10 +2,11 @@ package com.bumble.appyx.interactions.core.ui.state
 
 import androidx.compose.animation.core.SpringSpec
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -14,6 +15,11 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.bumble.appyx.combineState
 import com.bumble.appyx.interactions.core.ui.context.TransitionBounds
 import com.bumble.appyx.interactions.core.ui.context.TransitionBoundsAware
@@ -39,11 +45,22 @@ abstract class BaseMutableUiState<TargetUiState>(
         )
     )
 
-    abstract val modifier: Modifier
+    private val sizeChangedModifier: Modifier = Modifier
+        .onSizeChanged { size ->
+            _size.update { size }
+        }
+
+    protected abstract val combinedMotionPropertyModifier: Modifier
+
+    val modifier
+        get() = combinedMotionPropertyModifier
+            .then(sizeChangedModifier)
 
     private val _isBoundsVisible = MutableStateFlow(false)
     private val visibilitySources: Iterable<StateFlow<Boolean>> =
         motionProperties.mapNotNull { it.isVisibleFlow } + _isBoundsVisible
+
+    protected val _size = MutableStateFlow(IntSize.Zero)
 
     @Suppress("unused")
     val isVisible: StateFlow<Boolean> = combineState(
@@ -54,11 +71,10 @@ abstract class BaseMutableUiState<TargetUiState>(
     }
 
     /**
-     * This modifier duplicates original modifier, and will be placed on the dummy compose view
-     * to calculate bounds relative to parent and eventually update bounds visibility relative
-     * to parent's bounds. Because it's responsible only for calculating element's bounds it ensures
-     * that it's invisible by setting alpha as 0f. Additionally, it makes sure that it occupies all
-     * available space by applying fillMaxSize().
+     * This modifier duplicates original modifier, and will be placed on the dummy compose view with
+     * the same size as original composable to calculate bounds relative to parent, and eventually update
+     * bounds visibility relative to parent's bounds. Because it's responsible only for calculating
+     * element's bounds it ensures that it's invisible by setting alpha as 0f.
      */
     @Suppress("unused")
     val visibilityModifier: Modifier
@@ -67,8 +83,21 @@ abstract class BaseMutableUiState<TargetUiState>(
                 // Making sure that this modifier is invisible
                 alpha = 0f
             }
-            .then(modifier)
-            .fillMaxSize()
+            .then(combinedMotionPropertyModifier)
+            .composed {
+                val size by _size.collectAsState()
+                if (size != IntSize.Zero) {
+                    val localDensity = LocalDensity.current.density
+                    requiredSize(
+                        DpSize(
+                            (size.width / localDensity).dp,
+                            (size.height / localDensity).dp
+                        )
+                    )
+                } else {
+                    fillMaxSize()
+                }
+            }
             .onGloballyPositioned { coordinates ->
                 if (uiContext.clipToBounds) {
                     _isBoundsVisible.update {

--- a/ksp/mutable-ui-processor/src/commonMain/kotlin/com/bumble/appyx/interactions/ksp/MutableUiStateProcessor.kt
+++ b/ksp/mutable-ui-processor/src/commonMain/kotlin/com/bumble/appyx/interactions/ksp/MutableUiStateProcessor.kt
@@ -153,7 +153,7 @@ class MutableUiStateProcessor(
         }
 
     private fun generateModifierProperty(params: List<ParameterSpec>) =
-        PropertySpec.builder(PROPERTY_MODIFIER, Modifier::class, KModifier.OVERRIDE)
+        PropertySpec.builder(COMBINED_MOTION_PROPERTY_MODIFIER, Modifier::class, KModifier.OVERRIDE)
             .initializer(
                 with(CodeBlock.builder()) {
                     addStatement("Modifier")
@@ -307,7 +307,7 @@ class MutableUiStateProcessor(
         const val PARAM_END = "end"
         const val PARAM_FRACTION = "fraction"
 
-        const val PROPERTY_MODIFIER = "modifier"
+        const val COMBINED_MOTION_PROPERTY_MODIFIER = "combinedMotionPropertyModifier"
 
         const val FUNCTION_ANIMATE_TO = "animateTo"
         const val FUNCTION_SNAP_TO = "snapTo"


### PR DESCRIPTION
## Description

Previously when resolving an item's visibility the assumption was made that the item always matches the parent's bounds. This leads to incorrectly resolving the visibility of elements that do not match the parent's bounds. 

This bug could be observed in the example of the TestDrive. If we push the element off the screen it will still be visible, and therefore present in the composition.

This PR collects the last known size of the element and applies this size to the invisible dummy composable which resolves visibility for that element.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
