### PR TITLE
Do not create permanentNavModel inside ParentNode. Provide it via constructor to ParentNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
--
+- [#606](https://github.com/bumble-tech/appyx/pull/606) – **Fixed**: Do not create permanentNavModel inside ParentNode. Provide it via constructor to ParentNode
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-- [#606](https://github.com/bumble-tech/appyx/pull/606) – **Fixed**: Do not create permanentNavModel inside ParentNode. Provide it via constructor to ParentNode
+- [#606](https://github.com/bumble-tech/appyx/pull/606) – **Breaking change**: Do not create permanentNavModel inside ParentNode. Provide it via constructor to ParentNode
 
 ---
 

--- a/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
+++ b/libraries/core/src/androidTest/kotlin/com/bumble/appyx/core/node/PermanentChildTest.kt
@@ -39,6 +39,13 @@ class PermanentChildTest {
     }
 
     @Test
+    fun `WHEN_permanent_model_does_not_contain_relevant_nav_key_THEN_permanent_child_is_not_rendered`() {
+        rule.start()
+
+        rule.onNode(hasTestTag(TestParentNode.NavTarget::class.java.name)).assertDoesNotExist()
+    }
+
+    @Test
     fun `WHEN_visibility_switched_THEN_permanent_child_is_reused`() {
         createPermanentNavModelWithNavKey()
         rule.start()

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/PermanentChild.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/PermanentChild.kt
@@ -13,7 +13,7 @@ fun <NavTarget : Any> ParentNode<NavTarget>.PermanentChild(
     navTarget: NavTarget,
     decorator: @Composable (child: ChildRenderer) -> Unit
 ) {
-    val child = remember(navTarget) {
+    val child = remember(navTarget, permanentNavModel) {
         permanentNavModel
             .elements
             .value

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/PermanentChild.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/composable/PermanentChild.kt
@@ -1,0 +1,56 @@
+package com.bumble.appyx.core.composable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
+import com.bumble.appyx.core.node.Node
+import com.bumble.appyx.core.node.ParentNode
+
+@Composable
+fun <NavTarget : Any> ParentNode<NavTarget>.PermanentChild(
+    permanentNavModel: PermanentNavModel<NavTarget>,
+    navTarget: NavTarget,
+    decorator: @Composable (child: ChildRenderer) -> Unit
+) {
+    val child = remember(navTarget) {
+        permanentNavModel
+            .elements
+            .value
+            .find { it.key.navTarget == navTarget }
+            ?.let { childOrCreate(it.key) }
+            ?: throw IllegalStateException(
+                "No child found for $navTarget in $permanentNavModel. " +
+                        "Add $navTarget to $permanentNavModel before calling PermanentChild."
+            )
+    }
+
+    decorator(PermanentChildRender(child.node))
+}
+
+@Composable
+fun <NavTarget : Any> ParentNode<NavTarget>.PermanentChild(
+    permanentNavModel: PermanentNavModel<NavTarget>,
+    navTarget: NavTarget,
+) {
+    PermanentChild(permanentNavModel, navTarget) { child -> child() }
+}
+
+private class PermanentChildRender(private val node: Node) : ChildRenderer {
+
+    @Suppress(
+        "ComposableNaming" // This wants to be 'Invoke' but that won't work with 'operator'.
+    )
+    @Composable
+    override operator fun invoke(modifier: Modifier) {
+        node.Compose(modifier)
+    }
+
+    @Suppress(
+        "ComposableNaming" // This wants to be 'Invoke' but that won't work with 'operator'.
+    )
+    @Composable
+    override operator fun invoke() {
+        invoke(modifier = Modifier)
+    }
+}

--- a/libraries/core/src/test/kotlin/com/bumble/appyx/core/node/ParentNodeTest.kt
+++ b/libraries/core/src/test/kotlin/com/bumble/appyx/core/node/ParentNodeTest.kt
@@ -1,11 +1,16 @@
 package com.bumble.appyx.core.node
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.bumble.appyx.core.children.nodeOrNull
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.NavModel
+import com.bumble.appyx.core.navigation.model.combined.plus
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
+import com.bumble.appyx.core.navigation.model.permanent.operation.addUnique
+import com.bumble.appyx.core.node.ParentNodeTest.NavTarget.ChildA
+import com.bumble.appyx.core.node.ParentNodeTest.NavTarget.ChildB
 import com.bumble.appyx.core.node.ParentNodeTest.NodeB.Companion.StatusExecuted
-import com.bumble.appyx.core.node.ParentNodeTest.TestParentNode.NavTarget
-import com.bumble.appyx.core.node.ParentNodeTest.TestParentNode.NavTarget.ChildA
-import com.bumble.appyx.core.node.ParentNodeTest.TestParentNode.NavTarget.ChildB
+import com.bumble.appyx.core.state.SavedStateMap
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.testing.junit4.util.MainDispatcherRule
@@ -75,11 +80,84 @@ class ParentNodeTest {
             assertTrue(attachedNode is NodeB)
         }
 
-    private fun buildBackStack(initialElement: NavTarget = ChildA) =
-        BackStack(initialElement = initialElement, savedStateMap = null)
+    @Test
+    fun `GIVEN node with PermanentNavModel WHEN saves state THEN restores state correctly`() =
+        testScope.runTest {
+            //given
+            val permanentNavModel: PermanentNavModel<NavTarget> =
+                PermanentNavModel(ChildA, savedStateMap = null)
+            val node = buildParentNode(navModel = permanentNavModel)
+            assertChildrenCount(node, 1)
+
+            // when
+            permanentNavModel.addUnique(ChildB)
+            assertChildrenCount(node, 2)
+            val state = node.saveInstanceState { true }
+            val restoredStateNode =
+                buildParentNode(navModel = permanentNavModel, savedStateMap = state)
+
+            //then
+            assertChildrenCount(restoredStateNode, 2)
+        }
+
+    @Test
+    fun `GIVEN node with CombinedNavModel with PermanentNavModel WHEN saves state THEN restores state correctly`() =
+        testScope.runTest {
+            //given
+            val permanentNavModel: PermanentNavModel<NavTarget> =
+                PermanentNavModel(ChildA, savedStateMap = null)
+
+            val backStack = buildBackStack(initialElement = ChildB)
+            val node = buildParentNode(navModel = permanentNavModel + backStack)
+            assertChildrenCount(node, 2)
+
+            // when
+            permanentNavModel.addUnique(ChildB)
+            assertChildrenCount(node, 3)
+            val state = node.saveInstanceState { true }
+            val restoredStateNode =
+                buildParentNode(navModel = permanentNavModel + backStack, savedStateMap = state)
+
+            //then
+            assertChildrenCount(restoredStateNode, 3)
+        }
+
+    private fun assertChildrenCount(node: ParentNode<*>, expectedCount: Int) {
+        val childrenCount = node.children.value.values.mapNotNull { it.nodeOrNull }.count()
+        assertTrue(childrenCount == expectedCount)
+    }
+
+    private fun buildBackStack(
+        initialElement: NavTarget = ChildA,
+        savedStateMap: SavedStateMap? = null
+    ) =
+        BackStack(initialElement = initialElement, savedStateMap = savedStateMap)
 
     private fun buildParentNode(backStack: BackStack<NavTarget>) =
         TestParentNode(backStack).apply { onBuilt() }
+
+    private fun buildParentNode(
+        savedStateMap: SavedStateMap? = null,
+        navModel: NavModel<NavTarget, *>
+    ) =
+        TestPermanentModelParentNode(
+            savedStateMap = savedStateMap,
+            navModel = navModel
+        ).apply { onBuilt() }
+
+    private class TestPermanentModelParentNode(
+        savedStateMap: SavedStateMap? = null,
+        navModel: NavModel<NavTarget, *>
+    ) : ParentNode<NavTarget>(
+        buildContext = BuildContext.root(savedStateMap),
+        navModel = navModel
+    ) {
+
+        override fun resolve(navTarget: NavTarget, buildContext: BuildContext) = when (navTarget) {
+            ChildA -> node(buildContext) {}
+            ChildB -> NodeB(buildContext)
+        }
+    }
 
     private class TestParentNode(
         private val backStack: BackStack<NavTarget>
@@ -87,11 +165,6 @@ class ParentNodeTest {
         buildContext = BuildContext.root(null),
         navModel = backStack
     ) {
-
-        sealed class NavTarget {
-            object ChildA : NavTarget()
-            object ChildB : NavTarget()
-        }
 
         suspend fun waitForBAttached(): NodeB {
             return waitForChildAttached()
@@ -113,6 +186,11 @@ class ParentNodeTest {
             ChildA -> node(buildContext) {}
             ChildB -> NodeB(buildContext)
         }
+    }
+
+    private sealed class NavTarget {
+        object ChildA : NavTarget()
+        object ChildB : NavTarget()
     }
 
     private class NodeB(buildContext: BuildContext) : Node(buildContext) {

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/samples/SamplesSelectorNode.kt
@@ -19,9 +19,10 @@ import com.bumble.appyx.app.node.backstack.InsideTheBackStack
 import com.bumble.appyx.app.node.cards.CardsExampleNode
 import com.bumble.appyx.app.node.slideshow.WhatsAppyxSlideShow
 import com.bumble.appyx.core.composable.ChildRenderer
+import com.bumble.appyx.core.composable.PermanentChild
 import com.bumble.appyx.core.integrationpoint.LocalIntegrationPoint
 import com.bumble.appyx.core.modality.BuildContext
-import com.bumble.appyx.core.navigation.EmptyNavModel
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.node
@@ -30,9 +31,16 @@ import kotlinx.parcelize.Parcelize
 
 class SamplesSelectorNode(
     buildContext: BuildContext,
+    private val permanentNavModel: PermanentNavModel<NavTarget> = PermanentNavModel(
+        NavTarget.InsideTheBackStack,
+        NavTarget.CardsExample,
+        NavTarget.OnboardingScreen,
+        NavTarget.ComposeNavigationScreen,
+        savedStateMap = buildContext.savedStateMap,
+    ),
     private val outputFunc: (Output) -> Unit
 ) : ParentNode<SamplesSelectorNode.NavTarget>(
-    navModel = EmptyNavModel<NavTarget, Unit>(),
+    navModel = permanentNavModel,
     buildContext = buildContext
 ) {
     sealed class NavTarget : Parcelable {
@@ -53,7 +61,7 @@ class SamplesSelectorNode(
         object OpenCardsExample : Output()
         object OpenOnboarding : Output()
         object OpenComposeNavigation : Output()
-        object OpenInsideTheBackStack: Output()
+        object OpenInsideTheBackStack : Output()
     }
 
     @ExperimentalUnitApi
@@ -67,6 +75,7 @@ class SamplesSelectorNode(
                 buildContext = buildContext,
                 autoAdvanceDelayMs = 2500
             )
+
             is NavTarget.ComposeNavigationScreen -> {
                 node(buildContext) {
                     // compose-navigation fetches the integration point via LocalIntegrationPoint
@@ -77,6 +86,7 @@ class SamplesSelectorNode(
                     }
                 }
             }
+
             is NavTarget.InsideTheBackStack -> InsideTheBackStack(
                 buildContext = buildContext,
                 autoAdvanceDelayMs = 1000
@@ -124,6 +134,7 @@ class SamplesSelectorNode(
             onClick = { outputFunc(Output.OpenInsideTheBackStack) },
         ) {
             PermanentChild(
+                permanentNavModel = permanentNavModel,
                 navTarget = NavTarget.InsideTheBackStack,
                 decorator = decorator
             )
@@ -141,6 +152,7 @@ class SamplesSelectorNode(
             onClick = { outputFunc(Output.OpenComposeNavigation) },
         ) {
             PermanentChild(
+                permanentNavModel = permanentNavModel,
                 navTarget = NavTarget.ComposeNavigationScreen,
                 decorator = decorator
             )
@@ -158,6 +170,7 @@ class SamplesSelectorNode(
             onClick = { outputFunc(Output.OpenOnboarding) },
         ) {
             PermanentChild(
+                permanentNavModel = permanentNavModel,
                 navTarget = NavTarget.OnboardingScreen,
                 decorator = decorator
             )
@@ -172,9 +185,11 @@ class SamplesSelectorNode(
             onClick = { outputFunc(Output.OpenCardsExample) },
         ) {
             PermanentChild(
+                permanentNavModel = permanentNavModel,
                 navTarget = NavTarget.CardsExample,
                 decorator = decorator
             )
+
         }
     }
 }

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/slideshow/slide/app/StatefulNode1.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/slideshow/slide/app/StatefulNode1.kt
@@ -42,6 +42,10 @@ import kotlinx.parcelize.Parcelize
 class StatefulNode1(
     buildContext: BuildContext,
     private val permanentNavModel: PermanentNavModel<NavTarget> = PermanentNavModel(
+        NavTarget.Child(BASE_COUNTER),
+        NavTarget.Child(BASE_COUNTER * 2),
+        NavTarget.Child(BASE_COUNTER * 3),
+        NavTarget.Child(BASE_COUNTER * 4),
         savedStateMap = buildContext.savedStateMap
     )
 ) : ParentNode<StatefulNode1.NavTarget>(

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/slideshow/slide/app/StatefulNode1.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/slideshow/slide/app/StatefulNode1.kt
@@ -25,13 +25,14 @@ import androidx.compose.ui.unit.dp
 import com.bumble.appyx.app.composable.Page
 import com.bumble.appyx.app.node.child.GenericChildNode
 import com.bumble.appyx.app.ui.AppyxSampleAppTheme
+import com.bumble.appyx.core.composable.PermanentChild
 import com.bumble.appyx.core.integration.NodeHost
 import com.bumble.appyx.core.integrationpoint.IntegrationPointStub
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.modality.BuildContext.Companion.root
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
-import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import kotlinx.coroutines.delay
 import kotlinx.parcelize.Parcelize
 
@@ -39,12 +40,13 @@ import kotlinx.parcelize.Parcelize
 @ExperimentalAnimationApi
 @ExperimentalComposeUiApi
 class StatefulNode1(
-    buildContext: BuildContext
-) : ParentNode<StatefulNode1.NavTarget>(
-    buildContext = buildContext,
-    navModel = PermanentNavModel(
+    buildContext: BuildContext,
+    private val permanentNavModel: PermanentNavModel<NavTarget> = PermanentNavModel(
         savedStateMap = buildContext.savedStateMap
     )
+) : ParentNode<StatefulNode1.NavTarget>(
+    buildContext = buildContext,
+    navModel = permanentNavModel,
 ) {
     sealed class NavTarget : Parcelable {
         @Parcelize
@@ -62,8 +64,8 @@ class StatefulNode1(
             modifier = modifier,
             title = "Stateful",
             body = "Each Node on this screen has some state:" +
-                "\n\n1. The counter represents data from a background process (e.g. server)." +
-                "\n2. You can also tap them to change their colour. Try it!"
+                    "\n\n1. The counter represents data from a background process (e.g. server)." +
+                    "\n2. You can also tap them to change their colour. Try it!"
         ) {
             Column(Modifier.fillMaxSize()) {
                 Row(
@@ -108,8 +110,15 @@ class StatefulNode1(
     }
 
     @Composable
-    private fun ChildInABox(navTarget: NavTarget, showWithDelay: Long, modifier: Modifier = Modifier) {
-        PermanentChild(navTarget) { child ->
+    private fun ChildInABox(
+        navTarget: NavTarget,
+        showWithDelay: Long,
+        modifier: Modifier = Modifier
+    ) {
+        PermanentChild(
+            permanentNavModel = permanentNavModel,
+            navTarget
+        ) { child ->
             Box(modifier) {
                 var visible by remember { mutableStateOf(false) }
                 AnimatedVisibility(

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/combined/CombinedNavModelNode.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/combined/CombinedNavModelNode.kt
@@ -22,13 +22,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.core.composable.Children
+import com.bumble.appyx.core.composable.PermanentChild
 import com.bumble.appyx.core.modality.BuildContext
+import com.bumble.appyx.core.navigation.model.combined.plus
+import com.bumble.appyx.core.navigation.model.permanent.PermanentNavModel
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.navmodel.backstack.operation.push
 import com.bumble.appyx.navmodel.backstack.transitionhandler.rememberBackstackFader
-import com.bumble.appyx.core.navigation.model.combined.plus
 import com.bumble.appyx.sandbox.client.child.ChildNode
 import com.bumble.appyx.sandbox.client.combined.CombinedNavModelNode.NavTarget.Dynamic.Child
 import kotlinx.parcelize.Parcelize
@@ -46,9 +48,13 @@ class CombinedNavModelNode(
         savedStateMap = buildContext.savedStateMap,
         key = "BackStack2",
     ),
+    private val permanentNavModel: PermanentNavModel<NavTarget> = PermanentNavModel(
+        NavTarget.Permanent.Child1,
+        savedStateMap = buildContext.savedStateMap,
+    )
 ) : ParentNode<CombinedNavModelNode.NavTarget>(
     buildContext = buildContext,
-    navModel = backStack1 + backStack2,
+    navModel = backStack1 + backStack2 + permanentNavModel,
 ) {
 
     sealed class NavTarget : Parcelable {
@@ -100,7 +106,7 @@ class CombinedNavModelNode(
             Button(onClick = { visibility = !visibility }) {
                 Text(text = "Trigger visibility")
             }
-            PermanentChild(NavTarget.Permanent.Child1) { child ->
+            PermanentChild(permanentNavModel, NavTarget.Permanent.Child1) { child ->
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
## Description

Fixes: https://github.com/bumble-tech/appyx/issues/604

Using `PermanentChild` composable function, we're delaying adding a child to the `ParentNode` until `PermanentChild`  is invoked. This can lead to many problems as the appropriate `Node` will be created only when composable is invoked. Additionally, there's a lot of [complexity](https://github.com/bumble-tech/appyx/pull/605) associated with making sure that we're using only the same instance of `PermanentNavModel` in the cases when one is provided to the constructor.

This PR removes internally created `PermanentNavModel` and forces users to provide it from outside

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
