### PR TITLE
Fix web samples paddings

### DIFF
--- a/demos/mkdocs/appyx-components/common/src/commonMain/kotlin/com/bumble/appyx/demos/common/AppyxWebSample.kt
+++ b/demos/mkdocs/appyx-components/common/src/commonMain/kotlin/com/bumble/appyx/demos/common/AppyxWebSample.kt
@@ -133,7 +133,8 @@ fun <InteractionTarget : Any> ModalUi(
 ) {
     Box(
         modifier = modifier
-            .fillMaxSize(if (isChildMaxSize) 1f else 0.9f)
+            .fillMaxSize()
+            .padding(if (isChildMaxSize) 0.dp else 8.dp)
             .then(elementUiModel.modifier)
             .background(
                 color = when (val target = elementUiModel.element.interactionTarget) {


### PR DESCRIPTION
## Description

After replacing raw offset values with alignment spotlight web examples are misaligned. The reason is that we're using `fillMaxSize()` modifier which will make composable less than the container and put it to the top left corner. 

To avoid this for web samples we can use `padding`

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
