### PR TITLE
Use SDK 28 and avoid having instrumentation failing with timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,13 +95,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-29
+          key: avd-28
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           # Use API 29 https://github.com/ReactiveCircus/android-emulator-runner/issues/222
-          api-level: 29
+          # Use API 28 https://github.com/ReactiveCircus/android-emulator-runner/issues/373
+          api-level: 28
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -111,7 +112,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           # Use API 29 https://github.com/ReactiveCircus/android-emulator-runner/issues/222
-          api-level: 29
+          # Use API 28 https://github.com/ReactiveCircus/android-emulator-runner/issues/373
+          api-level: 28
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none


### PR DESCRIPTION
## Description



## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
