### PR TITLE
Sync ChildAwareExt generics with ChildAware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            adb shell pm list packages -3 | cut -f 2 -d ":" | while read package; do if [ "$package" = "com.bumble.appyx.sample.navigation.compose.test" ] || [ "$package" = "com.bumble.appyx.core.test" ] || [ "$package" = "com.bumble.appyx.interop.ribs.test" ]; then adb uninstall $package; fi; done
+            adb shell pm list packages -3 | cut -f 2 -d ":" | while read package; do if [ "$package" = "com.bumble.appyx.sample.navigation.compose.test" ] || [ "$package" = "com.bumble.appyx.core.test" ] || [ "$package" = "com.bumble.appyx.interop.ribs.test" ] || [ "$package" = "com.bumble.appyx.sample.navigtion.compose.test" ]; then adb uninstall $package; fi; done
             adb logcat > logcat.out &
             ./gradlew connectedCheck
       - name: Upload failed instrumentation artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
+            adb shell pm list packages -3 | cut -f 2 -d ":" | while read package; do if [ "$package" = "com.bumble.appyx.sample.navigation.compose.test" ] || [ "$package" = "com.bumble.appyx.core.test" ] || [ "$package" = "com.bumble.appyx.interop.ribs.test" ]; then adb uninstall $package; fi; done
             adb logcat > logcat.out &
             ./gradlew connectedCheck
       - name: Upload failed instrumentation artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Pending changes
 
+- [#705](https://github.com/bumble-tech/appyx/pull/705) – **Fixed**: ChildAware extension functions now allow Any type as a parameter
+
 ---
 
 ## 1.5.0

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareExt.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/children/ChildAwareExt.kt
@@ -1,14 +1,12 @@
 package com.bumble.appyx.core.children
 
-import com.bumble.appyx.core.node.Node
-
-inline fun <reified T : Node> ChildAware<*>.whenChildAttached(
+inline fun <reified T : Any> ChildAware<*>.whenChildAttached(
     noinline callback: ChildCallback<T>,
 ) {
     whenChildAttached(T::class, callback)
 }
 
-inline fun <reified T1 : Node, reified T2 : Node> ChildAware<*>.whenChildrenAttached(
+inline fun <reified T1 : Any, reified T2 : Any> ChildAware<*>.whenChildrenAttached(
     noinline callback: ChildrenCallback<T1, T2>,
 ) {
     whenChildrenAttached(T1::class, T2::class, callback)


### PR DESCRIPTION
## Description

`ChildAware` allows any T, but `ChildAwareExt` only `T : Node`. Align it.

## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
