### PR TITLE
Fix Backstack3D Motion Controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [#588](https://github.com/bumble-tech/appyx/pull/588) – Set bounds on all new motion controllers
 - [#589](https://github.com/bumble-tech/appyx/pull/589) – Fix visibility resolution for elements that do not match parent's size
 - [#591](https://github.com/bumble-tech/appyx/pull/591) – Flush output cache when onCreate is called in NodeConnector
-
+- [#592](https://github.com/bumble-tech/appyx/pull/592) – Fix Backstack3D Motion Controller
 
 ## 2.0.0-alpha04
 


### PR DESCRIPTION
## Description

Fix Backstack3D Motion Controller when the incoming card was coming from top instead of the bottom.

It was happening due to not considering updated transition bounds for incoming state 



## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
