### PR TITLE
Fix canHandeBackPress typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings 
 - [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode 
 - [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
+- [#673](https://github.com/bumble-tech/appyx/pull/673) – Fixed typo canHandeBackPress->canHandleBackPress
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending changes
 
 - [#670](https://github.com/bumble-tech/appyx/pull/670) - Fixes ios lifecycle
+- [#673](https://github.com/bumble-tech/appyx/pull/673) – Fix canHandeBackPress typo
 
 ---
 
@@ -24,7 +25,6 @@ Please refer to [2.0.0-alpha10 – Migration guide](2.0.0-alpha10.md)
 - [#654](https://github.com/bumble-tech/appyx/pull/654) - Renamings 
 - [#657](https://github.com/bumble-tech/appyx/pull/657) - Rename ParentNode & Node to Node and LeafNode 
 - [#644](https://github.com/bumble-tech/appyx/pull/644) – Refactor AppyxComponent and application of draggable modifier 
-- [#673](https://github.com/bumble-tech/appyx/pull/673) – Fixed typo canHandeBackPress->canHandleBackPress
 
 ### Fixed
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/AppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/AppyxComponent.kt
@@ -26,7 +26,7 @@ interface AppyxComponent<InteractionTarget : Any, ModelState : Any> : SavesInsta
 
     fun onRemovedFromComposition()
 
-    fun canHandeBackPress(): StateFlow<Boolean>
+    fun canHandleBackPress(): StateFlow<Boolean>
 
     fun handleBackPress(): Boolean
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/BaseAppyxComponent.kt
@@ -286,7 +286,7 @@ open class BaseAppyxComponent<InteractionTarget : Any, ModelState : Any>(
 
     override fun handleBackPress(): Boolean = backPressStrategy.handleBackPress()
 
-    override fun canHandeBackPress(): StateFlow<Boolean> = backPressStrategy.canHandleBackPress
+    override fun canHandleBackPress(): StateFlow<Boolean> = backPressStrategy.canHandleBackPress
 
     override fun saveInstanceState(state: MutableSavedStateMap) {
         model.saveInstanceState(state)

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/CombinedAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/CombinedAppyxComponent.kt
@@ -34,14 +34,14 @@ class CombinedAppyxComponent<InteractionTarget : Any>(
 
     override fun handleBackPress(): Boolean {
         appyxComponents.forEach { appyxComponent ->
-            if (appyxComponent.canHandeBackPress().value)
+            if (appyxComponent.canHandleBackPress().value)
                 return appyxComponent.handleBackPress()
         }
         return false
     }
 
-    override fun canHandeBackPress(): StateFlow<Boolean> =
-        combineState(appyxComponents.map { it.canHandeBackPress() }, scope) { array ->
+    override fun canHandleBackPress(): StateFlow<Boolean> =
+        combineState(appyxComponents.map { it.canHandleBackPress() }, scope) { array ->
             array.any { it }
         }
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/EmptyAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/core/model/EmptyAppyxComponent.kt
@@ -13,7 +13,7 @@ class EmptyAppyxComponent<InteractionTarget : Any> : AppyxComponent<InteractionT
 
     override fun onRemovedFromComposition() = Unit
 
-    override fun canHandeBackPress(): StateFlow<Boolean> = MutableStateFlow(false)
+    override fun canHandleBackPress(): StateFlow<Boolean> = MutableStateFlow(false)
 
     override fun handleBackPress(): Boolean = false
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentAppyxComponent.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/permanent/PermanentAppyxComponent.kt
@@ -47,7 +47,7 @@ class PermanentAppyxComponent<InteractionTarget : Any>(
         instant.operation(operation)
     }
 
-    override fun canHandeBackPress(): StateFlow<Boolean> = MutableStateFlow(false)
+    override fun canHandleBackPress(): StateFlow<Boolean> = MutableStateFlow(false)
 
     override fun handleBackPress(): Boolean = false
 

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/node/Node.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/node/Node.kt
@@ -206,7 +206,7 @@ abstract class Node<NavTarget : Any>(
     private fun BackHandler() {
         //todo support delegating to plugins
         val canHandleBack = appyxComponent
-            .canHandeBackPress()
+            .canHandleBackPress()
             .collectAsState(initial = false)
         PlatformBackHandler(enabled = canHandleBack.value) {
             appyxComponent.handleBackPress()

--- a/documentation/releases/2.0.0-alpha10.md
+++ b/documentation/releases/2.0.0-alpha10.md
@@ -156,6 +156,15 @@ class YourNode(
         }
 ```
 
+## Fixed typo `canHandeBackPress`
+
+```diff
+interface AppyxComponent /*...*/ {
+    /*...*/
+-    fun canHandeBackPress(): StateFlow<Boolean>
++    fun canHandleBackPress(): StateFlow<Boolean>
+```
+
 &nbsp;
 
 # Changes unlikely to affect you directly

--- a/documentation/releases/2.0.0-alpha10.md
+++ b/documentation/releases/2.0.0-alpha10.md
@@ -156,15 +156,6 @@ class YourNode(
         }
 ```
 
-## Fixed typo `canHandeBackPress`
-
-```diff
-interface AppyxComponent /*...*/ {
-    /*...*/
--    fun canHandeBackPress(): StateFlow<Boolean>
-+    fun canHandleBackPress(): StateFlow<Boolean>
-```
-
 &nbsp;
 
 # Changes unlikely to affect you directly

--- a/documentation/releases/2.0.0-alpha11.md
+++ b/documentation/releases/2.0.0-alpha11.md
@@ -1,0 +1,14 @@
+---
+title: 2.0.0-alpha11 – Migration guide
+---
+
+# 2.0.0-alpha11 – Migration guide
+
+## Fixed `canHandeBackPress` typo
+
+```diff
+interface AppyxComponent /*...*/ {
+    /*...*/
+-    fun canHandeBackPress(): StateFlow<Boolean>
++    fun canHandleBackPress(): StateFlow<Boolean>
+```


### PR DESCRIPTION
## Description
Fixed typo in AppyxComponent (`canHandeBackPress` -> to `canHandleBackPress`)


## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
