### PR TITLE
Fix visibility issue for bottom element in BackStackParallax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- [#638](https://github.com/bumble-tech/appyx/pull/638) - Setting alpha to 0 for bottom element when animation is finished
+- [#638](https://github.com/bumble-tech/appyx/pull/638) - Fix visibility issue for bottom element in BackStackParallax
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#630](https://github.com/bumble-tech/appyx/pull/630) – Pass initial state into Spotlights visualisations
 
+### Fixed
+
+- [#638](https://github.com/bumble-tech/appyx/pull/638) - Setting alpha to 0 for bottom element when animation is finished
+
 ---
 
 ## 2.0.0-alpha09

--- a/appyx-components/stable/backstack/android/src/androidTest/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallaxTest.kt
+++ b/appyx-components/stable/backstack/android/src/androidTest/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallaxTest.kt
@@ -36,7 +36,7 @@ class BackStackParallaxTest {
         with(visualisation.mapUpdate(backStackModel.output.value as Update<BackStackModel.State<InteractionTarget>>)) {
             Assert.assertFalse(get(0).visibleState.value) // Child #1 should be false
             Assert.assertFalse(get(1).visibleState.value) // Child #2 should be false
-            Assert.assertTrue(get(2).visibleState.value)  // Child #3 should be true
+            Assert.assertFalse(get(2).visibleState.value)  // Child #3 should be false
             Assert.assertTrue(get(3).visibleState.value)  // Child #4 should be true
         }
     }

--- a/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallax.kt
+++ b/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallax.kt
@@ -36,6 +36,7 @@ class BackStackParallax<InteractionTarget : Any>(
     private val right = TargetUiState(
         offsetMultiplier = 1f,
         shadow = Shadow.Target(value = 0f, easing = slowOutFastInEasing),
+        alpha = Alpha.Target(1f),
     )
 
     private val bottom = TargetUiState(
@@ -47,6 +48,7 @@ class BackStackParallax<InteractionTarget : Any>(
     private val top = TargetUiState(
         offsetMultiplier = 0f,
         shadow = Shadow.Target(25f),
+        alpha = Alpha.Target(value = 1f, easing = { fraction -> if (fraction == 0f) 0f else 1f })
     )
 
     override fun State<InteractionTarget>.toUiTargets(): List<MatchedTargetUiState<InteractionTarget, TargetUiState>> {

--- a/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallax.kt
+++ b/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/BackStackParallax.kt
@@ -41,6 +41,7 @@ class BackStackParallax<InteractionTarget : Any>(
     private val bottom = TargetUiState(
         offsetMultiplier = -0.2f,
         colorOverlay = ColorOverlay.Target(0.7f),
+        alpha = Alpha.Target(value = 0f, easing = { fraction -> if (fraction == 1f) 1f else 0f })
     )
 
     private val top = TargetUiState(

--- a/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/TargetUiState.kt
+++ b/appyx-components/stable/backstack/common/src/commonMain/kotlin/com/bumble/appyx/components/backstack/ui/parallax/TargetUiState.kt
@@ -21,7 +21,7 @@ class TargetUiState(
         offsetMultiplier: Float,
         colorOverlay: ColorOverlay.Target = ColorOverlay.Target(0f),
         shadow: Shadow.Target = Shadow.Target(0f),
-        alpha: Alpha.Target = Alpha.Target(1f),
+        alpha: Alpha.Target,
     ) : this(
         positionAlignment = PositionAlignment.Target(
             OutsideAlignment(


### PR DESCRIPTION
## Description

Multiple children are visible at the same time in BackStackParallax as the bottom element is still considered in composition. Reason being the bottom element was not out of bounds and had properties making it invisible.

Fixed the issue by setting the bottom element alpha to 0 when not visible (i.e. top element has fully covered it). 

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
