### PR TITLE
Use gradle/actions/setup-gradle@v4

### DIFF
--- a/.github/workflows/build_1.x.yml
+++ b/.github/workflows/build_1.x.yml
@@ -22,8 +22,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Build
@@ -72,8 +71,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/wrapper-validation-action@v2
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Pre build sources before launching emulator

--- a/.github/workflows/build_2.x.yml
+++ b/.github/workflows/build_2.x.yml
@@ -22,8 +22,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Build
@@ -71,8 +70,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Check publication setup
@@ -95,8 +93,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Setup Android SDK
@@ -133,8 +130,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/actions/wrapper-validation@v3
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: ${{ env.MAIN_BRANCH != 'true' }}
       - name: Setup Android SDK

--- a/.github/workflows/check_documentation.yml
+++ b/.github/workflows/check_documentation.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/wrapper-validation-action@v2
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
       - name: Generate distributions

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/wrapper-validation-action@v2
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
       - run: pip install mkdocs-material

--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/wrapper-validation-action@v2
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: gradle/wrapper-validation-action@v2
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
       - name: Build & publish


### PR DESCRIPTION
## Description

> Starting with v4 the setup-gradle action will [perform wrapper validation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation) on each execution. If you are using setup-gradle in your workflows, it is unlikely that you will need to use the wrapper-validation action.

`setup-gradle` uses deprecated `actions/cache`, so it does not work anymore.

## Check list

- [x] I have updated `CHANGELOG.md` if required.
- [x] I have updated documentation if required.
