### PR TITLE
appyx ribs-interop switched to rxjava3 compatible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
--
+- [#727](https://github.com/bumble-tech/appyx/pull/727) – **Updated**: Ribs to 0.41.0 and MVICore to 2.0.0
 
 ## 1.6.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ androidx-navigation-compose = "2.5.1"
 androidx-tracing = "1.2.0"
 coil = "2.2.1"
 composeBom = "2024.12.01"
-ribs = "0.39.0"
-mvicore = "1.2.6"
+ribs = "0.41.0"
+mvicore = "2.0.0"
 coroutines = "1.9.0-RC.2"
 kotlin = "2.0.20"
 junit5 = "5.8.2"
@@ -57,12 +57,11 @@ mvicore-binder = { module = "com.github.badoo.mvicore:binder", version.ref = "mv
 ribs-base = { module = "com.github.badoo.RIBs:rib-base", version.ref = "ribs" }
 ribs-base-test = { module = "com.github.badoo.RIBs:rib-base-test", version.ref = "ribs" }
 ribs-base-test-activity = { module = "com.github.badoo.RIBs:rib-base-test-activity", version.ref = "ribs" }
-ribs-base-test-rx2 = { module = "com.github.badoo.RIBs:rib-base-test-rx2", version.ref = "ribs" }
+ribs-base-test-rx3 = { module = "com.github.badoo.RIBs:rib-base-test-rx3", version.ref = "ribs" }
 ribs-compose = { module = "com.github.badoo.RIBs:rib-compose", version.ref = "ribs" }
 
 rxjava2 = "io.reactivex.rxjava2:rxjava:2.2.21"
-rxjava3 = "io.reactivex.rxjava3:rxjava:3.1.5"
-rxandroid2 = "io.reactivex.rxjava2:rxandroid:2.1.1"
+rxjava3 = "io.reactivex.rxjava3:rxjava:3.1.10"
 rxandroid3 = "io.reactivex.rxjava3:rxandroid:3.0.2"
 rxrelay2 = "com.jakewharton.rxrelay2:rxrelay:2.1.1"
 rxrelay3 = "com.jakewharton.rxrelay3:rxrelay:3.0.1"

--- a/samples/sandbox/build.gradle.kts
+++ b/samples/sandbox/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
 
     implementation(composeBom)
     implementation(project(":libraries:core"))
-    implementation(project(":libraries:interop-rx2"))
+    implementation(project(":libraries:interop-rx3"))
     implementation(project(":libraries:interop-ribs"))
     implementation(project(":samples:navmodel-samples"))
     implementation(project(":samples:common"))
@@ -80,9 +80,9 @@ dependencies {
     implementation(libs.mvicore.base)
     implementation(libs.mvicore.android)
     implementation(libs.mvicore.binder)
-    implementation(libs.rxjava2)
-    implementation(libs.rxandroid2)
-    implementation(libs.rxrelay2)
+    implementation(libs.rxjava3)
+    implementation(libs.rxandroid3)
+    implementation(libs.rxrelay3)
     implementation(libs.toolargetool)
 
     testImplementation(libs.androidx.arch.core.testing)
@@ -93,7 +93,7 @@ dependencies {
     testImplementation(project(":libraries:testing-junit4"))
     testImplementation(project(":libraries:testing-junit5"))
     testImplementation(libs.ribs.base.test)
-    testImplementation(libs.ribs.base.test.rx2)
+    testImplementation(libs.ribs.base.test.rx3)
 
     androidTestImplementation(composeBom)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxMviViewTestRule.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxMviViewTestRule.kt
@@ -3,9 +3,9 @@ package com.bumble.appyx.sandbox.client.test
 import com.bumble.appyx.core.node.NodeView
 import com.bumble.appyx.core.node.ViewFactory
 import com.bumble.appyx.testing.ui.rules.AppyxViewTestRule
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
-import io.reactivex.observers.TestObserver
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
+import io.reactivex.rxjava3.observers.TestObserver
 
 class AppyxMviViewTestRule<ViewModel : Any, Event : Any, View : NodeView>(
     private val modelConsumer: (View) -> Consumer<in ViewModel>,

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxViewRules.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/AppyxViewRules.kt
@@ -2,8 +2,8 @@ package com.bumble.appyx.sandbox.client.test
 
 import com.bumble.appyx.core.node.NodeView
 import com.bumble.appyx.core.node.ViewFactory
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
 
 fun <ViewModel : Any, Event : Any, View> appyxViewRule(
     viewFactory: ViewFactory<View>,

--- a/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/Utils.kt
+++ b/samples/sandbox/src/androidTest/kotlin/com/bumble/appyx/sandbox/client/test/Utils.kt
@@ -1,16 +1,16 @@
 package com.bumble.appyx.sandbox.client.test
 
-import io.reactivex.Observable
-import io.reactivex.ObservableSource
-import io.reactivex.observers.TestObserver
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.observers.TestObserver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.greaterThan
 
-fun <T> ObservableSource<out T>.wrapToObservable(): Observable<T> = Observable.wrap(cast())
+fun <T : Any> ObservableSource<out T>.wrapToObservable(): Observable<T> = Observable.wrap(cast())
 
 inline fun <reified T> Any?.cast(): T = this as T
 
-fun <T> TestObserver<T>.assertLastValueEqual(value: T) {
-    assertThat(this.valueCount(), greaterThan(0))
-    this.assertValueAt(valueCount() - 1, value)
+fun <T : Any> TestObserver<T>.assertLastValueEqual(value: T) {
+    assertThat(this.values().size, greaterThan(0))
+    this.assertValueAt(values().size - 1, value)
 }

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentInteractor.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentInteractor.kt
@@ -8,7 +8,7 @@ import com.badoo.ribs.routing.source.backstack.BackStack
 import com.badoo.ribs.routing.source.backstack.operation.push
 import com.bumble.appyx.sandbox.client.interop.parent.routing.RibsParentRouter.Configuration
 import com.bumble.appyx.sandbox.client.interop.parent.RibsParentView.Event
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 internal class RibsParentInteractor(
     private val backStack: BackStack<Configuration>,

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentView.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentView.kt
@@ -12,8 +12,8 @@ import com.badoo.ribs.core.view.ViewFactoryBuilder
 import com.bumble.appyx.R
 import com.bumble.appyx.sandbox.client.interop.parent.RibsParentView.Event
 import com.bumble.appyx.sandbox.client.interop.parent.RibsParentView.Event.SwitchClicked
-import com.jakewharton.rxrelay2.PublishRelay
-import io.reactivex.ObservableSource
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.ObservableSource
 
 interface RibsParentView : RibView, ObservableSource<Event> {
 

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode1.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.bumble.appyx.interop.rx2.connectable.Connectable
-import com.bumble.appyx.interop.rx2.connectable.NodeConnector
+import com.bumble.appyx.interop.rx3.connectable.Connectable
+import com.bumble.appyx.interop.rx3.connectable.NodeConnector
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode1.Input

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreChildNode2.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.bumble.appyx.interop.rx2.connectable.Connectable
-import com.bumble.appyx.interop.rx2.connectable.NodeConnector
+import com.bumble.appyx.interop.rx3.connectable.Connectable
+import com.bumble.appyx.interop.rx3.connectable.NodeConnector
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreChildNode2.Input

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleBuilder.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleBuilder.kt
@@ -3,7 +3,7 @@ package com.bumble.appyx.sandbox.client.mvicoreexample
 import com.bumble.appyx.core.builder.Builder
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.store.getRetainedDisposable
+import com.bumble.appyx.interop.rx3.store.getRetainedDisposable
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget.Child1

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractor.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleInteractor.kt
@@ -22,7 +22,7 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeat
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.OutputChild1ToWish
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.OutputChild2ToWish
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.StateToViewModel
-import io.reactivex.functions.Consumer
+import io.reactivex.rxjava3.functions.Consumer
 
 class MviCoreExampleInteractor(
     private val view: MviCoreExampleView,

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleView.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleView.kt
@@ -37,9 +37,9 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.InitialState
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.Loaded
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel.Loading
-import com.jakewharton.rxrelay2.PublishRelay
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
 
 interface MviCoreExampleView : Consumer<ViewModel>, ObservableSource<Event>
 
@@ -102,6 +102,7 @@ class MviCoreExampleViewImpl(
                             .testTag(LoadingTestTag)
                     )
                 }
+
                 is InitialState ->
                     Box(modifier = Modifier.fillMaxSize()) {
                         Column(modifier = Modifier.align(Alignment.Center)) {
@@ -121,6 +122,7 @@ class MviCoreExampleViewImpl(
                             }
                         }
                     }
+
                 is Loaded ->
                     Box(modifier = Modifier.fillMaxSize()) {
                         Text(

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/MviCoreExampleFeature.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/feature/MviCoreExampleFeature.kt
@@ -12,8 +12,8 @@ import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeat
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.Wish.ChildInput
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.Wish.Finish
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.Wish.LoadData
-import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.core.Observable
 import java.util.concurrent.TimeUnit
 
 class MviCoreExampleFeature(initialStateName: String) :
@@ -26,28 +26,28 @@ class MviCoreExampleFeature(initialStateName: String) :
 
     sealed class State {
         data class InitialState(val stateName: String) : State()
-        object Loading : State()
+        data object Loading : State()
         data class Loaded(val stateName: String) : State()
-        object Finished : State()
+        data object Finished : State()
     }
 
     sealed class Wish {
         data class ChildInput(val data: String) : Wish()
-        object LoadData : Wish()
-        object Finish : Wish()
+        data object LoadData : Wish()
+        data object Finish : Wish()
         data class ChangeState(val stateName: String) : Wish()
     }
 
     sealed class Effect {
         data class ChangeState(val stateName: String) : Effect()
         data class ChildInput(val data: String) : Effect()
-        object Loading : Effect()
-        object Finished : Effect()
-        object DataLoaded : Effect()
+        data object Loading : Effect()
+        data object Finished : Effect()
+        data object DataLoaded : Effect()
     }
 
     sealed class News {
-        object Finished : News()
+        data object Finished : News()
         data class StateUpdated(val message: String) : News()
     }
 
@@ -59,7 +59,7 @@ class MviCoreExampleFeature(initialStateName: String) :
                 is ChildInput -> Effect.ChildInput(wish.data).toObservable()
                 is LoadData -> Observable.timer(2, TimeUnit.SECONDS)
                     .map<Effect> { Effect.DataLoaded }
-                    .startWith(Effect.Loading)
+                    .startWithItem(Effect.Loading)
                     .observeOn(AndroidSchedulers.mainThread())
             }
     }
@@ -86,5 +86,5 @@ class MviCoreExampleFeature(initialStateName: String) :
 }
 
 
-fun <T> T?.toObservable(): Observable<T> =
+fun <T : Any> T?.toObservable(): Observable<T> =
     if (this == null) Observable.empty() else Observable.just(this)

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafBuilder.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafBuilder.kt
@@ -3,7 +3,7 @@ package com.bumble.appyx.sandbox.client.mvicoreexample.leaf
 import com.bumble.appyx.core.builder.Builder
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.store.getRetainedDisposable
+import com.bumble.appyx.interop.rx3.store.getRetainedDisposable
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature
 
 class MviCoreLeafBuilder : Builder<String>() {

--- a/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafView.kt
+++ b/samples/sandbox/src/main/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafView.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.unit.sp
 import com.bumble.appyx.core.node.NodeView
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.ViewModel
-import com.jakewharton.rxrelay2.PublishRelay
-import io.reactivex.ObservableSource
-import io.reactivex.functions.Consumer
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.functions.Consumer
 
 interface MviCoreLeafView : Consumer<ViewModel>, ObservableSource<MviCoreExampleViewImpl.Event>
 

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentNodeTest.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/interop/parent/RibsParentNodeTest.kt
@@ -9,7 +9,7 @@ import com.badoo.ribs.core.view.ViewFactory
 import com.badoo.ribs.test.builder.RibBuilderStub
 import com.badoo.ribs.test.node.RibNodeStub
 import com.badoo.ribs.test.node.RibNodeTestHelper
-import com.badoo.ribs.test.rx2.view.RibViewStub
+import com.badoo.ribs.test.rx3.view.RibViewStub
 import com.bumble.appyx.core.builder.SimpleBuilder
 import com.bumble.appyx.core.integrationpoint.IntegrationPointStub
 import com.bumble.appyx.interop.ribs.InteropNode

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeJUnit5Test.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/MviCoreExampleNodeJUnit5Test.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.firstChildOfType
-import com.bumble.appyx.interop.rx2.plugin.disposeOnDestroyPlugin
+import com.bumble.appyx.interop.rx3.plugin.disposeOnDestroyPlugin
 import com.bumble.appyx.navmodel.backstack.BackStack
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafNodeJUnit5Test.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafNodeJUnit5Test.kt
@@ -3,7 +3,7 @@ package com.bumble.appyx.sandbox.client.mvicoreexample.leaf
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.plugin.disposeOnDestroyPlugin
+import com.bumble.appyx.interop.rx3.plugin.disposeOnDestroyPlugin
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.News

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafNodeTest.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/client/mvicoreexample/leaf/MviCoreLeafNodeTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import com.bumble.appyx.core.modality.BuildContext
 import com.bumble.appyx.core.node.Node
-import com.bumble.appyx.interop.rx2.plugin.disposeOnDestroyPlugin
+import com.bumble.appyx.interop.rx3.plugin.disposeOnDestroyPlugin
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleNode.NavTarget
 import com.bumble.appyx.sandbox.client.mvicoreexample.MviCoreExampleViewImpl.Event
 import com.bumble.appyx.sandbox.client.mvicoreexample.feature.MviCoreExampleFeature.News

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/FeatureStub.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/FeatureStub.kt
@@ -1,19 +1,18 @@
 package com.bumble.appyx.sandbox.stub
 
 import com.badoo.mvicore.feature.Feature
-import com.jakewharton.rxrelay2.BehaviorRelay
-import com.jakewharton.rxrelay2.PublishRelay
-import io.reactivex.ObservableSource
-import io.reactivex.disposables.Disposable
-import io.reactivex.disposables.Disposables
-import io.reactivex.functions.Consumer
+import com.jakewharton.rxrelay3.BehaviorRelay
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.functions.Consumer
 
 open class FeatureStub<Wish : Any, State : Any, News : Any>(
     initialState: State,
     val wishesRelay: PublishRelay<Wish> = PublishRelay.create(),
     val statesRelay: BehaviorRelay<State> = BehaviorRelay.createDefault(initialState),
     val newsRelay: PublishRelay<News> = PublishRelay.create(),
-    private val disposable: Disposable = Disposables.empty()
+    private val disposable: Disposable = Disposable.empty()
 ) : Feature<Wish, State, News>,
     ObservableSource<State> by statesRelay,
     Consumer<Wish> by wishesRelay,

--- a/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/NodeViewStub.kt
+++ b/samples/sandbox/src/test/kotlin/com/bumble/appyx/sandbox/stub/NodeViewStub.kt
@@ -4,16 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.bumble.appyx.core.node.ParentNode
 import com.bumble.appyx.core.node.ParentNodeView
-import com.jakewharton.rxrelay2.PublishRelay
-import io.reactivex.ObservableSource
-import io.reactivex.disposables.Disposable
-import io.reactivex.disposables.Disposables
-import io.reactivex.functions.Consumer
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.ObservableSource
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.functions.Consumer
 
 open class NodeViewStub<Event : Any, ViewModel : Any, NavTarget : Any>(
     val eventsRelay: PublishRelay<Event> = PublishRelay.create(),
     val viewModelRelay: PublishRelay<ViewModel> = PublishRelay.create(),
-    private val disposable: Disposable = Disposables.empty()
+    private val disposable: Disposable = Disposable.empty()
 ) : ParentNodeView<NavTarget>,
     ObservableSource<Event> by eventsRelay,
     Consumer<ViewModel> by viewModelRelay,


### PR DESCRIPTION
## Description

Use RxJava3-based RIBs artifact.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
