### PR TITLE
Setting default value to NodeCustomisationDirectory in IosNodeHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Pending changes
 
-–
+### Fixed
+
+- [#608](https://github.com/bumble-tech/appyx/pull/608) – Setting default value to NodeCustomisationDirectory in IosNodeHost
 
 ## 2.0.0-alpha07
 

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/integration/IosNodeHost.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/integration/IosNodeHost.kt
@@ -26,7 +26,7 @@ fun <N : Node> IosNodeHost(
     onBackPressedEvents: Flow<Unit>,
     modifier: Modifier = Modifier,
     integrationPoint: IntegrationPoint,
-    customisations: NodeCustomisationDirectory = remember { NodeCustomisationDirectoryImpl() },
+    customisations: NodeCustomisationDirectory = remember { NodeCustomisationDirectoryImpl(null) },
     factory: NodeFactory<N>,
 ) {
     val platformLifecycleRegistry = remember {


### PR DESCRIPTION
## Description
- Fixing publishing iOS targets, setting default value to `NodeCustomisationDirectory` for iOS.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [X] I have updated documentation if required.
