### PR TITLE
Introduced global plugins, added GlobalNodeLifecycleAware

### DIFF
--- a/.github/workflows/build_1.x.yml
+++ b/.github/workflows/build_1.x.yml
@@ -125,7 +125,7 @@ jobs:
             ./gradlew connectedCheck
       - name: Upload failed instrumentation artifacts
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: instrumentation-failures
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Pending changes
 
+## 1.5.1
+
 - [#705](https://github.com/bumble-tech/appyx/pull/705) – **Fixed**: ChildAware extension functions now allow Any type as a parameter
 - [#716](https://github.com/bumble-tech/appyx/pull/716) – **Updated**: Kotlin (2.0.20), Compose Compiler (now implicit from Kotlin), Coroutines (1.9.0-RC.2), AGP (8.5.2), numerous Androidx libs
 - [#718](https://github.com/bumble-tech/appyx/pull/718) – **Added**: Introduced global plugins for all nodes and added [GlobalNodeLifecycleAware] which is contains the node in the callback.
+
+<div style="text-align: center"><small>18 Nov 2024</small></div>
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#705](https://github.com/bumble-tech/appyx/pull/705) – **Fixed**: ChildAware extension functions now allow Any type as a parameter
 - [#716](https://github.com/bumble-tech/appyx/pull/716) – **Updated**: Kotlin (2.0.20), Compose Compiler (now implicit from Kotlin), Coroutines (1.9.0-RC.2), AGP (8.5.2), numerous Androidx libs
+- [#718](https://github.com/bumble-tech/appyx/pull/718) – **Added**: Introduced global plugins for all nodes and added [GlobalNodeLifecycleAware] which is contains the node in the callback.
 
 ---
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.caching=true
 org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
-library.version=1.5.0
+library.version=1.5.1

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/Appyx.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/Appyx.kt
@@ -1,11 +1,17 @@
 package com.bumble.appyx
 
 import com.bumble.appyx.core.children.ChildEntry
+import com.bumble.appyx.core.plugin.Plugin
 
 object Appyx {
 
     var exceptionHandler: ((Exception) -> Unit)? = null
     var defaultChildKeepMode: ChildEntry.KeepMode = ChildEntry.KeepMode.KEEP
+
+    /**
+     * Plugins that are applied to all Nodes.
+     */
+    var globalPlugins: List<Plugin> = emptyList()
 
     fun reportException(exception: Exception) {
         val handler = exceptionHandler

--- a/libraries/core/src/main/kotlin/com/bumble/appyx/core/plugin/Plugins.kt
+++ b/libraries/core/src/main/kotlin/com/bumble/appyx/core/plugin/Plugins.kt
@@ -23,6 +23,11 @@ interface NodeLifecycleAware : Plugin {
     fun onCreate(lifecycle: Lifecycle) {}
 }
 
+interface GlobalNodeLifecycleAware : Plugin {
+    fun onCreate(node: Node, lifecycle: Lifecycle) {}
+    fun onDestroy(node: Node) {}
+}
+
 interface UpNavigationHandler : Plugin {
     fun handleUpNavigation(): Boolean = false
 }


### PR DESCRIPTION
## Description
Added 'global plugins' to enable developers to introduce diagnostic tools without needing to find the RIB within the view hierarchy

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [ ] I have updated documentation if required.
