### PR TITLE
Add missing Parcelable to InsideTheBackStack.NavTarget and IndexedBackStack.State

### DIFF
--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/backstack/InsideTheBackStack.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/backstack/InsideTheBackStack.kt
@@ -1,5 +1,6 @@
 package com.bumble.appyx.app.node.backstack
 
+import android.os.Parcelable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +31,7 @@ import com.bumble.appyx.core.node.Node
 import com.bumble.appyx.core.node.ParentNode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.parcelize.Parcelize
 
 class InsideTheBackStack(
     buildContext: BuildContext,
@@ -61,7 +63,8 @@ class InsideTheBackStack(
         }
     }
 
-    sealed class NavTarget {
+    sealed class NavTarget : Parcelable {
+        @Parcelize
         data class Child(val index: Int) : NavTarget() {
             override fun toString(): String = index.toString()
         }

--- a/samples/app/src/main/kotlin/com/bumble/appyx/app/node/backstack/app/indexedbackstack/IndexedBackStack.kt
+++ b/samples/app/src/main/kotlin/com/bumble/appyx/app/node/backstack/app/indexedbackstack/IndexedBackStack.kt
@@ -1,10 +1,12 @@
 package com.bumble.appyx.app.node.backstack.app.indexedbackstack
 
+import android.os.Parcelable
 import com.bumble.appyx.core.navigation.BaseNavModel
 import com.bumble.appyx.core.navigation.NavElements
 import com.bumble.appyx.core.navigation.NavKey
 import com.bumble.appyx.core.navigation.Operation
 import com.bumble.appyx.core.state.SavedStateMap
+import kotlinx.parcelize.Parcelize
 
 class IndexedBackStack<NavTarget : Any>(
     savedState: SavedStateMap?,
@@ -15,14 +17,20 @@ class IndexedBackStack<NavTarget : Any>(
     savedStateMap = savedState
 ) {
 
-    sealed interface State {
+    sealed interface State : Parcelable {
+        @Parcelize
         object Created : State
+
+        @Parcelize
         object Active : State
-        class Stashed(
+
+        @Parcelize
+        data class Stashed(
             val index: Int,
             val size: Int
         ) : State
 
+        @Parcelize
         object Destroyed : State
     }
 


### PR DESCRIPTION
## Summary

The sample app crashes when Android saves instance state (e.g. pressing Home while on the "Inside the backstack" screen). `InsideTheBackStack.NavTarget` and `IndexedBackStack.State` were missing `Parcelable` implementation, causing `Parcel.writeValue()` to fail at runtime with `IllegalArgumentException: unknown type for value`.

- Added `Parcelable` to `InsideTheBackStack.NavTarget` sealed class and `@Parcelize` to `Child`
- Added `Parcelable` to `IndexedBackStack.State` sealed interface and `@Parcelize` to all implementations

## Steps to reproduce

1. Launch `sample.app`
2. Tap "Inside the backstack"
3. Press the Home button (triggers `onSaveInstanceState`)
4. App crashes with: `java.lang.IllegalArgumentException: Parcel: unknown type for value 0`

## Maestro test

The following Maestro script can be used to verify the fix — it navigates to the screen, presses Home, resumes the app, and asserts the screen is still visible (no crash):

```yaml
appId: com.bumble.appyx.samples
---
- launchApp
- assertVisible:
    text: "Inside the backstack"
- tapOn: "Inside the backstack"
- assertVisible:
    text: "Pop"
- pressKey: Home
- waitForAnimationToEnd
- launchApp:
    appId: com.bumble.appyx.samples
    stopApp: false
- assertVisible:
    text: "Pop"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)