### PR TITLE
Remove mkdocs deployment in 1.x

### DIFF
--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -7,18 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - run: sed -i 's/${POST_MERGE_RUN_ID}/${{ github.run_id }}/g' documentation/how-to-use-appyx/sample-apps.md
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
-
   build-sample-app:
     name: Build sample app
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

To avoid accidentally overwriting `2.x` documentation on a `1.x` release. 

The `1.x` documentation lives in on https://bumble-tech.github.io/appyx/1.x/ and if necessary, it can be edited through `2.x` branch.

## Checklist

- [ ] I've updated `CHANGELOG.md` if required.
- [ ] I've updated the documentation if required.
