### PR TITLE
Don't use Compose leaked internal AtomicReference

### DIFF
--- a/appyx-navigation/common/build.gradle.kts
+++ b/appyx-navigation/common/build.gradle.kts
@@ -54,7 +54,6 @@ kotlin {
 
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.lifecycle.java8)
-
             }
         }
         val desktopMain by getting {

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/OnBackPressedCallback.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/OnBackPressedCallback.kt
@@ -1,6 +1,6 @@
 package com.bumble.appyx.navigation.platform
 
-import androidx.compose.runtime.AtomicReference
+import kotlin.concurrent.AtomicReference
 
 interface Cancellable {
     /**
@@ -39,7 +39,7 @@ abstract class OnBackPressedCallback(
      * added to.
      */
     fun remove() {
-        for (cancellable in cancellablesReference.get()) {
+        for (cancellable in cancellablesReference.value) {
             cancellable.cancel()
         }
     }
@@ -49,10 +49,10 @@ abstract class OnBackPressedCallback(
      */
     abstract fun handleOnBackPressed()
     fun addCancellable(cancellable: Cancellable) {
-        cancellablesReference.set(cancellablesReference.get() + cancellable)
+        cancellablesReference.getAndSet(cancellablesReference.value + cancellable)
     }
 
     fun removeCancellable(cancellable: Cancellable) {
-        cancellablesReference.set(cancellablesReference.get() - cancellable)
+        cancellablesReference.getAndSet(cancellablesReference.value - cancellable)
     }
 }

--- a/appyx-navigation/common/src/jsMain/kotlin/com/bumble/appyx/navigation/platform/OnBackPressedCallback.kt
+++ b/appyx-navigation/common/src/jsMain/kotlin/com/bumble/appyx/navigation/platform/OnBackPressedCallback.kt
@@ -1,7 +1,5 @@
 package com.bumble.appyx.navigation.platform
 
-import androidx.compose.runtime.AtomicReference
-
 interface Cancellable {
     /**
      * Cancel the subscription. This call should be idempotent, making it safe to
@@ -31,15 +29,14 @@ abstract class OnBackPressedCallback(
      *
      * @return Whether this callback should be considered enabled.
      */
-    private val cancellablesReference: AtomicReference<List<Cancellable>> =
-        AtomicReference(emptyList())
+    private val cancellables: MutableList<Cancellable> = mutableListOf()
 
     /**
      * Removes this callback from any [OnBackPressedDispatcher] it is currently
      * added to.
      */
     fun remove() {
-        for (cancellable in cancellablesReference.get()) {
+        for (cancellable in cancellables) {
             cancellable.cancel()
         }
     }
@@ -49,10 +46,14 @@ abstract class OnBackPressedCallback(
      */
     abstract fun handleOnBackPressed()
     fun addCancellable(cancellable: Cancellable) {
-        cancellablesReference.set(cancellablesReference.get() + cancellable)
+        run {
+            cancellables.add(cancellable)
+        }
     }
 
     fun removeCancellable(cancellable: Cancellable) {
-        cancellablesReference.set(cancellablesReference.get() - cancellable)
+        run {
+            cancellables.remove(cancellable)
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableCInteropCommonization=true
 library.version=2.0.0-alpha09
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.uikit.enabled=true


### PR DESCRIPTION
## Description

In the upcoming Compose Multiplatform version, the leaked AtomicReference class will no longer be exposed. Consequently, it is advisable to discontinue its usage and seek alternative methods to achieve the desired functionality.

## Check list

- [ ] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
