### PR TITLE
Reuse PermanentNavModel if provided in the list of navModels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
--
+- [#605](https://github.com/bumble-tech/appyx/pull/605) – **Fixed**: Reuse PermanentNavModel if provided in the list of NavModels 
 
 ---
 

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
@@ -13,23 +13,30 @@ import com.bumble.appyx.core.AppyxTestScenario
 import com.bumble.appyx.core.children.nodeOrNull
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.navigation.EmptyNavModel
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
+import com.bumble.appyx.core.node.PermanentChildTest.TestParentNode.NavTarget
 import kotlinx.parcelize.Parcelize
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
 class PermanentChildTest {
 
+    var nodeFactory: (buildContext: BuildContext) -> TestParentNode = {
+        TestParentNode(null, it)
+    }
+
     @get:Rule
     val rule = AppyxTestScenario { buildContext ->
-        TestParentNode(buildContext)
+        nodeFactory(buildContext)
     }
 
     @Test
     fun permanent_child_is_rendered() {
         rule.start()
 
-        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertExists()
+        rule.onNode(hasTestTag(NavTarget::class.java.name)).assertExists()
     }
 
     @Test
@@ -38,38 +45,80 @@ class PermanentChildTest {
         rule.node.renderPermanentChild = false
         val childNodes = rule.node.children.value.values.map { it.nodeOrNull }
 
-        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertDoesNotExist()
+        rule.onNode(hasTestTag(NavTarget::class.java.name)).assertDoesNotExist()
 
         rule.node.renderPermanentChild = true
 
-        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertExists()
+        rule.onNode(hasTestTag(NavTarget::class.java.name)).assertExists()
         assertEquals(childNodes, rule.node.children.value.values.map { it.nodeOrNull })
     }
 
+    @Test
+    fun given_permanent_model_with_key_When_PermanentChild_with_the_same_key_Then_has_one_child() {
+        val permanentNavModel = PermanentNavModel<NavTarget>(NavTarget.Child1, savedStateMap = null)
+        nodeFactory = { buildContext ->
+            TestParentNode(permanentNavModel, buildContext)
+        }
+
+        rule.start()
+
+        val childNodes = rule.node.children.value.values.map { it.nodeOrNull }
+        assertTrue(childNodes.count() == 1)
+    }
+
+    @Test
+    fun given_permanent_model_with_key_When_PermanentChild_add_new_key_Then_has_two_children() {
+        val permanentNavModel = PermanentNavModel<NavTarget>(NavTarget.Child2, savedStateMap = null)
+        nodeFactory = { buildContext ->
+            TestParentNode(permanentNavModel, buildContext)
+        }
+
+        rule.start()
+
+        val childNodes = rule.node.children.value.values.map { it.nodeOrNull }
+        assertTrue(childNodes.count() == 2)
+    }
+
     class TestParentNode(
+        private val permanentNavModel: PermanentNavModel<NavTarget>? = null,
         buildContext: BuildContext,
-    ) : ParentNode<TestParentNode.NavTarget>(
+    ) : ParentNode<NavTarget>(
         buildContext = buildContext,
-        navModel = EmptyNavModel<NavTarget, Any>(),
+        navModel = permanentNavModel ?: EmptyNavModel<NavTarget, Any>(),
     ) {
 
-        @Parcelize
-        object NavTarget : Parcelable
+        sealed class NavTarget : Parcelable {
+            @Parcelize
+            object Child1 : NavTarget()
+
+            @Parcelize
+            object Child2 : NavTarget()
+        }
 
         var renderPermanentChild by mutableStateOf(true)
 
-        override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
-            node(buildContext) { modifier ->
+
+        class ChildNode(
+            private val navTarget: NavTarget,
+            buildContext: BuildContext
+        ) : Node(buildContext) {
+
+            @Composable
+            override fun View(modifier: Modifier) {
                 BasicText(
                     text = navTarget.toString(),
                     modifier = modifier.testTag(NavTarget::class.java.name),
                 )
             }
+        }
+
+        override fun resolve(navTarget: NavTarget, buildContext: BuildContext): Node =
+            ChildNode(navTarget, buildContext)
 
         @Composable
         override fun View(modifier: Modifier) {
             if (renderPermanentChild) {
-                PermanentChild(NavTarget)
+                PermanentChild(NavTarget.Child1)
             }
         }
     }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
@@ -6,6 +6,7 @@ import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.NavModel
 import com.bumble.appyx.core.navigation.NavModelAdapter
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import com.bumble.appyx.core.plugin.Destroyable
 import com.bumble.appyx.core.state.MutableSavedStateMap
 import kotlinx.coroutines.CoroutineScope
@@ -17,6 +18,13 @@ import kotlin.coroutines.EmptyCoroutineContext
 class CombinedNavModel<NavTarget>(
     val navModels: List<NavModel<NavTarget, *>>,
 ) : NavModel<NavTarget, Any?>, Destroyable {
+
+    init {
+        val permanentNavModelCount = navModels.filterIsInstance<PermanentNavModel<*>>().count()
+        check(permanentNavModelCount <= MAX_PERMANENT_NAV_MODEL_COUNT) {
+            "Do not provide more than one PermanentNavModel"
+        }
+    }
 
     constructor(vararg navModels: NavModel<NavTarget, *>) : this(navModels.toList())
 
@@ -59,6 +67,10 @@ class CombinedNavModel<NavTarget>(
     override fun destroy() {
         scope.cancel()
         navModels.filterIsInstance<Destroyable>().forEach { it.destroy() }
+    }
+
+    companion object {
+        private const val MAX_PERMANENT_NAV_MODEL_COUNT = 1
     }
 
 }

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/navigation/model/combined/CombinedNavModel.kt
@@ -20,9 +20,14 @@ class CombinedNavModel<NavTarget>(
 ) : NavModel<NavTarget, Any?>, Destroyable {
 
     init {
-        val permanentNavModelCount = navModels.filterIsInstance<PermanentNavModel<*>>().count()
+        val permanentNavModelCount = navModels.count { it is PermanentNavModel<*> }
         check(permanentNavModelCount <= MAX_PERMANENT_NAV_MODEL_COUNT) {
-            "Do not provide more than one PermanentNavModel"
+            "CombinedNavModel does not support more than one PermanentNavModel"
+        }
+
+        val hasNoNestedCombinedNavModel = navModels.count { it is CombinedNavModel<*> } == 0
+        check(hasNoNestedCombinedNavModel) {
+            "CombinedNavModel does not support nested CombinedNavModel"
         }
     }
 

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/node/ParentNode.kt
@@ -93,10 +93,6 @@ abstract class ParentNode<NavTarget : Any>(
         }
     }
 
-    /**
-     * If PermanentNavModel is provided in the constructor, it will be retrieved and used.
-     * Otherwise, it will be created internally.
-     */
     private fun retrievePermanentNavModel(navModel: NavModel<NavTarget, *>): PermanentNavModel<NavTarget>? =
         when (navModel) {
             is CombinedNavModel<NavTarget> -> {

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/combined/CombinedNavModelNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/combined/CombinedNavModelNode.kt
@@ -23,12 +23,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.core.composable.Children
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.model.combined.plus
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.transitionhandler.rememberBackstackFader
-import com.bumble.appyx.core.navigation.model.combined.plus
 import com.bumble.appyx.sandbox.client.child.ChildNode
 import com.bumble.appyx.sandbox.client.combined.CombinedNavModelNode.NavTarget.Dynamic.Child
 import kotlinx.parcelize.Parcelize


### PR DESCRIPTION
## Description

Fixes: https://github.com/bumble-tech/appyx/issues/604

Problem: If `PermanentNavModel` was provided to the constructor of the ParentNode it will be ignored as ParenNode internally uses its own instance of `PermanentNavModel`. This PR ensures that we reuse the same instance of `PermanentNavModel` if it's provided 



## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
