### PR TITLE
[#600] Avoid gesture-related modifier if gestures are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Pending changes
 
-–
+### Fixed
+
+– [#600](https://github.com/bumble-tech/appyx/issues/600) - Fix Parent interaction is gone once it has a child on top
 
 ## 2.0.0
 

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/composable/AppyxInteractionsContainer.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/composable/AppyxInteractionsContainer.kt
@@ -113,11 +113,11 @@ fun <InteractionTarget : Any, ModelState : Any> AppyxInteractionsContainer(
                     )
                 )
             }
-            .onPointerEvent {
+            .then(if (!appyxComponent.isGesturesEnabled) Modifier else Modifier.onPointerEvent {
                 if (it.type == PointerEventType.Release) {
                     appyxComponent.onRelease()
                 }
-            }
+            })
     ) {
         CompositionLocalProvider(LocalBoxScope provides this) {
             elementUiModels.forEach { elementUiModel ->

--- a/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/composable/AppyxInteractionsContainer.kt
+++ b/appyx-interactions/common/src/commonMain/kotlin/com/bumble/appyx/interactions/composable/AppyxInteractionsContainer.kt
@@ -113,10 +113,13 @@ fun <InteractionTarget : Any, ModelState : Any> AppyxInteractionsContainer(
                     )
                 )
             }
-            .then(if (!appyxComponent.isGesturesEnabled) Modifier else Modifier.onPointerEvent {
-                if (it.type == PointerEventType.Release) {
-                    appyxComponent.onRelease()
-                }
+            .then(if (appyxComponent.isGesturesEnabled) {
+                Modifier.onPointerEvent {
+                    if (it.type == PointerEventType.Release) {
+                        appyxComponent.onRelease()
+                } else {
+                    Modifier
+                }   
             })
     ) {
         CompositionLocalProvider(LocalBoxScope provides this) {


### PR DESCRIPTION
## Description

Fixes #600 

The `.onPointerEvent` modifier applied to the parent `Box` of the container was always active, even when `isGesturesEnabled` was set to false. This caused unnecessary interception of gestures, preventing them from properly propagating up the view tree.

The fix is conditionally applying the `.onPointerEvent` modifier only when `isGesturesEnabled` is true. This ensures that gestures are intercepted only when necessary, allowing them to propagate correctly when gestures are disabled.

## Checklist

- [x] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
