### PR TITLE
Update jetpack compose BOM to 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Pending changes
 
-- 
+- [#730](https://github.com/bumble-tech/appyx/pull/730) – **Updated**: Jetpack Compose BOM to 1.8
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ accompanist = "0.28.0"
 androidx-lifecycle = "2.6.1"
 androidx-navigation-compose = "2.5.1"
 androidx-tracing = "1.2.0"
+agp = "8.9.2"
 coil = "2.2.1"
 composeBom = "2025.04.01"
 ribs = "0.41.0"
@@ -74,7 +75,7 @@ junit-vintage = { module = "org.junit.vintage:junit-vintage-engine", version.ref
 
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-plugin-android = "com.android.tools.build:gradle:8.5.2"
+plugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
 detekt-compose = "io.nlopez.compose.rules:detekt:0.1.6"
 toolargetool = "com.gu.android:toolargetool:0.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 # keep sorted please, use Edit -> Sort Lines
 
 [versions]
-androidCompileSdk = "34"
+androidCompileSdk = "35"
 androidMinSdk = "21"
 androidTargetSdk = "34"
 accompanist = "0.28.0"
@@ -9,7 +9,7 @@ androidx-lifecycle = "2.6.1"
 androidx-navigation-compose = "2.5.1"
 androidx-tracing = "1.2.0"
 coil = "2.2.1"
-composeBom = "2024.12.01"
+composeBom = "2025.04.01"
 ribs = "0.41.0"
 mvicore = "2.0.0"
 coroutines = "1.9.0-RC.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/navmodel-samples/lint-baseline.xml
+++ b/samples/navmodel-samples/lint-baseline.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.2)" variant="all" version="8.5.2">
+<issues format="6" by="lint 8.9.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.2)" variant="all" version="8.9.2">
 
     <issue
-        id="SuspiciousModifierThen"
-        message="Using Modifier.then with a Modifier factory function with an implicit receiver"
-        errorLine1="                    aspectRatio(1f)"
-        errorLine2="                    ~~~~~~~~~~~">
+        id="ConfigurationScreenWidthHeight"
+        message="Using Configuration.screenHeightDp instead of LocalWindowInfo.current.containerSize"
+        errorLine1="        val screenHeight = LocalConfiguration.current.screenHeightDp"
+        errorLine2="                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/kotlin/com/bumble/appyx/navmodel/spotlightadvanced/transitionhandler/SpotlightAdvancedSlider.kt"
-            line="93"
-            column="21"/>
+            file="src/main/kotlin/com/bumble/appyx/navmodel/modal/ModalTransitionHandler.kt"
+            line="34"
+            column="28"/>
     </issue>
 
     <issue


### PR DESCRIPTION
## Description

Jetpack compose update to 1.8

https://android-developers.googleblog.com/2025/04/whats-new-in-jetpack-compose-april-25.html

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
