### PR TITLE
Make dependencies on download page kts-friendly

### DIFF
--- a/documentation/releases/downloads.md
+++ b/documentation/releases/downloads.md
@@ -24,14 +24,14 @@ Adding the gradle dependency in a non-multiplatform project:
 ```groovy
 dependencies {
     // Platform-specific (pick the right one for your platform)
-    implementation "com.bumble.appyx:appyx-navigation-android:$version"
-    implementation "com.bumble.appyx:appyx-navigation-desktop:$version"
-    implementation "com.bumble.appyx:appyx-navigation-js:$version"
+    implementation("com.bumble.appyx:appyx-navigation-android:$version")
+    implementation("com.bumble.appyx:appyx-navigation-desktop:$version")
+    implementation("com.bumble.appyx:appyx-navigation-js:$version")
 
     // For iOS, you need separate dependencies for Simulator, x86 & Arm
-    implementation "com.bumble.appyx:appyx-navigation-iossimulatorarm64:$version"
-    implementation "com.bumble.appyx:appyx-navigation-iosx64:$version"
-    implementation "com.bumble.appyx:appyx-navigation-iosarm64:$version"
+    implementation("com.bumble.appyx:appyx-navigation-iossimulatorarm64:$version")
+    implementation("com.bumble.appyx:appyx-navigation-iosx64:$version")
+    implementation("com.bumble.appyx:appyx-navigation-iosarm64:$version")
 }
 ```
 
@@ -42,7 +42,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation "com.bumble.appyx:appyx-navigation:$version"
+                implementation("com.bumble.appyx:appyx-navigation:$version")
             }
         }
     }
@@ -56,14 +56,14 @@ Adding the gradle dependency in a non-multiplatform project:
 ```groovy
 dependencies {
     // Platform-specific (pick the right one for your platform)
-    implementation "com.bumble.appyx:appyx-interactions-android:$version"
-    implementation "com.bumble.appyx:appyx-interactions-desktop:$version"
-    implementation "com.bumble.appyx:appyx-interactions-js:$version"
+    implementation("com.bumble.appyx:appyx-interactions-android:$version")
+    implementation("com.bumble.appyx:appyx-interactions-desktop:$version")
+    implementation("com.bumble.appyx:appyx-interactions-js:$version")
 
     // For iOS, you need separate dependencies for Simulator, x86 & Arm
-    implementation "com.bumble.appyx:appyx-interactions-iossimulatorarm64:$version"
-    implementation "com.bumble.appyx:appyx-interactions-iosx64:$version"
-    implementation "com.bumble.appyx:appyx-interactions-iosarm64:$version"
+    implementation("com.bumble.appyx:appyx-interactions-iossimulatorarm64:$version")
+    implementation("com.bumble.appyx:appyx-interactions-iosx64:$version")
+    implementation("com.bumble.appyx:appyx-interactions-iosarm64:$version")
 }
 ```
 
@@ -74,7 +74,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation "com.bumble.appyx:appyx-interactions:$version"
+                implementation("com.bumble.appyx:appyx-interactions:$version")
             }
         }
     }
@@ -90,14 +90,14 @@ Adding the gradle dependency in a non-multiplatform project:
 ```groovy
 dependencies {
     // Platform-specific (pick the right one for your platform)
-    implementation "com.bumble.appyx:backstack-android:$version"
-    implementation "com.bumble.appyx:backstack-desktop:$version"
-    implementation "com.bumble.appyx:backstack-js:$version"
+    implementation("com.bumble.appyx:backstack-android:$version")
+    implementation("com.bumble.appyx:backstack-desktop:$version")
+    implementation("com.bumble.appyx:backstack-js:$version")
 
     // For iOS, you need separate dependencies for Simulator, x86 & Arm
-    implementation "com.bumble.appyx:backstack-iossimulatorarm64:$version"
-    implementation "com.bumble.appyx:backstack-iosx64:$version"
-    implementation "com.bumble.appyx:backstack-iosarm64:$version"
+    implementation("com.bumble.appyx:backstack-iossimulatorarm64:$version")
+    implementation("com.bumble.appyx:backstack-iosx64:$version")
+    implementation("com.bumble.appyx:backstack-iosarm64:$version")
 }
 ```
 
@@ -109,7 +109,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Use api, not implementation!
-                api "com.bumble.appyx:backstack:$version"
+                api("com.bumble.appyx:backstack:$version")
             }
         }
 
