### PR TITLE
Fix regressions: Local UI state is not persisted and flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - [#670](https://github.com/bumble-tech/appyx/pull/670) - Fixes ios lifecycle
 - [#673](https://github.com/bumble-tech/appyx/pull/673) – Fix canHandeBackPress typo
+- [#671](https://github.com/bumble-tech/appyx/issue/671) – Fix ui state saving issue
 
 ### Enhancement
 

--- a/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/ChildRenderer.kt
+++ b/appyx-navigation/common/src/commonMain/kotlin/com/bumble/appyx/navigation/composable/ChildRenderer.kt
@@ -1,8 +1,10 @@
 package com.bumble.appyx.navigation.composable
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
 
+@Stable
 interface ChildRenderer {
 
     @Suppress("ComposableNaming") // This wants to be 'Invoke' but that won't work with 'operator'.


### PR DESCRIPTION
## Description

Fixes https://github.com/bumble-tech/appyx/issues/671 https://github.com/bumble-tech/appyx/issues/672

[In this change](https://github.com/bumble-tech/appyx/pull/643/files#diff-9a0f08f4db634420e9298649dee9f9900f9b1e53fe4cb04bd6901af57e076ad8L22) introduced a bug where I accidentally started saving the state of the transition Box along with children UI state which was wrong. This PR reverts it back and now I only save the state of children UI and not the wrapping Box with transitions.

I checked out the repo in the issue and the bug seems to have gone:

https://github.com/bumble-tech/appyx/assets/5773436/9b502934-6651-4206-889f-b738880ada8e


## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
