### PR TITLE
Fix Navigation QuickStart documentation

### DIFF
--- a/documentation/navigation/quick-start.md
+++ b/documentation/navigation/quick-start.md
@@ -218,7 +218,7 @@ Let's create a dedicated class:
 ```kotlin
 class SomeChildNode(
     nodeContext: NodeContext
-) : Node(
+) : LeafNode(
     nodeContext = nodeContext
 ) {
     @Composable


### PR DESCRIPTION
## Description
With Appyx 2.0 there's no longer a standalone "Node" class which does not expect a NavTarget, so we have to use LeafNode now.

## Checklist
- [ ] I've updated `CHANGELOG.md` if required.
- [x] I've updated the documentation if required.
