### PR TITLE
Lower position and rotation animation default round-off thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 ## Pending changes
 
-–
+### Changed
+
+- [#611](https://github.com/bumble-tech/appyx/pull/611) – Lower position and rotation animation default round-off thresholds
+
+---
 
 ## 2.0.0-alpha08
 
 ### Fixed
 
 - [#608](https://github.com/bumble-tech/appyx/pull/608) – Setting default value to NodeCustomisationDirectory in IosNodeHost
+
+---
 
 ## 2.0.0-alpha07
 
@@ -19,6 +25,7 @@
 
 <div style="text-align: center"><small>4 Oct 2023</small></div>
 
+---
 
 ## 2.0.0-alpha06
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationX.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 class RotationX(
     coroutineScope: CoroutineScope,
     target: Target,
-    visibilityThreshold: Float = 1f,
+    visibilityThreshold: Float = 0.1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationY.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 class RotationY(
     coroutineScope: CoroutineScope,
     target: Target,
-    visibilityThreshold: Float = 1f,
+    visibilityThreshold: Float = 0.1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/RotationZ.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.StateFlow
 class RotationZ(
     coroutineScope: CoroutineScope,
     target: Target,
-    visibilityThreshold: Float = 1f,
+    visibilityThreshold: Float = 0.1f,
     displacement: StateFlow<Float> = MutableStateFlow(0f),
     private val origin: TransformOrigin = target.origin,
 ) : MotionProperty<Float, AnimationVector1D>(

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionInside.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionInside.kt
@@ -29,7 +29,7 @@ class PositionInside(
     coroutineScope: CoroutineScope,
     val target: Target,
     displacement: StateFlow<Value> = MutableStateFlow(Value.Zero),
-    visibilityThreshold: Value = Value(InsideAlignment(0.01f, 0.01f), DpOffset(1.dp, 1.dp)),
+    visibilityThreshold: Value = Value(InsideAlignment(0.001f, 0.001f), DpOffset(1.dp, 1.dp)),
 ) : MotionProperty<Value, AnimationVector4D>(
     coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Value.VectorConverter),

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionOutside.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/ui/property/impl/position/PositionOutside.kt
@@ -28,7 +28,7 @@ class PositionOutside(
     coroutineScope: CoroutineScope,
     val target: Target,
     displacement: StateFlow<Value> = MutableStateFlow(Value.Zero),
-    visibilityThreshold: Value = Value(OutsideAlignment(0.01f, 0.01f), DpOffset(1.dp, 1.dp)),
+    visibilityThreshold: Value = Value(OutsideAlignment(0.001f, 0.001f), DpOffset(1.dp, 1.dp)),
 ) : MotionProperty<Value, AnimationVector4D>(
     coroutineScope = coroutineScope,
     animatable = Animatable(target.value, Value.VectorConverter),


### PR DESCRIPTION
## Description

Lowers the default value for animation round-off by an order of magnitude. The previous values meant about 1% of a difference, which can cause quite a noticeable jump on large screens when it comes to animating position or rotation.

The values in question are passed to https://developer.android.com/reference/kotlin/androidx/compose/animation/core/SpringSpec#visibilityThreshold() for spring-based animations.

An API change to improve customisability of said parameters would follow in a different PR.


## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