@@ -124,14 +124,14 @@ Adding the gradle dependency in a non-multiplatform project:
 ```groovy
 dependencies {
     // Platform-specific (pick the right one for your platform)
-    implementation "com.bumble.appyx:spotlight-android:$version"
-    implementation "com.bumble.appyx:spotlight-desktop:$version"
-    implementation "com.bumble.appyx:spotlight-js:$version"
+    implementation("com.bumble.appyx:spotlight-android:$version")
+    implementation("com.bumble.appyx:spotlight-desktop:$version")
+    implementation("com.bumble.appyx:spotlight-js:$version")
 
     // For iOS, you need separate dependencies for Simulator, x86 & Arm
-    implementation "com.bumble.appyx:spotlight-iossimulatorarm64:$version"
-    implementation "com.bumble.appyx:spotlight-iosx64:$version"
-    implementation "com.bumble.appyx:spotlight-iosarm64:$version"
+    implementation("com.bumble.appyx:spotlight-iossimulatorarm64:$version")
+    implementation("com.bumble.appyx:spotlight-iosx64:$version")
+    implementation("com.bumble.appyx:spotlight-iosarm64:$version")
 }
 ```
 
@@ -143,7 +143,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Use api, not implementation!
-                api "com.bumble.appyx:spotlight:$version"
+                api("com.bumble.appyx:spotlight:$version")
             }
         }
 
@@ -164,12 +164,12 @@ Adding the gradle dependency in a non-multiplatform project:
 ```groovy
 dependencies {
     // Platform-specific (pick the right one for your platform)
-    implementation "com.bumble.appyx:utils-material3-android:$version"
-    implementation "com.bumble.appyx:utils-material3-desktop:$version"
-    implementation "com.bumble.appyx:utils-material3-js:$version"
-    implementation "com.bumble.appyx:utils-material3-iosarm64:$version"
-    implementation "com.bumble.appyx:utils-material3-iossimulatorarm64:$version"
-    implementation "com.bumble.appyx:utils-material3-iosx64:$version"
+    implementation("com.bumble.appyx:utils-material3-android:$version")
+    implementation("com.bumble.appyx:utils-material3-desktop:$version")
+    implementation("com.bumble.appyx:utils-material3-js:$version")
+    implementation("com.bumble.appyx:utils-material3-iosarm64:$version")
+    implementation("com.bumble.appyx:utils-material3-iossimulatorarm64:$version")
+    implementation("com.bumble.appyx:utils-material3-iosx64:$version")
 }
 ```
 
@@ -181,7 +181,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 // Use api, not implementation!
-                api "com.bumble.appyx:utils-material3:$version"
+                api("com.bumble.appyx:utils-material3:$version")
             }
         }
     }
@@ -193,7 +193,7 @@ kotlin {
 ```groovy
 dependencies {
     // Optional support for RxJava 2/3
-    implementation "com.bumble.appyx:utils-interop-rx2:$version"
+    implementation("com.bumble.appyx:utils-interop-rx2:$version")
 }
 ```
 
@@ -201,7 +201,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation "com.bumble.appyx:utils-interop-rx3:$version"
+    implementation("com.bumble.appyx:utils-interop-rx3:$version")
 }
 ```
 
@@ -214,8 +214,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.bumble.appyx:utils-interop-ribs:$version"
-
+    implementation("com.bumble.appyx:utils-interop-ribs:$version")
 }
 ```
 
