### PR TITLE
Flush output cache when onCreate is called in NodeConnector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#587](https://github.com/bumble-tech/appyx/pull/587) – Fix `DraggableChildren` and rename it to `AppyxComponent`
 - [#588](https://github.com/bumble-tech/appyx/pull/588) – Set bounds on all new motion controllers
 - [#589](https://github.com/bumble-tech/appyx/pull/589) – Fix visibility resolution for elements that do not match parent's size
+- [#591](https://github.com/bumble-tech/appyx/pull/591) – Flush output cache when onCreate is called in NodeConnector
 
 
 ## 2.0.0-alpha04

--- a/utils/interop-rx2/src/main/kotlin/com/bumble/appyx/utils/interop/rx2/connectable/NodeConnector.kt
+++ b/utils/interop-rx2/src/main/kotlin/com/bumble/appyx/utils/interop/rx2/connectable/NodeConnector.kt
@@ -2,7 +2,6 @@ package com.bumble.appyx.utils.interop.rx2.connectable
 
 import android.annotation.SuppressLint
 import com.bumble.appyx.navigation.lifecycle.Lifecycle
-import com.bumble.appyx.navigation.lifecycle.subscribe
 import com.jakewharton.rxrelay2.PublishRelay
 import com.jakewharton.rxrelay2.Relay
 import io.reactivex.Observer
@@ -32,7 +31,7 @@ class NodeConnector<Input: Any, Output: Any>(
     }
 
     override fun onCreate(lifecycle: Lifecycle) {
-        lifecycle.subscribe(onCreate = { flushOutputCache() })
+        flushOutputCache()
     }
 
     private val cacheSubscription = intake.subscribe {

--- a/utils/interop-rx3/src/main/kotlin/com/bumble/appyx/utils/interop/rx3/connectable/NodeConnector.kt
+++ b/utils/interop-rx3/src/main/kotlin/com/bumble/appyx/utils/interop/rx3/connectable/NodeConnector.kt
@@ -2,7 +2,6 @@ package com.bumble.appyx.utils.interop.rx3.connectable
 
 import android.annotation.SuppressLint
 import com.bumble.appyx.navigation.lifecycle.Lifecycle
-import com.bumble.appyx.navigation.lifecycle.subscribe
 import com.jakewharton.rxrelay3.PublishRelay
 import com.jakewharton.rxrelay3.Relay
 import io.reactivex.rxjava3.core.Observer
@@ -31,7 +30,7 @@ class NodeConnector<Input, Output : Any>(
     }
 
     override fun onCreate(lifecycle: Lifecycle) {
-        lifecycle.subscribe(onCreate = { flushOutputCache() })
+        flushOutputCache()
     }
 
     private val cacheSubscription = intake.subscribe {


### PR DESCRIPTION
## Description

The issue is described here https://github.com/bumble-tech/appyx/issues/590

This is a quick fix for NodeConnector to flush output. Since `onCreated` is called when lifecycle is brought to `onCreate` state we can safely do this




## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
