### PR TITLE
Fix iOS lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#652](https://github.com/bumble-tech/appyx/pull/652) - KSP processor renamed from `mutable-ui-processor` to `appyx-processor`
 - [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings
 - [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode
-- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier
+- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-– [#670](https://github.com/bumble-tech/appyx/pull/670) - Fixes ios lifecycle
+- [#670](https://github.com/bumble-tech/appyx/pull/670) - Fixes ios lifecycle
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-–
+– [#670](https://github.com/bumble-tech/appyx/pull/670) - Fixes ios lifecycle
 
 ---
 
@@ -19,11 +19,11 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#630](https://github.com/bumble-tech/appyx/pull/630) – Pass initial state into Spotlights visualisations
 - [#642](https://github.com/bumble-tech/appyx/pull/642) – Renamings
 - [#643](https://github.com/bumble-tech/appyx/pull/643) – Unify AppyxComponent composable between appyx-navigation and appyx-interactions modules
-- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package 
+- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package
 - [#652](https://github.com/bumble-tech/appyx/pull/652) - KSP processor renamed from `mutable-ui-processor` to `appyx-processor`
-- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings 
-- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode 
-- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
+- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings
+- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode
+- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,10 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#630](https://github.com/bumble-tech/appyx/pull/630) – Pass initial state into Spotlights visualisations
 - [#642](https://github.com/bumble-tech/appyx/pull/642) – Renamings
 - [#643](https://github.com/bumble-tech/appyx/pull/643) – Unify AppyxComponent composable between appyx-navigation and appyx-interactions modules
-- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package
+- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package 
 - [#652](https://github.com/bumble-tech/appyx/pull/652) - KSP processor renamed from `mutable-ui-processor` to `appyx-processor`
-- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings
-- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode
+- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings 
+- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode 
 - [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-–
+– [#670](https://github.com/bumble-tech/appyx/pull/670) - 
 
 ---
 
@@ -19,11 +19,11 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#630](https://github.com/bumble-tech/appyx/pull/630) – Pass initial state into Spotlights visualisations
 - [#642](https://github.com/bumble-tech/appyx/pull/642) – Renamings
 - [#643](https://github.com/bumble-tech/appyx/pull/643) – Unify AppyxComponent composable between appyx-navigation and appyx-interactions modules
-- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package 
+- [#651](https://github.com/bumble-tech/appyx/pull/651) - Keep only one instance of SaveStateMap typealias and moved it to `com.bumble.appyx.utils.multiplatform` package
 - [#652](https://github.com/bumble-tech/appyx/pull/652) - KSP processor renamed from `mutable-ui-processor` to `appyx-processor`
-- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings 
-- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode 
-- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
+- [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings
+- [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode
+- [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier
 
 ### Fixed
 

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/integration/IosNodeHost.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/integration/IosNodeHost.kt
@@ -8,10 +8,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.bumble.appyx.navigation.node.Node
+import com.bumble.appyx.navigation.platform.LifecycleListener
 import com.bumble.appyx.navigation.platform.LocalOnBackPressedDispatcherOwner
 import com.bumble.appyx.navigation.platform.OnBackPressedDispatcher
 import com.bumble.appyx.navigation.platform.OnBackPressedDispatcherOwner
-import com.bumble.appyx.navigation.platform.PlatformLifecycleRegistry
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectory
 import com.bumble.appyx.utils.customisations.NodeCustomisationDirectoryImpl
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -30,9 +30,8 @@ fun <N : Node<*>> IosNodeHost(
     customisations: NodeCustomisationDirectory = remember { NodeCustomisationDirectoryImpl(null) },
     factory: NodeFactory<N>,
 ) {
-    val platformLifecycleRegistry = remember {
-        PlatformLifecycleRegistry()
-    }
+    val lifecycleListener = remember { LifecycleListener() }
+
     val mainScreen = UIScreen.mainScreen
     val screenBounds = mainScreen.bounds
 
@@ -58,7 +57,7 @@ fun <N : Node<*>> IosNodeHost(
 
     CompositionLocalProvider(LocalOnBackPressedDispatcherOwner provides onBackPressedDispatcherOwner) {
         NodeHost(
-            lifecycle = platformLifecycleRegistry,
+            lifecycle = lifecycleListener.lifecycle,
             integrationPoint = integrationPoint,
             modifier = modifier,
             customisations = customisations,

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
@@ -1,0 +1,70 @@
+package com.bumble.appyx.navigation.platform
+
+import com.bumble.appyx.navigation.lifecycle.Lifecycle
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationWillResignActiveNotification
+import platform.UIKit.UIApplicationWillTerminateNotification
+import platform.darwin.NSObjectProtocol
+
+class LifecycleListener {
+    val lifecycle: PlatformLifecycleRegistry = PlatformLifecycleRegistry()
+
+    private lateinit var didEnterBackgroundNotificationObserver: NSObjectProtocol
+    private lateinit var willResignActiveNotificationObserver: NSObjectProtocol
+    private lateinit var didBecomeActiveNotificationObserver: NSObjectProtocol
+    private lateinit var willTerminateNotificationObserver: NSObjectProtocol
+
+    init {
+        created()
+        startObserving()
+    }
+
+    private fun startObserving() {
+        // GOES TO BACKGROUND
+        didEnterBackgroundNotificationObserver = addObserverFor(UIApplicationDidEnterBackgroundNotification) {
+            created()
+        }
+        // BECOMES INACTIVE
+        willResignActiveNotificationObserver = addObserverFor(UIApplicationWillResignActiveNotification) {
+            started()
+        }
+        // GETS FOCUS BACK / BECOMES ACTIVE
+        didBecomeActiveNotificationObserver = addObserverFor(UIApplicationDidBecomeActiveNotification) {
+            resumed()
+        }
+        // IS ABOUT TO BE TERMINATED
+        willTerminateNotificationObserver = addObserverFor(UIApplicationWillTerminateNotification) {
+            destroyed()
+        }
+    }
+
+    private fun addObserverFor(notification: platform.Foundation.NSNotificationName, block: () -> Unit) : NSObjectProtocol {
+        return NSNotificationCenter.defaultCenter.addObserverForName(
+            name = notification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+            usingBlock = {
+                block()
+            }
+        )
+    }
+
+    private fun created() {
+        lifecycle.setCurrentState(Lifecycle.State.CREATED)
+    }
+
+    private fun resumed() {
+        lifecycle.setCurrentState(Lifecycle.State.RESUMED)
+    }
+
+    private fun started() {
+        lifecycle.setCurrentState(Lifecycle.State.STARTED)
+    }
+
+    private fun destroyed() {
+        lifecycle.setCurrentState(Lifecycle.State.DESTROYED)
+    }
+}

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
@@ -23,19 +23,19 @@ class LifecycleListener {
     }
 
     private fun startObserving() {
-        // GOES TO BACKGROUND
+        // Goes to background
         didEnterBackgroundNotificationObserver = addObserverFor(UIApplicationDidEnterBackgroundNotification) {
             created()
         }
-        // BECOMES INACTIVE
+        // Becomes inactive
         willResignActiveNotificationObserver = addObserverFor(UIApplicationWillResignActiveNotification) {
             started()
         }
-        // GETS FOCUS BACK / BECOMES ACTIVE
+        // Gets focus back / Becomes active
         didBecomeActiveNotificationObserver = addObserverFor(UIApplicationDidBecomeActiveNotification) {
             resumed()
         }
-        // IS ABOUT TO BE TERMINATED
+        // Is about to be terminated
         willTerminateNotificationObserver = addObserverFor(UIApplicationWillTerminateNotification) {
             destroyed()
         }

--- a/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
+++ b/appyx-navigation/common/src/iosMain/kotlin/com/bumble/appyx/navigation/platform/LifecycleListener.kt
@@ -41,7 +41,10 @@ class LifecycleListener {
         }
     }
 
-    private fun addObserverFor(notification: platform.Foundation.NSNotificationName, block: () -> Unit) : NSObjectProtocol {
+    private fun addObserverFor(
+        notification: platform.Foundation.NSNotificationName,
+        block: () -> Unit
+    ) : NSObjectProtocol {
         return NSNotificationCenter.defaultCenter.addObserverForName(
             name = notification,
             `object` = null,


### PR DESCRIPTION
## Description

Currently, the app's iOS lifecycle wasn't working as expected, when the app was going to the background the Appyx Nodes were not updating their lifecycle states as expected.

This PR solves the issue by making the iOS app to pass the app Lifecycle to the iOSNodeHost.

## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