@@ -223,16 +222,16 @@ dependencies {
 ### Testing
 
 ```groovy
-    // Test rules and utility classes for testing on Android
-    debugImplementation "com.bumble.appyx:utils-testing-ui-activity:$version"
-    androidTestImplementation "com.bumble.appyx:utils-testing-ui:$version"
+// Test rules and utility classes for testing on Android
+debugImplementation("com.bumble.appyx:utils-testing-ui-activity:$version")
+androidTestImplementation("com.bumble.appyx:utils-testing-ui:$version")
 
-    // Utility classes for unit testing
-    testImplementation "com.bumble.appyx:utils-testing-unit-common:$version"
-    
-    // Test rules and utility classes for unit testing using JUnit4
-    testImplementation "com.bumble.appyx:utils-testing-junit4:$version"
+// Utility classes for unit testing
+testImplementation("com.bumble.appyx:utils-testing-unit-common:$version")
 
-    // Test extensions and utility classes for unit testing using JUnit5
-    testImplementation "com.bumble.appyx:utils-testing-junit5:$version"
+// Test rules and utility classes for unit testing using JUnit4
+testImplementation("com.bumble.appyx:utils-testing-junit4:$version")
+
+// Test extensions and utility classes for unit testing using JUnit5
+testImplementation("com.bumble.appyx:utils-testing-junit5:$version")
 ```

--- a/documentation/releases/downloads.md
+++ b/documentation/releases/downloads.md
@@ -10,7 +10,7 @@ title: Downloads
 
 ## Repository
 
-```groovy
+```kotlin
 repositories {
     mavenCentral()
 }
@@ -21,7 +21,7 @@ repositories {
 
 Adding the gradle dependency in a non-multiplatform project:
 
-```groovy
+```kotlin
 dependencies {
     // Platform-specific (pick the right one for your platform)
     implementation("com.bumble.appyx:appyx-navigation-android:$version")
@@ -37,7 +37,7 @@ dependencies {
 
 Adding the gradle dependency in a multiplatform project:
 
-```groovy
+```kotlin
 kotlin {
     sourceSets {
         val commonMain by getting {
@@ -53,7 +53,7 @@ kotlin {
 
 Adding the gradle dependency in a non-multiplatform project:
 
-```groovy
+```kotlin
 dependencies {
     // Platform-specific (pick the right one for your platform)
     implementation("com.bumble.appyx:appyx-interactions-android:$version")
@@ -69,7 +69,7 @@ dependencies {
 
 Adding the gradle dependency in a multiplatform project:
 
-```groovy
+```kotlin
 kotlin {
     sourceSets {
         val commonMain by getting {
@@ -87,7 +87,7 @@ kotlin {
 
 Adding the gradle dependency in a non-multiplatform project:
 
-```groovy
+```kotlin
 dependencies {
     // Platform-specific (pick the right one for your platform)
     implementation("com.bumble.appyx:backstack-android:$version")
@@ -103,7 +103,7 @@ dependencies {
 
 Adding the gradle dependency in a multiplatform project:
 
-```groovy
+```kotlin
 kotlin {
     sourceSets {
         val commonMain by getting {
@@ -121,7 +121,7 @@ kotlin {
 
 Adding the gradle dependency in a non-multiplatform project:
 
-```groovy
+```kotlin
 dependencies {
     // Platform-specific (pick the right one for your platform)
     implementation("com.bumble.appyx:spotlight-android:$version")
@@ -137,7 +137,7 @@ dependencies {
 
 Adding the gradle dependency in a multiplatform project:
 
-```groovy
+```kotlin
 kotlin {
     sourceSets {
         val commonMain by getting {
@@ -161,7 +161,7 @@ See more in [Material 3 support](../navigation/features/material3.md).
 
 Adding the gradle dependency in a non-multiplatform project:
 
-```groovy
+```kotlin
 dependencies {
     // Platform-specific (pick the right one for your platform)
     implementation("com.bumble.appyx:utils-material3-android:$version")
@@ -175,7 +175,7 @@ dependencies {
 
 Adding the gradle dependency in a multiplatform project:
 
-```groovy
+```kotlin
 kotlin {
     sourceSets {
         val commonMain by getting {
@@ -190,7 +190,7 @@ kotlin {
 
 ### RxJava 2
 
-```groovy
+```kotlin
 dependencies {
     // Optional support for RxJava 2/3
     implementation("com.bumble.appyx:utils-interop-rx2:$version")
@@ -199,7 +199,7 @@ dependencies {
 
 ### RxJava 3
 
-```groovy
+```kotlin
 dependencies {
     implementation("com.bumble.appyx:utils-interop-rx3:$version")
 }
@@ -207,7 +207,7 @@ dependencies {
 
 ### badoo/RIBs
 
-```groovy
+```kotlin
 repositories {
     // Don't forget to add this, since badoo/RIBs is hosted on jitpack:
     maven(url = "https://jitpack.io")
@@ -221,7 +221,7 @@ dependencies {
 
 ### Testing
 
-```groovy
+```kotlin
 // Test rules and utility classes for testing on Android
 debugImplementation("com.bumble.appyx:utils-testing-ui-activity:$version")
 androidTestImplementation("com.bumble.appyx:utils-testing-ui:$version")


### PR DESCRIPTION
## Description

Added braces to dependency declarations on the Downloads page to make them copy-paste friendly for kts build scripts

...

## Check list

- [X] I have updated `CHANGELOG.md` if required.
- [X] I have updated documentation if required.
